### PR TITLE
regions: fix package module type

### DIFF
--- a/packages/regions/package.json
+++ b/packages/regions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/regions",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Regions",
   "repository": {
     "type": "git",

--- a/packages/regions/package.json
+++ b/packages/regions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/regions",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Regions",
   "repository": {
     "type": "git",

--- a/packages/regions/src/index.ts
+++ b/packages/regions/src/index.ts
@@ -1,6 +1,6 @@
-import { Region } from "./Region";
+import { Region, RegionJSON } from "./Region";
 import RegionDB from "./RegionDB";
 
 export { Region, RegionDB };
-
+export type { RegionJSON };
 export * from "./datasets/us";

--- a/packages/regions/tsconfig.json
+++ b/packages/regions/tsconfig.json
@@ -6,7 +6,8 @@
     "declarationDir": "lib",
     "noEmit": false,
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "module": "commonjs"
   },
   "include": ["src/**/*.ts", "src/**/*.json"],
   "exclude": ["node_modules", "**/*.test.*"]


### PR DESCRIPTION
We were not setting the module type of the regions package correctly, which breaks only when we try to use the package.