### PR TITLE
ui-components: add LegendCategorical

### DIFF
--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.stories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Story, ComponentMeta } from "@storybook/react";
+import LegendCategorical, { LegendCategoricalProps } from "./LegendCategorical";
+
+export default {
+  title: "Components/LegendCategorical",
+  component: LegendCategorical,
+} as ComponentMeta<typeof LegendCategorical>;
+
+interface Item {
+  label: string;
+  color: string;
+}
+
+const Template: Story<LegendCategoricalProps<Item>> = (args) => (
+  <LegendCategorical {...args} />
+);
+
+const items: Item[] = [
+  { label: "Legend item 1", color: "#90BE6D" },
+  { label: "Legend item 2", color: "#F9C74F" },
+  { label: "Legend item 3", color: "#F8961E" },
+  { label: "Legend item 4", color: "#E16420" },
+  { label: "Legend item 5", color: "#A10003" },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getItemColor = (item: Item, itemIndex: number) => item.color;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getItemLabel = (item: Item, itemIndex: number) => item.label;
+
+export const Example = Template.bind({});
+Example.args = {
+  items,
+  getItemColor,
+  getItemLabel,
+};

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.stories.tsx
@@ -29,9 +29,17 @@ const getItemColor = (item: Item, itemIndex: number) => item.color;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getItemLabel = (item: Item, itemIndex: number) => item.label;
 
-export const Example = Template.bind({});
-Example.args = {
+export const Horizontal = Template.bind({});
+Horizontal.args = {
   items,
   getItemColor,
   getItemLabel,
+};
+
+export const Vertical = Template.bind({});
+Vertical.args = {
+  items,
+  getItemColor,
+  getItemLabel,
+  horizontal: false,
 };

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.style.ts
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.style.ts
@@ -1,0 +1,16 @@
+import { styled } from "../../styles";
+import isValidProp from "@emotion/is-prop-valid";
+
+export const Square = styled("div", { shouldForwardProp: isValidProp })<{
+  color: string;
+}>`
+  min-width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  margin-right: ${(props) => props.theme.spacing(1)};
+  background-color: ${(props) => props.color};
+`;
+
+export const Label = styled("span")`
+  line-height: 1.2;
+`;

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -11,8 +11,10 @@ export interface LegendCategoricalProps<T> {
   getItemLabel: (item: T, itemIndex: number) => string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-const LegendCategorical = <T extends unknown>({
+/**
+ * LegendCategorical represents a legend of items, each with a color block and a corresponding label.
+ */
+const LegendCategorical = <T,>({
   items,
   getItemColor,
   getItemLabel,

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import Stack from "@mui/material/Stack";
+import { Square, Label } from "./LegendCategorical.style";
+
+export interface LegendCategoricalProps<T> {
+  /** Array of items representing legend items */
+  items: T[];
+  /** Function that returns the color of each legend item */
+  getItemColor: (item: T, itemIndex: number) => string;
+  /** Function that returns the label of each legend item */
+  getItemLabel: (item: T, itemIndex: number) => string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
+const LegendCategorical = <T extends unknown>({
+  items,
+  getItemColor,
+  getItemLabel,
+}: LegendCategoricalProps<T>) => {
+  return (
+    <Stack
+      direction={{ xs: "column", md: "row" }}
+      spacing={{ xs: 1.5, md: 2.5 }}
+    >
+      {items.map((item: T, itemIndex: number) => {
+        return (
+          <Stack direction="row" alignItems="center" key={`item-${itemIndex}`}>
+            <Square color={getItemColor(item, itemIndex)} />
+            <Label>{getItemLabel(item, itemIndex)}</Label>
+          </Stack>
+        );
+      })}
+    </Stack>
+  );
+};
+
+export default LegendCategorical;

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -9,6 +9,11 @@ export interface LegendCategoricalProps<T> {
   getItemColor: (item: T, itemIndex: number) => string;
   /** Function that returns the label of each legend item */
   getItemLabel: (item: T, itemIndex: number) => string;
+  /**
+   * Whether or not the legend items are oriented horizontally (in a row) on desktop screens ('md' and wider).
+   * Defaults to true. If false, the legend items will be oriented vertically/in a column.
+   */
+  horizontal?: boolean;
 }
 
 /**
@@ -18,11 +23,14 @@ const LegendCategorical = <T,>({
   items,
   getItemColor,
   getItemLabel,
+  horizontal = true,
 }: LegendCategoricalProps<T>) => {
+  const desktopLegendOrientation = horizontal ? "row" : "column";
+  const desktopLegendSpacing = horizontal ? 2.5 : 1.5;
   return (
     <Stack
-      direction={{ xs: "column", md: "row" }}
-      spacing={{ xs: 1.5, md: 2.5 }}
+      direction={{ xs: "column", md: desktopLegendOrientation }}
+      spacing={{ xs: 1.5, md: desktopLegendSpacing }}
     >
       {items.map((item: T, itemIndex: number) => {
         return (

--- a/packages/ui-components/src/components/LegendCategorical/index.ts
+++ b/packages/ui-components/src/components/LegendCategorical/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LegendCategorical";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -1,3 +1,3 @@
 export { default as LegendThreshold } from "./components/LegendThreshold";
 
-export { default as LegendCategorical } from "components/LegendCategorical";
+export { default as LegendCategorical } from "./components/LegendCategorical";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -1,1 +1,3 @@
 export { default as LegendThreshold } from "./components/LegendThreshold";
+
+export { default as LegendCategorical } from "components/LegendCategorical";

--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -202,7 +202,7 @@ export default function (/** @type {import('plop').NodePlopAPI} */ plop) {
         type: "append",
         path: `packages/ui-components/src/index.ts`,
         template:
-          'export { default as {{pascalCase name}} } from "components/{{pascalCase name}}";',
+          'export { default as {{pascalCase name}} } from "./components/{{pascalCase name}}";',
         unique: true,
       },
     ],


### PR DESCRIPTION
A legend of color blocks and corresponding labels


**Desktop/screens `md` and wider:** 
<img width="769" alt="Screen Shot 2022-08-01 at 5 07 04 PM" src="https://user-images.githubusercontent.com/44076375/182246770-e381c487-4720-44a8-b204-15b7be22cd07.png">

**Mobile/screens narrower than `md`:**
<img width="173" alt="Screen Shot 2022-08-01 at 5 07 16 PM" src="https://user-images.githubusercontent.com/44076375/182246777-42a4e0dd-4bdc-4256-905d-b42379d5f2ec.png">