### PR TITLE
ui-components: remove markdown from index.ts temporarily

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/ui-components",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "UI components for Act Now",
   "repository": {
     "type": "git",

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -11,7 +11,7 @@ export type { LegendCategoricalProps } from "./components/LegendCategorical";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
-export { default as Markdown } from "./components/Markdown";
+// export { default as Markdown } from "./components/Markdown";
 
 /**
  * Material UI Theme extensions

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -11,6 +11,8 @@ export type { LegendCategoricalProps } from "./components/LegendCategorical";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
+
+// Note (8/10/22) - Markdown is causing a bug. Commenting it out until fixed.
 // export { default as Markdown } from "./components/Markdown";
 
 /**


### PR DESCRIPTION
[this markdown bug fix attempt](https://github.com/covid-projections/act-now-packages/pull/47) did not work, so we're commenting markdown out for now