### PR TITLE
Theming in ui-components package

### DIFF
--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.style.ts
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.style.ts
@@ -10,7 +10,3 @@ export const Square = styled("div", { shouldForwardProp: isValidProp })<{
   margin-right: ${(props) => props.theme.spacing(1)};
   background-color: ${(props) => props.color};
 `;
-
-export const Label = styled("span")`
-  line-height: 1.2;
-`;

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import Stack from "@mui/material/Stack";
-import { Square, Label } from "./LegendCategorical.style";
+import Typography from "@mui/material/Typography";
+import { Square } from "./LegendCategorical.style";
+import { ThemeProvider } from "@mui/material/styles";
+import { theme } from "../../styles";
 
 export interface LegendCategoricalProps<T> {
   /** Array of items representing legend items */
@@ -28,19 +31,27 @@ const LegendCategorical = <T,>({
   const desktopLegendOrientation = horizontal ? "row" : "column";
   const desktopLegendSpacing = horizontal ? 2.5 : 1.5;
   return (
-    <Stack
-      direction={{ xs: "column", md: desktopLegendOrientation }}
-      spacing={{ xs: 1.5, md: desktopLegendSpacing }}
-    >
-      {items.map((item: T, itemIndex: number) => {
-        return (
-          <Stack direction="row" alignItems="center" key={`item-${itemIndex}`}>
-            <Square color={getItemColor(item, itemIndex)} />
-            <Label>{getItemLabel(item, itemIndex)}</Label>
-          </Stack>
-        );
-      })}
-    </Stack>
+    <ThemeProvider theme={theme}>
+      <Stack
+        direction={{ xs: "column", md: desktopLegendOrientation }}
+        spacing={{ xs: 1.5, md: desktopLegendSpacing }}
+      >
+        {items.map((item: T, itemIndex: number) => {
+          return (
+            <Stack
+              direction="row"
+              alignItems="center"
+              key={`item-${itemIndex}`}
+            >
+              <Square color={getItemColor(item, itemIndex)} />
+              <Typography variant="paragraphSmall">
+                {getItemLabel(item, itemIndex)}
+              </Typography>
+            </Stack>
+          );
+        })}
+      </Stack>
+    </ThemeProvider>
   );
 };
 

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { Square } from "./LegendCategorical.style";
-import { ThemeProvider } from "@mui/material/styles";
-import { theme } from "../../styles";
 
 export interface LegendCategoricalProps<T> {
   /** Array of items representing legend items */
@@ -31,27 +29,21 @@ const LegendCategorical = <T,>({
   const desktopLegendOrientation = horizontal ? "row" : "column";
   const desktopLegendSpacing = horizontal ? 2.5 : 1.5;
   return (
-    <ThemeProvider theme={theme}>
-      <Stack
-        direction={{ xs: "column", md: desktopLegendOrientation }}
-        spacing={{ xs: 1.5, md: desktopLegendSpacing }}
-      >
-        {items.map((item: T, itemIndex: number) => {
-          return (
-            <Stack
-              direction="row"
-              alignItems="center"
-              key={`item-${itemIndex}`}
-            >
-              <Square color={getItemColor(item, itemIndex)} />
-              <Typography variant="paragraphSmall">
-                {getItemLabel(item, itemIndex)}
-              </Typography>
-            </Stack>
-          );
-        })}
-      </Stack>
-    </ThemeProvider>
+    <Stack
+      direction={{ xs: "column", md: desktopLegendOrientation }}
+      spacing={{ xs: 1.5, md: desktopLegendSpacing }}
+    >
+      {items.map((item: T, itemIndex: number) => {
+        return (
+          <Stack direction="row" alignItems="center" key={`item-${itemIndex}`}>
+            <Square color={getItemColor(item, itemIndex)} />
+            <Typography variant="paragraphSmall">
+              {getItemLabel(item, itemIndex)}
+            </Typography>
+          </Stack>
+        );
+      })}
+    </Stack>
   );
 };
 

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -12,15 +12,17 @@ export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
 
-// Material UI Theme extensions
-//
-// In order to use our extensions to the material UI theme in TypeScript code,
-// we must patch some material-ui interfaces since the allowed values for various
-// properties (e.g. the `variant` property on typography) are based on the
-// members of these interfaces.
-//
-// In order to make sure consumers of our package can use our theme extensions, we do
-// this in the index.ts file.
+/**
+ * Material UI Theme extensions
+ *
+ * In order to use our extensions to the material UI theme in TypeScript code,
+ * we must patch some material-ui interfaces since the allowed values for various
+ * properties (e.g. the `variant` property on typography) are based on the
+ * members of these interfaces.
+ *
+ * In order to make sure consumers of our package can use our theme extensions, we do
+ * this in the index.ts file.
+ */
 
 declare module "@mui/material/Typography" {
   interface TypographyPropsVariantOverrides {

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -1,3 +1,5 @@
+import { Theme } from "@mui/material/styles";
+
 /** Theme variables */
 export * from "./styles"; // styled, theme
 
@@ -9,3 +11,42 @@ export type { LegendCategoricalProps } from "./components/LegendCategorical";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
+
+// Material UI Theme extensions
+//
+// In order to use our extensions to the material UI theme in TypeScript code,
+// we must patch some material-ui interfaces since the allowed values for various
+// properties (e.g. the `variant` property on typography) are based on the
+// members of these interfaces.
+//
+// In order to make sure consumers of our package can use our theme extensions, we do
+// this in the index.ts file.
+
+declare module "@mui/material/Typography" {
+  interface TypographyPropsVariantOverrides {
+    paragraphSmall: true;
+    paragraphLarge: true;
+  }
+}
+
+declare module "@mui/material/styles" {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends Theme {}
+
+  interface Palette {
+    severity: {
+      100: string;
+      200: string;
+      300: string;
+      400: string;
+      500: string;
+    };
+    gradient: {
+      100: string;
+      200: string;
+      300: string;
+      400: string;
+      500: string;
+    };
+  }
+}

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -1,3 +1,7 @@
+/** Theme variables */
+export * from "./styles"; // styled, theme
+
+/** UI Components and props */
 export { default as LegendThreshold } from "./components/LegendThreshold";
 export type { LegendThresholdProps } from "./components/LegendThreshold";
 export { default as LegendCategorical } from "./components/LegendCategorical";

--- a/packages/ui-components/src/styles/theme/index.ts
+++ b/packages/ui-components/src/styles/theme/index.ts
@@ -1,5 +1,1 @@
-import { createTheme } from "@mui/material/styles";
-
-const theme = createTheme({});
-
-export default theme;
+export { default } from "./theme";

--- a/packages/ui-components/src/styles/theme/interfaces.ts
+++ b/packages/ui-components/src/styles/theme/interfaces.ts
@@ -1,0 +1,8 @@
+/** Theme interfaces */
+import { TypographyOptions } from "@mui/material/styles/createTypography";
+
+/** Typography */
+export interface ExtendedTypographyOptions extends TypographyOptions {
+  paragraphSmall: React.CSSProperties;
+  paragraphLarge: React.CSSProperties;
+}

--- a/packages/ui-components/src/styles/theme/palette.ts
+++ b/packages/ui-components/src/styles/theme/palette.ts
@@ -1,0 +1,76 @@
+// (In progress) - color names matching what exists in Figma's Act Now design system (as of 8/4/22)
+const colors = {
+  text: {
+    emphasized: "#121314",
+    default: "#3C4245",
+    deemphasized: "#5F6C72",
+    light: "#F6F6F6",
+  },
+  background: {
+    light: "#FFFFFF",
+    medium: "", // TODO - Josh to translate to hex in figma
+    dark: "#121314",
+  },
+  border: {
+    default: "#5f6c7233", // TODO - Josh to translate to hex in figma
+  },
+  action: {
+    primary: "#464FC7",
+    primaryHover: "#1D27B1",
+  },
+  severity: {
+    100: "#00D474",
+    200: "#FFC900",
+    300: "#FF9600",
+    400: "#D9002C",
+    500: "#790019",
+  },
+  gradient: {
+    100: "#CCB7FA",
+    200: "#B292F9",
+    300: "#9670F7",
+    400: "#794DF3",
+    500: "#5936B6",
+  },
+};
+
+const palette = {
+  primary: {
+    main: colors.action.primary,
+    dark: colors.action.primaryHover,
+  },
+  secondary: {
+    light: colors.text.deemphasized,
+    main: colors.text.default,
+    dark: colors.text.emphasized,
+  },
+  common: {
+    black: "black",
+    white: "white",
+  },
+  success: {
+    main: colors.severity[100], // severity100
+  },
+  text: {
+    primary: colors.text.default,
+    secondary: colors.text.emphasized,
+    secondaryLight: colors.text.deemphasized,
+    light: colors.text.light,
+  },
+  severity: {
+    100: colors.severity[100],
+    200: colors.severity[200],
+    300: colors.severity[300],
+    400: colors.severity[400],
+    500: colors.severity[500],
+  },
+  gradient: {
+    100: colors.gradient[100],
+    200: colors.gradient[200],
+    300: colors.gradient[300],
+    400: colors.gradient[400],
+    500: colors.gradient[500],
+  },
+};
+
+export default palette;

--- a/packages/ui-components/src/styles/theme/palette.ts
+++ b/packages/ui-components/src/styles/theme/palette.ts
@@ -50,7 +50,7 @@ const palette = {
     white: "white",
   },
   success: {
-    main: colors.severity[100], // severity100
+    main: colors.severity[100],
   },
   text: {
     primary: colors.text.default,

--- a/packages/ui-components/src/styles/theme/palette.ts
+++ b/packages/ui-components/src/styles/theme/palette.ts
@@ -43,6 +43,7 @@ const palette = {
     light: colors.text.deemphasized,
     main: colors.text.default,
     dark: colors.text.emphasized,
+    contrastText: colors.text.light,
   },
   common: {
     black: "black",
@@ -53,9 +54,7 @@ const palette = {
   },
   text: {
     primary: colors.text.default,
-    secondary: colors.text.emphasized,
-    secondaryLight: colors.text.deemphasized,
-    light: colors.text.light,
+    secondary: colors.text.deemphasized,
   },
   severity: {
     100: colors.severity[100],

--- a/packages/ui-components/src/styles/theme/theme.ts
+++ b/packages/ui-components/src/styles/theme/theme.ts
@@ -1,28 +1,6 @@
-import { createTheme, Theme } from "@mui/material/styles";
+import { createTheme } from "@mui/material/styles";
 import palette from "./palette";
 import typography from "./typography";
-
-declare module "@mui/material/styles" {
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface DefaultTheme extends Theme {}
-
-  interface Palette {
-    severity: {
-      100: string;
-      200: string;
-      300: string;
-      400: string;
-      500: string;
-    };
-    gradient: {
-      100: string;
-      200: string;
-      300: string;
-      400: string;
-      500: string;
-    };
-  }
-}
 
 /**
  * Theme configuration variables

--- a/packages/ui-components/src/styles/theme/theme.ts
+++ b/packages/ui-components/src/styles/theme/theme.ts
@@ -1,0 +1,36 @@
+import { createTheme, Theme } from "@mui/material/styles";
+import palette from "./palette";
+import typography from "./typography";
+
+declare module "@mui/material/styles" {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface DefaultTheme extends Theme {}
+
+  interface Palette {
+    severity: {
+      100: string;
+      200: string;
+      300: string;
+      400: string;
+      500: string;
+    };
+    gradient: {
+      100: string;
+      200: string;
+      300: string;
+      400: string;
+      500: string;
+    };
+  }
+}
+
+/**
+ * Theme configuration variables
+ * https://mui.com/customization/theming/#theme-configuration-variables
+ */
+const theme = createTheme({
+  palette,
+  typography,
+});
+
+export default theme;

--- a/packages/ui-components/src/styles/theme/typography.ts
+++ b/packages/ui-components/src/styles/theme/typography.ts
@@ -1,17 +1,5 @@
-import { TypographyOptions } from "@mui/material/styles/createTypography";
 import palette from "./palette";
-
-declare module "@mui/material/Typography" {
-  interface TypographyPropsVariantOverrides {
-    paragraphSmall: true;
-    paragraphLarge: true;
-  }
-}
-
-interface ExtendedTypographyOptions extends TypographyOptions {
-  paragraphSmall: React.CSSProperties;
-  paragraphLarge: React.CSSProperties;
-}
+import { ExtendedTypographyOptions } from "./interfaces";
 
 const typographyConstants = {
   fontFamily: "Arial",
@@ -34,7 +22,7 @@ const typography: ExtendedTypographyOptions = {
     fontFamily: typographyConstants.fontFamily,
     fontSize: typographyConstants.fontSizePSmall,
     lineHeight: typographyConstants.lineHeightSmall,
-    color: palette.text.secondaryLight,
+    color: palette.secondary.contrastText,
   },
   paragraphLarge: {
     fontFamily: typographyConstants.fontFamily,

--- a/packages/ui-components/src/styles/theme/typography.ts
+++ b/packages/ui-components/src/styles/theme/typography.ts
@@ -1,0 +1,47 @@
+import { TypographyOptions } from "@mui/material/styles/createTypography";
+import palette from "./palette";
+
+declare module "@mui/material/Typography" {
+  interface TypographyPropsVariantOverrides {
+    paragraphSmall: true;
+    paragraphLarge: true;
+  }
+}
+
+interface ExtendedTypographyOptions extends TypographyOptions {
+  paragraphSmall: React.CSSProperties;
+  paragraphLarge: React.CSSProperties;
+}
+
+const typographyConstants = {
+  fontFamily: "Arial",
+
+  fontWeightRegular: 400,
+  fontWeightMedium: 500,
+  fontWeightBold: 700,
+
+  fontSizePSmall: ".875rem",
+  fontSizeBase: "1rem",
+
+  lineHeightSmall: 1,
+  lineHeightBase: 1.5,
+};
+
+const typography: ExtendedTypographyOptions = {
+  fontFamily: typographyConstants.fontFamily,
+
+  paragraphSmall: {
+    fontFamily: typographyConstants.fontFamily,
+    fontSize: typographyConstants.fontSizePSmall,
+    lineHeight: typographyConstants.lineHeightSmall,
+    color: palette.text.secondaryLight,
+  },
+  paragraphLarge: {
+    fontFamily: typographyConstants.fontFamily,
+    fontSize: typographyConstants.fontSizeBase,
+    lineHeight: typographyConstants.lineHeightBase,
+  },
+};
+
+export { typographyConstants };
+export default typography;


### PR DESCRIPTION
Sets up MUI theme extensions according to our [figma design system](https://www.figma.com/file/YN7x6bJmSfRHaovP5ABKu2/ActNow-Design-System?node-id=29%3A1035) and adds to typography+palette accordingly. Putting the MUI theme extension declarations in `ui-components/src/index.ts` should result in them showing up in any repo that has the `ui-components` package installed, and therefore should apply the custom theming to that repo. <-- Going to test this out by merging/publishing this PR and testing custom theming in another repo

As of now, custom theme variables are working properly when used to style components in this package (see the custom themed `variant="paragraphSmall"` [here](https://github.com/covid-projections/act-now-packages/pull/34/files#diff-1ff454cd5c955105ef616d90f64d202ff509436f688a484c1546a9eecf72689eR40)). We want the same custom theme variables to be applied to any `act-now-template` project's theme (and we want to control the shape of the custom theme from a single location - [hopefully here](https://github.com/covid-projections/act-now-packages/pull/34/files#diff-e8db90eaf056409aa60f99ae7e58bc599864cd6e284b72fcade7570c4697b1f8R15-R54)). 