### PR TITLE
ui-components: LegendThreshold is now an SVG element

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,6 +13,7 @@ on:
           - time-utils
           - regions
           - ui-components
+          - ui-components-test
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,7 +13,6 @@ on:
           - time-utils
           - regions
           - ui-components
-          - ui-components-test
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@actnowcoalition/ui-components",
-  "version": "1.3.0",
+  "name": "@actnowcoalition/ui-components-test",
+  "version": "1.4.0",
   "description": "UI components for Act Now",
   "repository": {
     "type": "git",
@@ -12,13 +12,16 @@
   ],
   "author": "Act Now Coalition",
   "license": "MIT",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "lib"
+    "dist"
   ],
   "scripts": {
-    "build": "tsc --project ./tsconfig.json",
+    "build:esm": "tsc --project ./tsconfig.esm.json",
+    "build:cjs": "tsc --project ./tsconfig.cjs.json",
+    "build": "yarn build:esm && yarn build:cjs",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@actnowcoalition/ui-components-test",
+  "name": "@actnowcoalition/ui-components",
   "version": "1.4.0",
   "description": "UI components for Act Now",
   "repository": {

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
 import LegendThreshold, { LegendThresholdProps } from "./LegendThreshold";
-import { styled } from "../../styles";
 
 export default {
   title: "Components/LegendThreshold",
@@ -70,18 +69,3 @@ Squared.args = {
   borderRadius: 0,
   showLabels: true,
 };
-
-const StyledLegendThreshold = styled(LegendThreshold)`
-  line {
-    stroke: ${({ theme }) => theme.palette.grey[50]};
-  }
-  text {
-    fill: ${({ theme }) => theme.palette.grey[50]};
-  }
-`;
-
-export const StyledExample = () => (
-  <div style={{ backgroundColor: "#555", padding: 16 }}>
-    <StyledLegendThreshold {...DefaultProps.args} onClick={() => "clicked"} />
-  </div>
-);

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -82,6 +82,6 @@ const StyledLegendThreshold = styled(LegendThreshold)`
 
 export const StyledExample = () => (
   <div style={{ backgroundColor: "#555", padding: 16 }}>
-    <StyledLegendThreshold {...DefaultProps.args} />
+    <StyledLegendThreshold {...DefaultProps.args} onClick={() => "clicked"} />
   </div>
 );

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -13,9 +13,7 @@ interface Item {
 }
 
 const Template: Story<LegendThresholdProps<Item>> = (args) => (
-  <svg width={args.width} height={args.height}>
-    <LegendThreshold {...args} />
-  </svg>
+  <LegendThreshold {...args} />
 );
 
 const width = 300;

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
 import LegendThreshold, { LegendThresholdProps } from "./LegendThreshold";
+import { styled } from "../../styles";
 
 export default {
   title: "Components/LegendThreshold",
@@ -69,3 +70,18 @@ Squared.args = {
   borderRadius: 0,
   showLabels: true,
 };
+
+const StyledLegendThreshold = styled(LegendThreshold)`
+  line {
+    stroke: ${({ theme }) => theme.palette.grey[50]};
+  }
+  text {
+    fill: ${({ theme }) => theme.palette.grey[50]};
+  }
+`;
+
+export const StyledExample = () => (
+  <div style={{ backgroundColor: "#555", padding: 16 }}>
+    <StyledLegendThreshold {...DefaultProps.args} />
+  </div>
+);

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -45,7 +45,9 @@ const LegendThreshold = <T,>({
   getItemColor,
   getItemEndLabel,
   showLabels = true,
-}: LegendThresholdProps<T>) => {
+  ...otherSvgProps
+}: LegendThresholdProps<T> &
+  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
   const indexList = items.map((item, itemIndex) => itemIndex);
   const scaleRect = scaleBand({ domain: indexList, range: [0, width] });
   const rectWidth = scaleRect.bandwidth();
@@ -56,7 +58,7 @@ const LegendThreshold = <T,>({
   const tickLabelPadding = 2;
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} {...otherSvgProps}>
       <defs>
         <clipPath id={clipPathId}>
           <rect

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -33,12 +33,8 @@ export interface LegendThresholdProps<T> {
 }
 
 /**
- * `LegendThreshold` represents a scale with specific thresholds that separate
- * a set of levels. By default, the component shows labels between each level.
- *
- * Notes: This component returns an SVG Group element to make it easier to
- * integrate with other components inside an SVG element. Make sure to wrap
- * it in an SVG element if using it as standalone component.
+ * `LegendThreshold` represents a scale with thresholds that separate
+ * a set of levels. By default, the labels between each level are shown.
  */
 const LegendThreshold = <T,>({
   height = 40,
@@ -60,7 +56,7 @@ const LegendThreshold = <T,>({
   const tickLabelPadding = 2;
 
   return (
-    <Group>
+    <svg width={width} height={height}>
       <defs>
         <clipPath id={clipPathId}>
           <rect
@@ -96,7 +92,7 @@ const LegendThreshold = <T,>({
           );
         })}
       </Group>
-    </Group>
+    </svg>
   );
 };
 

--- a/packages/ui-components/tsconfig.base.json
+++ b/packages/ui-components/tsconfig.base.json
@@ -8,6 +8,6 @@
     "rootDir": "src",
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.json"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
   "exclude": ["node_modules", "**/*.test.*"]
 }

--- a/packages/ui-components/tsconfig.base.json
+++ b/packages/ui-components/tsconfig.base.json
@@ -3,13 +3,11 @@
   "compilerOptions": {
     "baseUrl": "src",
     "declaration": true,
-    "declarationDir": "lib",
+    "declarationDir": "./dist",
     "noEmit": false,
-    "outDir": "lib",
     "rootDir": "src",
-    "module": "commonjs",
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
+  "include": ["src/**/*.ts", "src/**/*.json"],
   "exclude": ["node_modules", "**/*.test.*"]
 }

--- a/packages/ui-components/tsconfig.cjs.json
+++ b/packages/ui-components/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist/cjs/"
+  }
+}

--- a/packages/ui-components/tsconfig.esm.json
+++ b/packages/ui-components/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./dist/esm/"
+  }
+}


### PR DESCRIPTION
Minor updates to the `LegendThreshold` component and `tsconfig` of the `ui-components` package.

## Changes

- The `LegendThreshold` component is now a SVG element (based on PR feedback, also, we haven't used that component within an SVG element before, so exposing it as an SVG feels more appropiate.
- Update the `tsconfig` of the `ui-components` package to generate CommonJS and ESModules (see https://github.com/covid-projections/act-now-packages/pull/17 where this is done for the `regions` package)
- Extends the `LegendThreshold` props to include SVG props, which are passed down to the inner SVG element. This allows the component to be wrapped in `styled` and also to pass SVG attributes (margins, etc) to the component without having to wrap it on a `div` (added an example on the stories as well).

