### PR TITLE
Explicitly list packages in workspace so we can control the build order.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
   "license": "MIT",
   "private": true,
   "workspaces": [
-    "./packages/*"
+    "./packages/assert",
+    "./packages/number-format",
+    "./packages/time-utils",
+    "./packages/regions",
+    "./packages/metrics",
+    "./packages/ui-components"
   ],
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
The metrics package stopped building when I added a dependency on regions, because yarn was building
metrics before regions. I'm explicitly listing the packages so we can control the build order.