### PR TITLE
Add legend threshold vertical

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@actnowcoalition/metrics": "^0.0.1",
+    "@actnowcoalition/number-format": "^1.1.1",
     "@actnowcoalition/regions": "^1.1.6",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import LegendThreshold, { LegendThresholdProps } from "./LegendThreshold";
+import LegendThreshold from ".";
+import { LegendThresholdProps } from "./LegendThreshold";
 
 export default {
   title: "Components/LegendThreshold",
@@ -21,6 +22,9 @@ const height = 40;
 const barHeight = 20;
 const borderRadius = 4;
 
+const verticalWidth = 14.4;
+const verticalHeight = 60;
+
 const items: Item[] = [
   { label: "10", color: "#90BE6D" },
   { label: "20", color: "#F9C74F" },
@@ -36,9 +40,22 @@ const getItemEndLabel = (item: Item, itemIndex: number) => item.label;
 
 export const DefaultProps = Template.bind({});
 DefaultProps.args = {
+  orientation: "horizontal",
   height,
   width,
   barHeight,
+  borderRadius,
+  items,
+  getItemColor,
+  getItemEndLabel,
+};
+
+export const VerticalProps = Template.bind({});
+VerticalProps.args = {
+  orientation: "vertical",
+  height: verticalHeight,
+  width: verticalWidth,
+  barHeight: verticalHeight,
   borderRadius,
   items,
   getItemColor,

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -48,6 +48,7 @@ HorizontalDefault.args = {
   width: horizontalWidth,
   barHeight: horizontalBarHeight,
   borderRadius,
+  showLabels: true,
   items,
   getItemColor,
   getItemEndLabel,

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import LegendThreshold from ".";
-import { LegendThresholdProps } from "./LegendThreshold";
+import LegendThreshold, { LegendThresholdProps } from ".";
 
 export default {
   title: "Components/LegendThreshold",

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -17,13 +17,16 @@ const Template: Story<LegendThresholdProps<Item>> = (args) => (
   <LegendThreshold {...args} />
 );
 
-const width = 300;
-const height = 40;
-const barHeight = 20;
-const borderRadius = 4;
+// Horizontal legend threshold props
+const horizontalHeight = 40;
+const horizontalBarHeight = 20;
+const horizontalWidth = 300;
 
-const verticalWidth = 14.4;
-const verticalHeight = 60;
+// Vertical legend threshold props
+const verticalWidth = 20;
+const verticalHeight = 300;
+
+const borderRadius = 4;
 
 const items: Item[] = [
   { label: "10", color: "#90BE6D" },
@@ -38,51 +41,62 @@ const getItemColor = (item: Item, itemIndex: number) => item.color;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getItemEndLabel = (item: Item, itemIndex: number) => item.label;
 
-export const DefaultProps = Template.bind({});
-DefaultProps.args = {
+export const HorizontalDefault = Template.bind({});
+HorizontalDefault.args = {
   orientation: "horizontal",
-  height,
-  width,
-  barHeight,
+  height: horizontalHeight,
+  width: horizontalWidth,
+  barHeight: horizontalBarHeight,
   borderRadius,
   items,
   getItemColor,
   getItemEndLabel,
 };
 
-export const VerticalProps = Template.bind({});
-VerticalProps.args = {
+export const HorizontalWithoutLabels = Template.bind({});
+HorizontalWithoutLabels.args = {
+  ...HorizontalDefault.args,
+  height: horizontalBarHeight,
+  showLabels: false,
+};
+
+export const HorizontalRounded = Template.bind({});
+HorizontalRounded.args = {
+  ...HorizontalDefault.args,
+  height: horizontalBarHeight,
+  borderRadius: horizontalBarHeight / 2,
+  showLabels: false,
+};
+
+export const HorizontalSquared = Template.bind({});
+HorizontalSquared.args = {
+  ...HorizontalDefault.args,
+  borderRadius: 0,
+  showLabels: true,
+};
+
+export const VerticalDefault = Template.bind({});
+VerticalDefault.args = {
   orientation: "vertical",
   height: verticalHeight,
-  width: verticalWidth,
   barHeight: verticalHeight,
+  width: verticalWidth,
   borderRadius,
   items,
   getItemColor,
   getItemEndLabel,
 };
 
-export const WithLabels = Template.bind({});
-WithLabels.args = { ...DefaultProps.args };
-
-export const WithoutLabels = Template.bind({});
-WithoutLabels.args = {
-  ...DefaultProps.args,
-  height: barHeight,
+export const VerticalRounded = Template.bind({});
+VerticalRounded.args = {
+  ...VerticalDefault.args,
+  borderRadius: verticalWidth / 2,
   showLabels: false,
 };
 
-export const Rounded = Template.bind({});
-Rounded.args = {
-  ...DefaultProps.args,
-  height: barHeight,
-  borderRadius: barHeight / 2,
-  showLabels: false,
-};
-
-export const Squared = Template.bind({});
-Squared.args = {
-  ...DefaultProps.args,
+export const VerticalSquared = Template.bind({});
+VerticalSquared.args = {
+  ...VerticalDefault.args,
   borderRadius: 0,
   showLabels: true,
 };

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import LegendThreshold, { LegendThresholdProps } from ".";
+import LegendThreshold from ".";
+import { LegendThresholdProps } from "./LegendThreshold";
 
 export default {
   title: "Components/LegendThreshold",
@@ -78,24 +79,20 @@ export const VerticalDefault = Template.bind({});
 VerticalDefault.args = {
   orientation: "vertical",
   height: verticalHeight,
-  barHeight: verticalHeight,
   width: verticalWidth,
   borderRadius,
   items,
   getItemColor,
-  getItemEndLabel,
 };
 
 export const VerticalRounded = Template.bind({});
 VerticalRounded.args = {
   ...VerticalDefault.args,
   borderRadius: verticalWidth / 2,
-  showLabels: false,
 };
 
 export const VerticalSquared = Template.bind({});
 VerticalSquared.args = {
   ...VerticalDefault.args,
   borderRadius: 0,
-  showLabels: true,
 };

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -14,10 +14,7 @@ export type LegendThresholdProps<T> =
  * `LegendThreshold` represents a scale with thresholds that separate
  * a set of levels. By default, the labels between each level are shown.
  */
-const LegendThreshold = <T,>(
-  props: LegendThresholdProps<T> &
-    Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdHorizontalProps<T>>
-) => {
+const LegendThreshold = <T,>(props: LegendThresholdProps<T>) => {
   return props.orientation === "horizontal" ? (
     <LegendThresholdHorizontal {...props} />
   ) : (

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -1,67 +1,24 @@
 import React from "react";
-import LegendThresholdHorizontal from "./LegendThresholdHorizontal";
-import LegendThresholdVertical from "./LegendThresholdVertical";
+import LegendThresholdHorizontal, {
+  LegendThresholdHorizontalProps,
+} from "./LegendThresholdHorizontal";
+import LegendThresholdVertical, {
+  LegendThresholdVerticalProps,
+} from "./LegendThresholdVertical";
 
-export interface LegendThresholdProps<T> {
-  /** Orientation of the bars */
-  orientation?: "horizontal" | "vertical";
-  /** Height of the component, including the colored bars and labels. */
-  height?: number;
-  /**
-   * Height of the colored bars. When not adding the bars, make sure that
-   * `barHeight` is set to the same value as `height`.
-   */
-  barHeight?: number;
-  /** Width of the component */
-  width?: number;
-  /** Border radius of the colored bars */
-  borderRadius?: number;
-  /** List of items representing the labels */
-  items: T[];
-  /** Function that returns the color of each level */
-  getItemColor: (item: T, itemIndex: number) => string;
-  /**
-   * Note that only the labels between two levels are rendered. The last
-   * end label won't be shown.
-   */
-  getItemEndLabel: (item: T, itemIndex: number) => string;
-  /**
-   * Whether to show the labels or not (true by default). Make sure to set
-   * `barHeight` to `height` when not including the labels.
-   */
-  showLabels?: boolean;
-}
+export type LegendThresholdProps<T> =
+  | LegendThresholdHorizontalProps<T>
+  | LegendThresholdVerticalProps<T>;
 
 /**
  * `LegendThreshold` represents a scale with thresholds that separate
  * a set of levels. By default, the labels between each level are shown.
  */
-const LegendThreshold = <T,>({
-  orientation = "horizontal",
-  height,
-  barHeight,
-  width,
-  borderRadius = 4,
-  items,
-  getItemColor,
-  getItemEndLabel,
-  showLabels = true,
-  ...otherSvgProps
-}: LegendThresholdProps<T> &
-  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
-  const props = {
-    orientation,
-    height,
-    barHeight,
-    width,
-    borderRadius,
-    items,
-    getItemColor,
-    getItemEndLabel,
-    showLabels,
-    ...otherSvgProps,
-  };
-  return orientation === "horizontal" ? (
+const LegendThreshold = <T,>(
+  props: LegendThresholdProps<T> &
+    Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdHorizontalProps<T>>
+) => {
+  return props.orientation === "horizontal" ? (
     <LegendThresholdHorizontal {...props} />
   ) : (
     <LegendThresholdVertical {...props} />

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Group } from "@visx/group";
-import { scaleBand } from "@visx/scale";
-import uniqueId from "lodash/uniqueId";
-import { TickLabel, TickMark } from "./LegendThreshold.style";
+import LegendThresholdHorizontal from "./LegendThresholdHorizontal";
+import LegendThresholdVertical from "./LegendThresholdVertical";
 
 export interface LegendThresholdProps<T> {
+  /** Orientation of the bars */
+  orientation?: "horizontal" | "vertical";
   /** Height of the component, including the colored bars and labels. */
   height?: number;
   /**
@@ -37,9 +37,10 @@ export interface LegendThresholdProps<T> {
  * a set of levels. By default, the labels between each level are shown.
  */
 const LegendThreshold = <T,>({
-  height = 40,
-  barHeight = 30,
-  width = 80,
+  orientation = "horizontal",
+  height,
+  barHeight,
+  width,
   borderRadius = 4,
   items,
   getItemColor,
@@ -48,53 +49,22 @@ const LegendThreshold = <T,>({
   ...otherSvgProps
 }: LegendThresholdProps<T> &
   Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
-  const indexList = items.map((item, itemIndex) => itemIndex);
-  const scaleRect = scaleBand({ domain: indexList, range: [0, width] });
-  const rectWidth = scaleRect.bandwidth();
-
-  const clipPathId = uniqueId(`bars-clip-path-`);
-
-  const labelTickHeight = 4;
-  const tickLabelPadding = 2;
-
-  return (
-    <svg width={width} height={height} {...otherSvgProps}>
-      <defs>
-        <clipPath id={clipPathId}>
-          <rect
-            y={0}
-            width={width}
-            height={showLabels ? barHeight : height}
-            rx={borderRadius}
-            ry={borderRadius}
-          />
-        </clipPath>
-      </defs>
-      <Group>
-        {items.map((item, itemIndex) => {
-          const x = scaleRect(itemIndex) ?? 0;
-          return (
-            <Group key={`item-${itemIndex}`}>
-              <rect
-                x={x}
-                height={barHeight}
-                width={rectWidth}
-                fill={getItemColor(item, itemIndex)}
-                clipPath={`url(#${clipPathId})`}
-              />
-              {showLabels && itemIndex !== items.length - 1 && (
-                <Group top={barHeight} left={x + rectWidth}>
-                  <TickMark y1={0} y2={labelTickHeight} />
-                  <TickLabel y={labelTickHeight + tickLabelPadding}>
-                    {getItemEndLabel(item, itemIndex)}
-                  </TickLabel>
-                </Group>
-              )}
-            </Group>
-          );
-        })}
-      </Group>
-    </svg>
+  const props = {
+    orientation,
+    height,
+    barHeight,
+    width,
+    borderRadius,
+    items,
+    getItemColor,
+    getItemEndLabel,
+    showLabels,
+    ...otherSvgProps,
+  };
+  return orientation === "horizontal" ? (
+    <LegendThresholdHorizontal {...props} />
+  ) : (
+    <LegendThresholdVertical {...props} />
   );
 };
 

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -13,11 +13,6 @@ export interface LegendThresholdHorizontalProps<T>
    */
   barHeight?: number;
   /**
-   * Whether to show the labels or not (true by default). Make sure to set
-   * `barHeight` to `height` when not including the labels.
-   */
-  showLabels?: boolean;
-  /**
    * Note that only the labels between two levels are rendered. The last
    * end label won't be shown.
    */
@@ -36,7 +31,7 @@ const LegendThresholdHorizontal = <T,>({
   items,
   getItemColor,
   getItemEndLabel,
-  showLabels,
+  showLabels = true,
   ...otherSvgProps
 }: LegendThresholdHorizontalProps<T> &
   Omit<

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { Group } from "@visx/group";
+import { scaleBand } from "@visx/scale";
+import uniqueId from "lodash/uniqueId";
+import { TickLabel, TickMark } from "./LegendThreshold.style";
+import { LegendThresholdProps } from ".";
+
+/**
+ * `LegendThreshold` represents a scale with thresholds that separate
+ * a set of levels. By default, the labels between each level are shown.
+ */
+const LegendThresholdHorizontal = <T,>({
+  height = 40,
+  barHeight = 30,
+  width = 80,
+  borderRadius,
+  items,
+  getItemColor,
+  getItemEndLabel,
+  showLabels,
+  ...otherSvgProps
+}: LegendThresholdProps<T> &
+  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
+  const indexList = items.map((item, itemIndex) => itemIndex);
+  const scaleRect = scaleBand({ domain: indexList, range: [0, width] });
+  const rectWidth = scaleRect.bandwidth();
+
+  const clipPathId = uniqueId(`bars-clip-path-`);
+
+  const labelTickHeight = 4;
+  const tickLabelPadding = 2;
+
+  return (
+    <svg width={width} height={height} {...otherSvgProps}>
+      <defs>
+        <clipPath id={clipPathId}>
+          <rect
+            y={0}
+            width={width}
+            height={showLabels ? barHeight : height}
+            rx={borderRadius}
+            ry={borderRadius}
+          />
+        </clipPath>
+      </defs>
+      <Group>
+        {items.map((item, itemIndex) => {
+          const x = scaleRect(itemIndex) ?? 0;
+          return (
+            <Group key={`item-${itemIndex}`}>
+              <rect
+                x={x}
+                height={barHeight}
+                width={rectWidth}
+                fill={getItemColor(item, itemIndex)}
+                clipPath={`url(#${clipPathId})`}
+              />
+              {showLabels && itemIndex !== items.length - 1 && (
+                <Group top={barHeight} left={x + rectWidth}>
+                  <TickMark y1={0} y2={labelTickHeight} />
+                  <TickLabel y={labelTickHeight + tickLabelPadding}>
+                    {getItemEndLabel(item, itemIndex)}
+                  </TickLabel>
+                </Group>
+              )}
+            </Group>
+          );
+        })}
+      </Group>
+    </svg>
+  );
+};
+
+export default LegendThresholdHorizontal;

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -3,7 +3,7 @@ import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
 import uniqueId from "lodash/uniqueId";
 import { TickLabel, TickMark } from "./LegendThreshold.style";
-import { CommonLegendThresholdProps } from ".";
+import { CommonLegendThresholdProps } from "./interfaces";
 
 export interface LegendThresholdHorizontalProps<T>
   extends CommonLegendThresholdProps<T> {

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -3,10 +3,29 @@ import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
 import uniqueId from "lodash/uniqueId";
 import { TickLabel, TickMark } from "./LegendThreshold.style";
-import { LegendThresholdProps } from ".";
+import { CommonLegendThresholdProps } from ".";
+
+export interface LegendThresholdHorizontalProps<T>
+  extends CommonLegendThresholdProps<T> {
+  /**
+   * Height of the colored bars. When not adding the bars, make sure that
+   * `barHeight` is set to the same value as `height`.
+   */
+  barHeight?: number;
+  /**
+   * Whether to show the labels or not (true by default). Make sure to set
+   * `barHeight` to `height` when not including the labels.
+   */
+  showLabels?: boolean;
+  /**
+   * Note that only the labels between two levels are rendered. The last
+   * end label won't be shown.
+   */
+  getItemEndLabel?: (item: T, itemIndex: number) => string;
+}
 
 /**
- * `LegendThreshold` represents a scale with thresholds that separate
+ * `LegendThresholdHorizontal` represents a scale with thresholds that separate
  * a set of levels. By default, the labels between each level are shown.
  */
 const LegendThresholdHorizontal = <T,>({
@@ -19,8 +38,11 @@ const LegendThresholdHorizontal = <T,>({
   getItemEndLabel,
   showLabels,
   ...otherSvgProps
-}: LegendThresholdProps<T> &
-  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
+}: LegendThresholdHorizontalProps<T> &
+  Omit<
+    React.SVGProps<SVGSVGElement>,
+    keyof LegendThresholdHorizontalProps<T>
+  >) => {
   const indexList = items.map((item, itemIndex) => itemIndex);
   const scaleRect = scaleBand({ domain: indexList, range: [0, width] });
   const rectWidth = scaleRect.bandwidth();
@@ -60,7 +82,7 @@ const LegendThresholdHorizontal = <T,>({
                 <Group top={barHeight} left={x + rectWidth}>
                   <TickMark y1={0} y2={labelTickHeight} />
                   <TickLabel y={labelTickHeight + tickLabelPadding}>
-                    {getItemEndLabel(item, itemIndex)}
+                    {getItemEndLabel && getItemEndLabel(item, itemIndex)}
                   </TickLabel>
                 </Group>
               )}

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -11,8 +11,8 @@ import { LegendThresholdProps } from ".";
  */
 const LegendThresholdHorizontal = <T,>({
   height = 40,
-  barHeight = 30,
-  width = 80,
+  barHeight = 20,
+  width = 300,
   borderRadius,
   items,
   getItemColor,
@@ -35,6 +35,7 @@ const LegendThresholdHorizontal = <T,>({
       <defs>
         <clipPath id={clipPathId}>
           <rect
+            x={0}
             y={0}
             width={width}
             height={showLabels ? barHeight : height}

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -7,6 +7,8 @@ import { CommonLegendThresholdProps } from "./interfaces";
 
 export interface LegendThresholdHorizontalProps<T>
   extends CommonLegendThresholdProps<T> {
+  /** Orientation of the bars */
+  orientation: "horizontal";
   /**
    * Height of the colored bars. When not adding the bars, make sure that
    * `barHeight` is set to the same value as `height`.

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -2,10 +2,12 @@ import React from "react";
 import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
 import uniqueId from "lodash/uniqueId";
-import { LegendThresholdProps } from ".";
+import { CommonLegendThresholdProps } from ".";
+
+export type LegendThresholdVerticalProps<T> = CommonLegendThresholdProps<T>;
 
 /**
- * `LegendThreshold` represents a scale with thresholds that separate
+ * `LegendThresholdVertical` represents a scale with thresholds that separate
  * a set of levels. By default, the labels between each level are shown.
  */
 const LegendThresholdVertical = <T,>({
@@ -14,13 +16,12 @@ const LegendThresholdVertical = <T,>({
   borderRadius,
   items,
   getItemColor,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getItemEndLabel,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  showLabels = true,
   ...otherSvgProps
-}: LegendThresholdProps<T> &
-  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
+}: LegendThresholdVerticalProps<T> &
+  Omit<
+    React.SVGProps<SVGSVGElement>,
+    keyof LegendThresholdVerticalProps<T>
+  >) => {
   const indexList = items.map((item, itemIndex) => itemIndex);
   const scaleRect = scaleBand({ domain: indexList, range: [0, height] });
   const barHeight = scaleRect.bandwidth();

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -7,11 +7,6 @@ import { CommonLegendThresholdProps } from "./interfaces";
 export interface LegendThresholdVerticalProps<T>
   extends CommonLegendThresholdProps<T> {
   /**
-   * Whether to show the labels or not (true by default). Make sure to set
-   * `barHeight` to `height` when not including the labels.
-   */
-  showLabels?: boolean;
-  /**
    * Note that only the labels between two levels are rendered. The last
    * end label won't be shown.
    */

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Group } from "@visx/group";
+import { scaleBand } from "@visx/scale";
+import uniqueId from "lodash/uniqueId";
+import { LegendThresholdProps } from ".";
+
+/**
+ * `LegendThreshold` represents a scale with thresholds that separate
+ * a set of levels. By default, the labels between each level are shown.
+ */
+const LegendThresholdVertical = <T,>({
+  height = 100,
+  width = 14.4,
+  borderRadius = 4,
+  items,
+  getItemColor,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getItemEndLabel,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  showLabels = true,
+  ...otherSvgProps
+}: LegendThresholdProps<T> &
+  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
+  const indexList = items.map((item, itemIndex) => itemIndex);
+  const scaleRect = scaleBand({ domain: indexList, range: [0, height] });
+  const rectHeight = scaleRect.bandwidth();
+
+  const clipPathId = uniqueId(`bars-clip-path-`);
+
+  return (
+    <svg width={width} height={height} {...otherSvgProps}>
+      <defs>
+        <clipPath id={clipPathId}>
+          <rect
+            x={0}
+            y={0}
+            width={width}
+            height={height}
+            rx={borderRadius}
+            ry={borderRadius}
+          />
+        </clipPath>
+      </defs>
+      <Group>
+        {items.map((item, itemIndex) => {
+          const y = scaleRect(itemIndex) ?? 0;
+          return (
+            <Group key={`item-${itemIndex}`}>
+              <rect
+                x={0}
+                y={y}
+                height={rectHeight}
+                width={width}
+                fill={getItemColor(item, itemIndex)}
+                clipPath={`url(#${clipPathId})`}
+              />
+            </Group>
+          );
+        })}
+      </Group>
+    </svg>
+  );
+};
+
+export default LegendThresholdVertical;

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -4,7 +4,19 @@ import { scaleBand } from "@visx/scale";
 import uniqueId from "lodash/uniqueId";
 import { CommonLegendThresholdProps } from "./interfaces";
 
-export type LegendThresholdVerticalProps<T> = CommonLegendThresholdProps<T>;
+export interface LegendThresholdVerticalProps<T>
+  extends CommonLegendThresholdProps<T> {
+  /**
+   * Whether to show the labels or not (true by default). Make sure to set
+   * `barHeight` to `height` when not including the labels.
+   */
+  showLabels?: boolean;
+  /**
+   * Note that only the labels between two levels are rendered. The last
+   * end label won't be shown.
+   */
+  getItemEndLabel?: (item: T, itemIndex: number) => string;
+}
 
 /**
  * `LegendThresholdVertical` represents a scale with thresholds that separate

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
 import uniqueId from "lodash/uniqueId";
-import { CommonLegendThresholdProps } from ".";
+import { CommonLegendThresholdProps } from "./interfaces";
 
 export type LegendThresholdVerticalProps<T> = CommonLegendThresholdProps<T>;
 

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -9,9 +9,9 @@ import { LegendThresholdProps } from ".";
  * a set of levels. By default, the labels between each level are shown.
  */
 const LegendThresholdVertical = <T,>({
-  height = 100,
-  width = 14.4,
-  borderRadius = 4,
+  height = 300,
+  width = 20,
+  borderRadius,
   items,
   getItemColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -23,7 +23,7 @@ const LegendThresholdVertical = <T,>({
   Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
   const indexList = items.map((item, itemIndex) => itemIndex);
   const scaleRect = scaleBand({ domain: indexList, range: [0, height] });
-  const rectHeight = scaleRect.bandwidth();
+  const barHeight = scaleRect.bandwidth();
 
   const clipPathId = uniqueId(`bars-clip-path-`);
 
@@ -49,7 +49,7 @@ const LegendThresholdVertical = <T,>({
               <rect
                 x={0}
                 y={y}
-                height={rectHeight}
+                height={barHeight}
                 width={width}
                 fill={getItemColor(item, itemIndex)}
                 clipPath={`url(#${clipPathId})`}

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -6,11 +6,10 @@ import { CommonLegendThresholdProps } from "./interfaces";
 
 export interface LegendThresholdVerticalProps<T>
   extends CommonLegendThresholdProps<T> {
-  /**
-   * Note that only the labels between two levels are rendered. The last
-   * end label won't be shown.
-   */
-  getItemEndLabel?: (item: T, itemIndex: number) => string;
+  /** Orientation of the bars */
+  orientation: "vertical";
+  getItemLabel?: (item: T, itemIndex: number) => string;
+  getItemSublabel?: (item: T, itemIndex: number) => string;
 }
 
 /**
@@ -24,11 +23,7 @@ const LegendThresholdVertical = <T,>({
   items,
   getItemColor,
   ...otherSvgProps
-}: LegendThresholdVerticalProps<T> &
-  Omit<
-    React.SVGProps<SVGSVGElement>,
-    keyof LegendThresholdVerticalProps<T>
-  >) => {
+}: LegendThresholdVerticalProps<T>) => {
   const indexList = items.map((item, itemIndex) => itemIndex);
   const scaleRect = scaleBand({ domain: indexList, range: [0, height] });
   const barHeight = scaleRect.bandwidth();

--- a/packages/ui-components/src/components/LegendThreshold/index.ts
+++ b/packages/ui-components/src/components/LegendThreshold/index.ts
@@ -1,4 +1,4 @@
 import LegendThreshold from "./LegendThreshold";
 
-export type { CommonLegendThresholdProps } from "./interfaces";
+export type { LegendThresholdProps } from "./LegendThreshold";
 export default LegendThreshold;

--- a/packages/ui-components/src/components/LegendThreshold/index.ts
+++ b/packages/ui-components/src/components/LegendThreshold/index.ts
@@ -1,4 +1,4 @@
 import LegendThreshold from "./LegendThreshold";
 
-export type { LegendThresholdProps } from "./LegendThreshold";
+export type { CommonLegendThresholdProps } from "./interfaces";
 export default LegendThreshold;

--- a/packages/ui-components/src/components/LegendThreshold/index.ts
+++ b/packages/ui-components/src/components/LegendThreshold/index.ts
@@ -1,4 +1,4 @@
-import LegendThreshold, { LegendThresholdProps } from "./LegendThreshold";
+import LegendThreshold from "./LegendThreshold";
 
-export type { LegendThresholdProps };
+export type { LegendThresholdProps } from "./LegendThreshold";
 export default LegendThreshold;

--- a/packages/ui-components/src/components/LegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/LegendThreshold/interfaces.ts
@@ -1,0 +1,14 @@
+export interface CommonLegendThresholdProps<T> {
+  /** Orientation of the bars */
+  orientation?: "horizontal" | "vertical";
+  /** Height of the component, including the colored bars and labels. */
+  height?: number;
+  /** Width of the component */
+  width?: number;
+  /** Border radius of the colored bars */
+  borderRadius?: number;
+  /** List of items representing the labels */
+  items: T[];
+  /** Function that returns the color of each level */
+  getItemColor: (item: T, itemIndex: number) => string;
+}

--- a/packages/ui-components/src/components/LegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/LegendThreshold/interfaces.ts
@@ -1,6 +1,4 @@
 export interface CommonLegendThresholdProps<T> {
-  /** Orientation of the bars */
-  orientation?: "horizontal" | "vertical";
   /** Height of the component, including the colored bars and labels. */
   height?: number;
   /** Width of the component */

--- a/packages/ui-components/src/components/LegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/LegendThreshold/interfaces.ts
@@ -11,4 +11,9 @@ export interface CommonLegendThresholdProps<T> {
   items: T[];
   /** Function that returns the color of each level */
   getItemColor: (item: T, itemIndex: number) => string;
+  /**
+   * Whether to show the labels or not (true by default). Make sure to set
+   * `barHeight` to `height` when not including the labels.
+   */
+  showLabels?: boolean;
 }

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -4,7 +4,7 @@ import { Theme } from "@mui/material/styles";
 export * from "./styles"; // styled, theme
 
 /** UI Components and props */
-export { default as LegendThreshold } from "./components/LegendThreshold";
+export { default as LegendThresholdHorizontal } from "./components/LegendThreshold";
 export type { LegendThresholdProps } from "./components/LegendThreshold";
 export { default as LegendCategorical } from "./components/LegendCategorical";
 export type { LegendCategoricalProps } from "./components/LegendCategorical";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -4,7 +4,7 @@ import { Theme } from "@mui/material/styles";
 export * from "./styles"; // styled, theme
 
 /** UI Components and props */
-export { default as LegendThresholdHorizontal } from "./components/LegendThreshold";
+export { default as LegendThreshold } from "./components/LegendThreshold";
 export type { LegendThresholdProps } from "./components/LegendThreshold";
 export { default as LegendCategorical } from "./components/LegendCategorical";
 export type { LegendCategoricalProps } from "./components/LegendCategorical";

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -16,6 +16,11 @@
     "@actnowcoalition/time-utils" "^1.0.1"
     lodash "^4.17.21"
 
+"@actnowcoalition/number-format@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/number-format/-/number-format-1.1.1.tgz#e69680ea88bac2cbfaab4b1a3e4a5ae4a7c90f28"
+  integrity sha512-lwqiDceGOXKZDzOa9cZKzFggxu/ZakocxBDzxBKt/DJT+yGBJXuujRbFD9iEz8753p32FCUWKtgQXvpmN1wjSA==
+
 "@actnowcoalition/regions@^1.1.6":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@actnowcoalition/regions/-/regions-1.1.6.tgz#c12ca335cb65afe2ebc08309f0ea012f15a74ea0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@actnowcoalition/metrics@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.0.1.tgz#0ee136ae83451d2a507ffbffd72b74162f4109bd"
+  integrity sha512-ctHPAvwDTt4bt20PurlFCZaCTMokP1gOJgvMzujrrW+PzW00tRLFNeMGWVjGg26gnPqNRQ/kPeW8k+/Alqahgw==
+  dependencies:
+    "@actnowcoalition/assert" "^1.0.0"
+    "@actnowcoalition/time-utils" "^1.0.1"
+    lodash "^4.17.21"
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -3092,12 +3101,29 @@
   dependencies:
     "@types/d3-color" "^1"
 
+"@types/d3-path@^1", "@types/d3-path@^1.0.8":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
+  integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
+
+"@types/d3-random@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-2.2.1.tgz#551edbb71cb317dea2cf9c76ebe059d311eefacb"
+  integrity sha512-5vvxn6//poNeOxt1ZwC7QU//dG9QqABjy1T7fP/xmFHY95GnaOw3yABf29hiu5SR1Oo34XcpyHFbzod+vemQjA==
+
 "@types/d3-scale@^3.3.0":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-3.3.2.tgz#18c94e90f4f1c6b1ee14a70f14bfca2bd1c61d06"
   integrity sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==
   dependencies:
     "@types/d3-time" "^2"
+
+"@types/d3-shape@^1.3.1":
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-1.3.8.tgz#c3c15ec7436b4ce24e38de517586850f1fea8e89"
+  integrity sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==
+  dependencies:
+    "@types/d3-path" "^1"
 
 "@types/d3-time@^2", "@types/d3-time@^2.0.0":
   version "2.1.1"
@@ -3222,7 +3248,7 @@
     "@types/fined" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.167", "@types/lodash@^4.14.182":
+"@types/lodash@^4.14.167", "@types/lodash@^4.14.172", "@types/lodash@^4.14.182":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
@@ -3511,7 +3537,15 @@
     "@typescript-eslint/types" "5.23.0"
     eslint-visitor-keys "^3.0.0"
 
-"@visx/group@^2.10.0":
+"@visx/curve@2.1.0", "@visx/curve@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@visx/curve/-/curve-2.1.0.tgz#f614bfe3db66df7db7382db7a75ced1506b94602"
+  integrity sha512-9b6JOnx91gmOQiSPhUOxdsvcnW88fgqfTPKoVgQxidMsD/I3wksixtwo8TR/vtEz2aHzzsEEhlv1qK7Y3yaSDw==
+  dependencies:
+    "@types/d3-shape" "^1.3.1"
+    d3-shape "^1.0.6"
+
+"@visx/group@2.10.0", "@visx/group@^2.10.0":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@visx/group/-/group-2.10.0.tgz#95839851832545621eb0d091866a61dafe552ae1"
   integrity sha512-DNJDX71f65Et1+UgQvYlZbE66owYUAfcxTkC96Db6TnxV221VKI3T5l23UWbnMzwFBP9dR3PWUjjqhhF12N5pA==
@@ -3520,7 +3554,15 @@
     classnames "^2.3.1"
     prop-types "^15.6.2"
 
-"@visx/scale@^2.2.2":
+"@visx/mock-data@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@visx/mock-data/-/mock-data-2.1.2.tgz#e3e2130d5617694a34e62dcfa7ede3275db72ccd"
+  integrity sha512-6xUVP56tiPwVi3BxvoXPQzDYWG6iX2nnOlsHEYsHgK8gHq1r7AhjQtdbQUX7QF0QkmkJM0cW8TBjZ2e+dItB8Q==
+  dependencies:
+    "@types/d3-random" "^2.2.0"
+    d3-random "^2.2.2"
+
+"@visx/scale@2.2.2", "@visx/scale@^2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@visx/scale/-/scale-2.2.2.tgz#b8eafabdcf92bb45ab196058fe184772ad80fd25"
   integrity sha512-3aDySGUTpe6VykDQmF+g2nz5paFu9iSPTcCOEgkcru0/v5tmGzUdvivy8CkYbr87HN73V/Jc53lGm+kJUQcLBw==
@@ -3531,6 +3573,24 @@
     d3-interpolate "^1.4.0"
     d3-scale "^3.3.0"
     d3-time "^2.1.1"
+
+"@visx/shape@^2.12.2":
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@visx/shape/-/shape-2.12.2.tgz#81ed88bf823aa84a4f5f32a9c9daf8371a606897"
+  integrity sha512-4gN0fyHWYXiJ+Ck8VAazXX0i8TOnLJvOc5jZBnaJDVxgnSIfCjJn0+Nsy96l9Dy/bCMTh4DBYUBv9k+YICBUOA==
+  dependencies:
+    "@types/d3-path" "^1.0.8"
+    "@types/d3-shape" "^1.3.1"
+    "@types/lodash" "^4.14.172"
+    "@types/react" "*"
+    "@visx/curve" "2.1.0"
+    "@visx/group" "2.10.0"
+    "@visx/scale" "2.2.2"
+    classnames "^2.3.1"
+    d3-path "^1.0.5"
+    d3-shape "^1.2.0"
+    lodash "^4.17.21"
+    prop-types "^15.5.10"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -5594,6 +5654,16 @@ d3-interpolate@^1.4.0:
   dependencies:
     d3-color "1"
 
+d3-path@1, d3-path@^1.0.5:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+d3-random@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-2.2.2.tgz#5eebd209ef4e45a2b362b019c1fb21c2c98cbb6e"
+  integrity sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==
+
 d3-scale@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.3.0.tgz#28c600b29f47e5b9cd2df9749c206727966203f3"
@@ -5604,6 +5674,13 @@ d3-scale@^3.3.0:
     d3-interpolate "1.2.0 - 2"
     d3-time "^2.1.1"
     d3-time-format "2 - 3"
+
+d3-shape@^1.0.6, d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
 
 "d3-time-format@2 - 3":
   version "3.0.0"
@@ -10835,7 +10912,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==


### PR DESCRIPTION
This PR adds legend threshold vertical to Act Now Packages.

**Note:** Labels are not implemented in this PR, as per note [here](https://www.dropbox.com/scl/fi/j8laxj6xeyoz12ambmldf/Act-Now-as-a-Platform-Eng.-Vision-and-Q3-Roadmap.paper?dl=0&rlkey=s0mf7m662swlj4zo8dlesd6o3#:h2=LegendThreshold-(vertical)).

close #60 