### PR TITLE
ui-components: attempt to fix markdown bug

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/ui-components",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "UI components for Act Now",
   "repository": {
     "type": "git",

--- a/packages/ui-components/src/components/Markdown/Markdown.style.ts
+++ b/packages/ui-components/src/components/Markdown/Markdown.style.ts
@@ -1,4 +1,6 @@
+import { lazy } from "react";
 import { styled } from "../../styles";
-import ReactMarkdown from "react-markdown";
+
+const ReactMarkdown = lazy(() => import("react-markdown"));
 
 export const MarkdownBody = styled(ReactMarkdown)``;

--- a/packages/ui-components/src/components/Markdown/Markdown.tsx
+++ b/packages/ui-components/src/components/Markdown/Markdown.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { MarkdownBody } from "./Markdown.style";
 import remarkGfm from "remark-gfm";
 import { ReactMarkdownOptions } from "react-markdown/lib/react-markdown";
+import { MarkdownBody } from "./Markdown.style";
 
 const Markdown: React.FC<ReactMarkdownOptions> = ({
   children,

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -11,7 +11,7 @@ export type { LegendCategoricalProps } from "./components/LegendCategorical";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
-export { default as Markdown } from "./components/Markdown";
+// export { default as Markdown } from "./components/Markdown";
 
 /**
  * Material UI Theme extensions

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -11,7 +11,7 @@ export type { LegendCategoricalProps } from "./components/LegendCategorical";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
-// export { default as Markdown } from "./components/Markdown";
+export { default as Markdown } from "./components/Markdown";
 
 /**
  * Material UI Theme extensions


### PR DESCRIPTION
the markdown component seems to be broken (something having to do with next). error:

![Screen Shot 2022-08-10 at 11 54 56 AM](https://user-images.githubusercontent.com/44076375/183961457-5d7fb255-09b1-4bfb-b3f4-0f620c1f2c67.png)

fix attempt: import ReactMarkdown dynamically 