### PR TITLE
Run yarn after generating a package

### DIFF
--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -1,16 +1,23 @@
+/**
+ * Plop is a tool that saves time and helps scaffolding code with consistency.
+ *
+ * See https://plopjs.com/documentation/ for more details.
+ */
+
 import _ from "lodash";
+import { exec } from "child_process";
 
 const templateReadme = prepareTemplate(`
-# {{> packageName}}
+# {{dashCase name}}
 
-{{> packageDescription}}
+{{sentenceCase description}}
 `);
 
 const templatePackage = prepareTemplate(`
 {
-  "name": "@actnowcoalition/{{> packageName}}",
+  "name": "@actnowcoalition/{{dashCase name}}",
   "version": "1.0.0",
-  "description": "{{> packageDescription}}",
+  "description": "{{sentenceCase description}}",
   "repository": {
     "type": "git",
     "url": "git@github.com:covid-projections/act-now-packages.git"
@@ -28,34 +35,52 @@ const templatePackage = prepareTemplate(`
 }`);
 
 export default function (/** @type {import('plop').NodePlopAPI} */ plop) {
-  plop.setPartial("packageName", "{{dashCase name}}");
-  plop.setPartial("packageDescription", "{{sentenceCase description}}");
+  /**
+   * Sets a custom action type to run `yarn` on the new package folder. Note
+   * that it will only include typescript, any other dependencies will still
+   * need to be added after creating the package.
+   */
+  plop.setActionType("yarn", function (answers, config, plop) {
+    const dashCase = plop.getHelper("dashCase");
+    const command = `cd packages/${dashCase(answers.name)}; yarn; cd ../..;`;
+    exec(command, function (error, stdout) {
+      if (error) {
+        console.error(`Error: ${error}`);
+        return;
+      }
+      console.log(stdout);
+    });
+  });
+
   plop.setGenerator("package", {
     description: "",
     prompts: [
-      { type: "input", name: "name", message: "" },
-      { type: "input", name: "description", message: "" },
+      { type: "input", name: "name" },
+      { type: "input", name: "description" },
     ],
     actions: [
       {
         type: "add",
-        path: `packages/{{> packageName}}/README.md`,
+        path: `packages/{{dashCase name}}/README.md`,
         template: templateReadme,
       },
       {
         type: "add",
-        path: `packages/{{> packageName}}/src/index.ts`,
+        path: `packages/{{dashCase name}}/src/index.ts`,
         template: "",
       },
       {
         type: "add",
-        path: `packages/{{> packageName}}/package.json`,
+        path: `packages/{{dashCase name}}/package.json`,
         template: templatePackage,
       },
       {
         type: "add",
-        path: `packages/{{> packageName}}/LICENSE`,
+        path: `packages/{{dashCase name}}/LICENSE`,
         templateFile: "./LICENSE",
+      },
+      {
+        type: "yarn",
       },
     ],
   });

--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -36,14 +36,13 @@ const templatePackage = prepareTemplate(`
 
 export default function (/** @type {import('plop').NodePlopAPI} */ plop) {
   /**
-   * Sets a custom action type to run `yarn` on the new package folder. Note
-   * that it will only include typescript, any other dependencies will still
+   * Sets a custom action type to run `yarn` on the root directory, which
+   * will install the new package dependencies on its directory. Note that
+   * it will only include typescript, any other dependencies will still
    * need to be added after creating the package.
    */
-  plop.setActionType("yarn", function (answers, config, plop) {
-    const dashCase = plop.getHelper("dashCase");
-    const command = `cd packages/${dashCase(answers.name)}; yarn; cd ../..;`;
-    exec(command, function (error, stdout) {
+  plop.setActionType("yarn", function () {
+    exec(`yarn`, function (error, stdout) {
       if (error) {
         console.error(`Error: ${error}`);
         return;


### PR DESCRIPTION
Adds a custom command to the Plopfile to run `yarn` in the package folder after creating a new package. It can be tested by running `yarn create-package` - the newly created package should have its own `node_modules` directory after creation.

I also simplified the templates a bit (removed the partial) to make the Plopfile easier to read (for people not familiar with Handlebars). 
