### PR TITLE
Minor Timeseries tweaks and prep for publishing.

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/metrics",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Classes for representing metrics and loading metric data",
   "repository": {
     "type": "git",
@@ -30,6 +30,7 @@
   "sideEffects": false,
   "dependencies": {
     "@actnowcoalition/assert": "^1.0.0",
+    "@actnowcoalition/time-utils": "^1.0.1",
     "lodash": "^4.17.21"
   }
 }

--- a/packages/metrics/src/Timeseries/Timeseries.test.ts
+++ b/packages/metrics/src/Timeseries/Timeseries.test.ts
@@ -64,6 +64,13 @@ describe("Timeseries", () => {
     expect(ts.values).toEqual(values);
   });
 
+  test("fromDateRange() with big ranges (leap years, daylight savings, etc.)", () => {
+    const startDate = new Date("2019-01-01");
+    const endDate = new Date("2021-01-01");
+    const ts = Timeseries.fromDateRange(startDate, endDate, () => 1);
+    expect(ts.dates.length).toBe(732);
+  });
+
   test("findNearestDate() finds nearest date", () => {
     const points = [
       {

--- a/packages/metrics/src/Timeseries/Timeseries.test.ts
+++ b/packages/metrics/src/Timeseries/Timeseries.test.ts
@@ -43,6 +43,27 @@ describe("Timeseries", () => {
     expect(ts.points).toEqual([points[1], points[0]]);
   });
 
+  test("fromDateRange() with iteratee", () => {
+    const startDate = new Date("2021-01-01");
+    const endDate = new Date("2021-01-03");
+    const expectedDates = [
+      "2021-01-01T00:00:00.000Z",
+      "2021-01-02T00:00:00.000Z",
+      "2021-01-03T00:00:00.000Z",
+    ];
+    const values = [1, 2, 3];
+
+    // using values array
+    let ts = Timeseries.fromDateRange(startDate, endDate, values);
+    expect(ts.dates.map((d) => d.toISOString())).toEqual(expectedDates);
+    expect(ts.values).toEqual(values);
+
+    // using value iteratee
+    ts = Timeseries.fromDateRange(startDate, endDate, (date, i) => values[i]);
+    expect(ts.dates.map((d) => d.toISOString())).toEqual(expectedDates);
+    expect(ts.values).toEqual(values);
+  });
+
   test("findNearestDate() finds nearest date", () => {
     const points = [
       {
@@ -91,7 +112,7 @@ describe("Timeseries", () => {
     ]);
     const tsWithoutNulls: Timeseries<number> = ts.removeNils();
     expect(tsWithoutNulls.length).toBe(3);
-    expect(tsWithoutNulls.values()).toEqual([1, 2, 3]);
+    expect(tsWithoutNulls.values).toEqual([1, 2, 3]);
   });
 
   test(`hasData() can be used as a type guard for NonEmptyTimeseries`, () => {
@@ -103,7 +124,7 @@ describe("Timeseries", () => {
       // NonEmptyTimeseries and last() and findNearestDate() should be
       // non-nullable, so TypeScript will let us access `.value` without a null
       // check.
-      console.log(ts.last().value);
+      console.log(ts.last.value);
       console.log(ts.findNearestDate(new Date()).value);
     }
   });

--- a/packages/metrics/src/Timeseries/Timeseries.ts
+++ b/packages/metrics/src/Timeseries/Timeseries.ts
@@ -80,7 +80,7 @@ export class Timeseries<T = unknown> {
         value: valueFn(date, index),
       });
       index++;
-      date.setDate(date.getDate() + 1);
+      date.setUTCDate(date.getUTCDate() + 1);
     }
     return new Timeseries<T>(points);
   }

--- a/packages/metrics/src/Timeseries/Timeseries.ts
+++ b/packages/metrics/src/Timeseries/Timeseries.ts
@@ -1,10 +1,12 @@
-import { assert } from "@actnowcoalition/assert";
-import isFinite from "lodash/isFinite";
 import isNil from "lodash/isNil";
 import first from "lodash/first";
 import last from "lodash/last";
 import maxBy from "lodash/maxBy";
 import minBy from "lodash/minBy";
+
+import { assert } from "@actnowcoalition/assert";
+import { isFinite } from "@actnowcoalition/number-format";
+import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
 
 /**
  * A single point in a timeseries containing a date (which must not contain a
@@ -48,6 +50,41 @@ export class Timeseries<T = unknown> {
       .sort((a, b) => a.date.getTime() - b.date.getTime());
   }
 
+  /**
+   * Static constructor to help create a timeseries from a range of dates and
+   * some values.
+   *
+   * @param start The start date of the timeseries.
+   * @param end The end date of the timeseries.
+   * @param valueProvider An array of values or iteratee function that returns
+   * values for the dates in the date range.
+   * @returns A new timeseries.
+   */
+  static fromDateRange<T>(
+    startDate: Date,
+    endDate: Date,
+    valueProvider: T[] | ((date: Date, index: number) => T)
+  ): Timeseries<T> {
+    const valueFn = Array.isArray(valueProvider)
+      ? (date: Date, index: number) => valueProvider[index]
+      : valueProvider;
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    const points = [];
+    let index = 0;
+    const date = start;
+    while (date <= end) {
+      points.push({
+        // Clone the date since we're going to mutate it below.
+        date: new Date(date),
+        value: valueFn(date, index),
+      });
+      index++;
+      date.setDate(date.getDate() + 1);
+    }
+    return new Timeseries<T>(points);
+  }
+
   /** The length of the timeseries. */
   get length(): number {
     return this.points.length;
@@ -64,13 +101,13 @@ export class Timeseries<T = unknown> {
     return this.length > 0;
   }
 
-  /** Returns the dates of the points in the timeseries. */
-  dates(): Date[] {
+  /** The dates of the points in the timeseries. */
+  get dates(): Date[] {
     return this.points.map((p) => p.date);
   }
 
-  /** Returns the values of the points in the timeseries. */
-  values(): T[] {
+  /** The values of the points in the timeseries. */
+  get values(): T[] {
     return this.points.map((p) => p.value);
   }
 
@@ -181,64 +218,64 @@ export class Timeseries<T = unknown> {
   }
 
   /**
-   * Returns the first point in the timeseries, or undefined if the timeseries is
+   * The first point in the timeseries, or undefined if the timeseries is
    * empty.
    *
    * You can use {@link Timeseries.hasData} to guard against the timeseries
    * being empty and ensure this can't return undefined.
    */
-  first(): TimeseriesPoint<T> | undefined {
+  get first(): TimeseriesPoint<T> | undefined {
     return first(this.points);
   }
 
   /**
-   * Returns the last point in the timeseries or undefined if the timeseries is
+   * The last point in the timeseries or undefined if the timeseries is
    * empty.
    *
    * You can use {@link Timeseries.hasData} to guard against the timeseries
    * being empty and ensure this can't return undefined.
    */
-  last(): TimeseriesPoint<T> | undefined {
+  get last(): TimeseriesPoint<T> | undefined {
     return last(this.points);
   }
 
   /**
-   * Returns the minimum (earliest) date in the timeseries.
+   * The minimum (earliest) date in the timeseries.
    *
    * You can use {@link Timeseries.hasData} to guard against the timeseries
    * being empty and ensure this can't return undefined.
    */
-  minDate(): Date | undefined {
+  get minDate(): Date | undefined {
     return minBy(this.points, (p) => p.date)?.date;
   }
 
   /**
-   * Returns the maximum (latest) date in the timeseries.
+   * The maximum (latest) date in the timeseries.
    *
    * You can use {@link Timeseries.hasData} to guard against the timeseries
    * being empty and ensure this can't return undefined.
    */
-  maxDate(): Date | undefined {
+  get maxDate(): Date | undefined {
     return maxBy(this.points, (p) => p.date)?.date;
   }
 
   /**
-   * Returns the minimum value in the timeseries.
+   * The minimum value in the timeseries.
    *
    * You can use {@link Timeseries.hasData} to guard against the timeseries
    * being empty and ensure this can't return undefined.
    */
-  minValue(): T | undefined {
+  get minValue(): T | undefined {
     return minBy(this.points, (p) => p.value)?.value;
   }
 
   /**
-   * Returns the maximum value in the timeseries.
+   * The maximum value in the timeseries.
    *
    * You can use {@link Timeseries.hasData} to guard against the timeseries
    * being empty and ensure this can't return undefined.
    */
-  maxValue(): T | undefined {
+  get maxValue(): T | undefined {
     return maxBy(this.points, (p) => p.value)?.value;
   }
 
@@ -266,7 +303,7 @@ export class Timeseries<T = unknown> {
 
   private static isoDateString(date: Date): string {
     // Dates are guaranteed not to have a time component so we just return the ISO date.
-    return date.toISOString().split("T")[0];
+    return formatUTCDateTime(date, DateFormat.YYYY_MM_DD);
   }
 }
 
@@ -287,11 +324,11 @@ export class Timeseries<T = unknown> {
  * ```
  */
 export interface NonEmptyTimeseries<T> extends Timeseries<T> {
-  first(): TimeseriesPoint<T>;
-  last(): TimeseriesPoint<T>;
+  get first(): TimeseriesPoint<T>;
+  get last(): TimeseriesPoint<T>;
   findNearestDate(date: Date): TimeseriesPoint<T>;
-  minDate(): Date;
-  maxDate(): Date;
-  minValue(): T;
-  maxValue(): T;
+  get minDate(): Date;
+  get maxDate(): Date;
+  get minValue(): T;
+  get maxValue(): T;
 }

--- a/packages/metrics/src/Timeseries/timeseries_utils.test.ts
+++ b/packages/metrics/src/Timeseries/timeseries_utils.test.ts
@@ -33,8 +33,8 @@ describe("Timeseries utils", () => {
       /*days=*/ 3,
       /*includeTrailingZeros=*/ true
     );
-    expect(withTrailingZeros.dates()).toEqual(ts.dates());
-    expect(withTrailingZeros.values()).toEqual([
+    expect(withTrailingZeros.dates).toEqual(ts.dates);
+    expect(withTrailingZeros.values).toEqual([
       1 / 1,
       (1 + 2) / 2,
       (1 + 2 + 3) / 3,
@@ -49,8 +49,8 @@ describe("Timeseries utils", () => {
       /*days=*/ 3,
       /*includeTrailingZeros=*/ false
     );
-    expect(withoutTrailingZeros.dates()).toEqual(ts.dates());
-    expect(withoutTrailingZeros.values()).toEqual([
+    expect(withoutTrailingZeros.dates).toEqual(ts.dates);
+    expect(withoutTrailingZeros.values).toEqual([
       1 / 1,
       (1 + 2) / 2,
       (1 + 2 + 3) / 3,

--- a/packages/metrics/yarn.lock
+++ b/packages/metrics/yarn.lock
@@ -7,15 +7,34 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-1.0.0.tgz#060686d3f81aefc5e2f23709c51d0236389104eb"
   integrity sha512-LVu0iIEnl2tfCFWuynm7pXX6jtLiiD3o3vV5mJSdnKONOsGAWs7CW15tMj30SUrLHLP3zhHFFpu9Y/hXL/Flig==
 
+"@actnowcoalition/time-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/time-utils/-/time-utils-1.0.1.tgz#4caf60c55764a73ec31be223cefee880568204b9"
+  integrity sha512-IKquf6m4tu4k6GUTWEvw8wL+sVRnyOOztXotEwM2WdCPNlHd4nPX3X1ZdVoOKPqdF7kIeplu1y7sFjhIpnmABA==
+  dependencies:
+    "@actnowcoalition/assert" "^1.0.0"
+    "@types/luxon" "^2.3.2"
+    luxon "^2.4.0"
+
 "@types/lodash@^4.14.182":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
 
+"@types/luxon@^2.3.2":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-2.4.0.tgz#897d3abc23b68d78b69d76a12c21e01eb5adab95"
+  integrity sha512-oCavjEjRXuR6URJEtQm0eBdfsBiEcGBZbq21of8iGkeKxU1+1xgKuFPClaBZl2KB8ZZBSWlgk61tH6Mf+nvZVw==
+
 lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+luxon@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.5.0.tgz#098090f67d690b247e83c090267a60b1aa8ea96c"
+  integrity sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A==
 
 typescript@^4.6.4:
   version "4.7.4"

--- a/packages/number-format/package.json
+++ b/packages/number-format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/number-format",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "Number formatting utility functions",
   "repository": {
     "type": "git",

--- a/packages/number-format/src/index.ts
+++ b/packages/number-format/src/index.ts
@@ -145,3 +145,24 @@ function getOptionsFromPlacesOrOptions(
       }
     : { ...placesOrOptions, ...formattingStyleForOptions };
 }
+
+/**
+ * Type guard that checks if the provided value is a number.
+ *
+ * @param value Value to check.
+ * @returns True if the value is a number.
+ */
+export function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+/**
+ * Type guard that checks if the provided value is a number and
+ * is not NaN, Infinity or -Infinity.
+ *
+ * @param value Value to check.
+ * @returns True if the value is a number.
+ */
+export function isFinite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}

--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -26,7 +26,7 @@ yarn add @actnowcoalition/{{dashCase name}}
 const templatePackage = prepareTemplate(`
 {
   "name": "@actnowcoalition/{{dashCase name}}",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "{{sentenceCase description}}",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Added a Timeseries.fromDateRange() that's convenient for creating test timeseries, etc.
* Changed several simple methods on Timeseries into getter properties instead (last(), minValue(), etc.).
* Make Timeseries use time-utils package for formatting ISO dates.
* Changed the version to 0.0.1 in preparation for publishing.
* Changed the default package version (in plopfile) to 0.0.1.
* Also added a couple helpers to the number-format package that were handy.