### PR TITLE
Bump regions package version (1.1.4 -> 1.1.5)

### DIFF
--- a/packages/regions/package.json
+++ b/packages/regions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/regions",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Regions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Increases the package  # so that we can republish with the changes from #14 