### PR TITLE
Implements LineChart

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -35,10 +35,12 @@
     "@storybook/manager-webpack4": "^6.5.10",
     "@storybook/react": "^6.5.10",
     "@storybook/testing-library": "^0.0.13",
+    "@visx/mock-data": "^2.1.2",
     "babel-loader": "^8.2.5",
     "typescript": "^4.6.4"
   },
   "dependencies": {
+    "@actnowcoalition/metrics": "^0.0.1",
     "@actnowcoalition/regions": "^1.1.6",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
@@ -46,6 +48,7 @@
     "@mui/material": "^5.9.1",
     "@visx/group": "^2.10.0",
     "@visx/scale": "^2.2.2",
+    "@visx/shape": "^2.12.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.3",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -46,6 +46,7 @@
     "@emotion/styled": "^11.9.3",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.1",
+    "@visx/curve": "^2.1.0",
     "@visx/group": "^2.10.0",
     "@visx/scale": "^2.2.2",
     "@visx/shape": "^2.12.2",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -26,6 +26,7 @@
     "build-storybook": "build-storybook"
   },
   "devDependencies": {
+    "@actnowcoalition/assert": "^1.0.1",
     "@babel/core": "^7.18.9",
     "@storybook/addon-actions": "^6.5.10",
     "@storybook/addon-essentials": "^6.5.10",

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import LineChart from ".";
-import { assert } from "@actnowcoalition/assert";
-import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { appleStock } from "@visx/mock-data";
+import { assert } from "@actnowcoalition/assert";
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+import LineChart from ".";
 
 export default {
   title: "Charts/LineChart",

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import LineChart from ".";
+import { assert } from "@actnowcoalition/assert";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { appleStock } from "@visx/mock-data";
@@ -10,9 +11,8 @@ export default {
   component: LineChart,
 } as ComponentMeta<typeof LineChart>;
 
-const width = 300;
-const height = 100;
-const padding = 4;
+const [width, height] = [600, 400];
+const padding = 20;
 
 const Template: ComponentStory<typeof LineChart> = (args) => (
   <svg width={width} height={height} style={{ border: "solid 1px #eee" }}>
@@ -26,30 +26,30 @@ interface AppleStockPoint {
 }
 
 const formatPoint = (p: AppleStockPoint): TimeseriesPoint<number> => ({
-  date: new Date(`${p.date.substring(0, 10)}T00:00:00Z`),
+  date: new Date(p.date.substring(0, 10)),
   value: p.close,
 });
 
 const timeseries = new Timeseries(appleStock.map(formatPoint));
+assert(timeseries.hasData(), `Timeseries cannot be empty`);
 
-const startDate = timeseries.hasData()
-  ? timeseries.minDate
-  : new Date("2007-04-24");
-const endDate = timeseries.hasData()
-  ? timeseries.maxDate
-  : new Date("2007-04-30");
-
-const minValue = timeseries.hasData() ? timeseries.minValue : 0;
-const maxValue = timeseries.hasData() ? timeseries.maxValue : 10;
+const { minDate, maxDate, minValue, maxValue } = timeseries;
 
 const xScale = scaleTime({
-  domain: [startDate, endDate],
+  domain: [minDate, maxDate],
   range: [padding, width - padding],
 });
+
 const yScale = scaleLinear({
   domain: [minValue, maxValue],
   range: [height - 2 * padding, padding],
 });
 
-export const Example = Template.bind({});
-Example.args = { timeseries, xScale, yScale, stroke: "blue" };
+export const SolidLine = Template.bind({});
+SolidLine.args = {
+  timeseries,
+  xScale,
+  yScale,
+  stroke: "#2a9d8f",
+  strokeWidth: 2,
+};

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -20,17 +20,16 @@ const Template: ComponentStory<typeof LineChart> = (args) => (
   </svg>
 );
 
-interface AppleStockPoint {
-  date: string;
-  close: number;
-}
+// We format the points from appleStock to match TimeseriesPoint<number>
+// so we can use them to initialize Timeseries.
+const points = appleStock.map(
+  (p: { date: string; close: number }): TimeseriesPoint<number> => ({
+    date: new Date(p.date.substring(0, 10)),
+    value: p.close,
+  })
+);
 
-const formatPoint = (p: AppleStockPoint): TimeseriesPoint<number> => ({
-  date: new Date(p.date.substring(0, 10)),
-  value: p.close,
-});
-
-const timeseries = new Timeseries(appleStock.map(formatPoint));
+const timeseries = new Timeseries(points);
 assert(timeseries.hasData(), `Timeseries cannot be empty`);
 
 const { minDate, maxDate, minValue, maxValue } = timeseries;
@@ -51,5 +50,13 @@ SolidLine.args = {
   xScale,
   yScale,
   stroke: "#2a9d8f",
-  strokeWidth: 2,
+};
+
+export const DottedLine = Template.bind({});
+DottedLine.args = {
+  timeseries,
+  xScale,
+  yScale,
+  strokeWidth: 1,
+  strokeDasharray: "2 2",
 };

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import LineChart from ".";
-import { Timeseries } from "@actnowcoalition/metrics";
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { appleStock } from "@visx/mock-data";
-import { TimeseriesPoint } from "packages/metrics/dist";
-import { AppleStock } from "@visx/mock-data/lib/mocks/appleStock";
 
 export default {
   title: "Charts/LineChart",
@@ -22,7 +20,12 @@ const Template: ComponentStory<typeof LineChart> = (args) => (
   </svg>
 );
 
-const formatPoint = (p: AppleStock): TimeseriesPoint<number> => ({
+interface AppleStockPoint {
+  date: string;
+  close: number;
+}
+
+const formatPoint = (p: AppleStockPoint): TimeseriesPoint<number> => ({
   date: new Date(`${p.date.substring(0, 10)}T00:00:00Z`),
   value: p.close,
 });

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import LineChart from ".";
+import { Timeseries } from "@actnowcoalition/metrics";
+import { scaleLinear, scaleTime } from "@visx/scale";
+import { appleStock } from "@visx/mock-data";
+import { TimeseriesPoint } from "packages/metrics/dist";
+import { AppleStock } from "@visx/mock-data/lib/mocks/appleStock";
+
+export default {
+  title: "Charts/LineChart",
+  component: LineChart,
+} as ComponentMeta<typeof LineChart>;
+
+const width = 300;
+const height = 100;
+const padding = 4;
+
+const Template: ComponentStory<typeof LineChart> = (args) => (
+  <svg width={width} height={height} style={{ border: "solid 1px #eee" }}>
+    <LineChart {...args} />
+  </svg>
+);
+
+const formatPoint = (p: AppleStock): TimeseriesPoint<number> => ({
+  date: new Date(`${p.date.substring(0, 10)}T00:00:00Z`),
+  value: p.close,
+});
+
+const timeseries = new Timeseries(appleStock.map(formatPoint));
+
+const startDate = timeseries.hasData()
+  ? timeseries.minDate
+  : new Date("2007-04-24");
+const endDate = timeseries.hasData()
+  ? timeseries.maxDate
+  : new Date("2007-04-30");
+
+const minValue = timeseries.hasData() ? timeseries.minValue : 0;
+const maxValue = timeseries.hasData() ? timeseries.maxValue : 10;
+
+const xScale = scaleTime({
+  domain: [startDate, endDate],
+  range: [padding, width - padding],
+});
+const yScale = scaleLinear({
+  domain: [minValue, maxValue],
+  range: [height - 2 * padding, padding],
+});
+
+export const Example = Template.bind({});
+Example.args = { timeseries, xScale, yScale, stroke: "blue" };

--- a/packages/ui-components/src/components/LineChart/LineChart.style.ts
+++ b/packages/ui-components/src/components/LineChart/LineChart.style.ts
@@ -1,3 +1,0 @@
-import { styled } from "../../styles";
-
-export const Container = styled("div")``;

--- a/packages/ui-components/src/components/LineChart/LineChart.style.ts
+++ b/packages/ui-components/src/components/LineChart/LineChart.style.ts
@@ -1,0 +1,3 @@
+import { styled } from "../../styles";
+
+export const Container = styled("div")``;

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -5,8 +5,8 @@ import { ScaleLinear, ScaleTime } from "d3-scale";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
 
-interface LineChartOwnProps {
-  /** {@link Timeseries} used to draw the line chart */
+export interface LineChartOwnProps {
+  /** Timeseries used to draw the line chart */
   timeseries: Timeseries<number>;
 
   /** Scale to transform point dates to positions on the x-axis */
@@ -45,7 +45,7 @@ export type LineChartProps = LineChartOwnProps &
  *      <svg>
  *    );
  *
- * @param timeseries {@link Timeseries} to represent as a line.
+ * @param timeseries Timeseries to represent as a line.
  * @param xScale d3-scale to transform point dates to pixel positions on the x-axis.
  * @param yScale d3-scale to transform point values to pixel positions on the y-axis.
  *

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -4,7 +4,7 @@ import { ScaleLinear, ScaleTime } from "d3-scale";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
 
-interface LineChartProps {
+export interface LineChartProps {
   timeseries: Timeseries<number>;
   xScale: ScaleTime<number, number>;
   yScale: ScaleLinear<number, number>;

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -9,10 +9,10 @@ export interface LineChartOwnProps {
   /** Timeseries used to draw the line chart */
   timeseries: Timeseries<number>;
 
-  /** Scale to transform point dates to positions on the x-axis */
+  /** Scale to transform point dates to pixel positions on the x-axis */
   xScale: ScaleTime<number, number>;
 
-  /** Scale to transform point values to position on the y-axis */
+  /** Scale to transform point values to piel position on the y-axis */
   yScale: ScaleLinear<number, number>;
 }
 
@@ -30,19 +30,19 @@ export type LineChartProps = LineChartOwnProps &
  *
  * @example
  *    const xScale = scaleLinear({ domain: [minDate, maxDate], range: [0, 200] });
- *    const yScale = scaleLInear({ domain: [minVal, maxVal], range: [0, 100] });
+ *    const yScale = scaleLinear({ domain: [minVal, maxVal], range: [0, 100] });
  *
  *    return (
  *      <svg>
  *        <BarChart ... />
  *        <LineChart
  *          timeseries={timeseries}
- *          xScale={}
- *          yScale={}
+ *          xScale={p => xScale(p.date)}
+ *          yScale={p => yScale(p.value)}
  *          stroke="blue"
  *          strokeDasharray="4 4"
  *        />
- *      <svg>
+ *      </svg>
  *    );
  *
  * @param timeseries Timeseries to represent as a line.

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -6,13 +6,13 @@ import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
 
 interface LineChartOwnProps {
-  /** */
+  /** {@link Timeseries} used to draw the line chart */
   timeseries: Timeseries<number>;
 
-  /** */
+  /** Scale to transform point dates to positions on the x-axis */
   xScale: ScaleTime<number, number>;
 
-  /** */
+  /** Scale to transform point values to position on the y-axis */
   yScale: ScaleLinear<number, number>;
 }
 
@@ -21,11 +21,33 @@ export type LineChartProps = LineChartOwnProps &
   LinePathProps<TimeseriesPoint<number>>;
 
 /**
- * LineChart
+ * LineChart is a chart building block that return an SVG path element, given
+ * a timeseries and x and y scales.
  *
- * @param timeseries
- * @param xScale
- * @param yScale
+ * The LineChart is intended to be used as building block of more complex
+ * charts, so it doesn't include axes, tooltips or anything else. See
+ * Storybook for a working example.
+ *
+ * @example
+ *    const xScale = scaleLinear({ domain: [minDate, maxDate], range: [0, 200] });
+ *    const yScale = scaleLInear({ domain: [minVal, maxVal], range: [0, 100] });
+ *
+ *    return (
+ *      <svg>
+ *        <BarChart ... />
+ *        <LineChart
+ *          timeseries={timeseries}
+ *          xScale={}
+ *          yScale={}
+ *          stroke="blue"
+ *          strokeDasharray="4 4"
+ *        />
+ *      <svg>
+ *    );
+ *
+ * @param timeseries {@link Timeseries} to represent as a line.
+ * @param xScale d3-scale to transform point dates to pixel positions on the x-axis.
+ * @param yScale d3-scale to transform point values to pixel positions on the y-axis.
  *
  * @returns SVG Path element
  */
@@ -33,6 +55,10 @@ const LineChart: React.FC<LineChartProps> = ({
   timeseries,
   xScale,
   yScale,
+  stroke = "#000",
+  strokeWidth = 2,
+  shapeRendering = "geometricPrecision",
+  strokeLinejoin = "round",
   ...otherLineProps
 }) => {
   const data = timeseries.removeNils();
@@ -42,8 +68,10 @@ const LineChart: React.FC<LineChartProps> = ({
       x={(d) => xScale(d.date)}
       y={(d) => yScale(d.value)}
       curve={curveMonotoneX}
-      shapeRendering="geometricPrecision"
-      strokeLinejoin="round"
+      shapeRendering={shapeRendering}
+      strokeLinejoin={strokeLinejoin}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
       {...otherLineProps}
     />
   );

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { LinePath } from "@visx/shape";
+import { curveMonotoneX } from "@visx/curve";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
@@ -23,10 +24,13 @@ const LineChart: React.FC<LineChartProps> = ({
   const data = timeseries.removeNils();
   return (
     <LinePath
-      {...otherLineProps}
       data={data.points}
       x={(d) => xScale(d.date)}
       y={(d) => yScale(d.value)}
+      curve={curveMonotoneX}
+      shapeRendering="geometricPrecision"
+      strokeLinejoin="round"
+      {...otherLineProps}
     />
   );
 };

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -4,17 +4,22 @@ import { ScaleLinear, ScaleTime } from "d3-scale";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
 
-export interface LineChartProps {
+interface LineChartOwnProps {
   timeseries: Timeseries<number>;
   xScale: ScaleTime<number, number>;
   yScale: ScaleLinear<number, number>;
 }
 
-const LineChart: React.FC<
-  LineChartProps &
-    React.SVGProps<SVGPathElement> &
-    LinePathProps<TimeseriesPoint<number>>
-> = ({ timeseries, xScale, yScale, ...otherLineProps }) => {
+export type LineChartProps = LineChartOwnProps &
+  React.SVGProps<SVGPathElement> &
+  LinePathProps<TimeseriesPoint<number>>;
+
+const LineChart: React.FC<LineChartProps> = ({
+  timeseries,
+  xScale,
+  yScale,
+  ...otherLineProps
+}) => {
   const data = timeseries.removeNils();
   return (
     <LinePath

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { LinePath } from "@visx/shape";
+import { ScaleLinear, ScaleTime } from "d3-scale";
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
+
+interface LineChartProps {
+  timeseries: Timeseries<number>;
+  xScale: ScaleTime<number, number>;
+  yScale: ScaleLinear<number, number>;
+}
+
+const LineChart: React.FC<
+  LineChartProps &
+    React.SVGProps<SVGPathElement> &
+    LinePathProps<TimeseriesPoint<number>>
+> = ({ timeseries, xScale, yScale, ...otherLineProps }) => {
+  const data = timeseries.removeNils();
+  return (
+    <LinePath
+      {...otherLineProps}
+      data={data.points}
+      x={(d) => xScale(d.date)}
+      y={(d) => yScale(d.value)}
+    />
+  );
+};
+
+export default LineChart;

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -6,8 +6,13 @@ import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
 
 interface LineChartOwnProps {
+  /** */
   timeseries: Timeseries<number>;
+
+  /** */
   xScale: ScaleTime<number, number>;
+
+  /** */
   yScale: ScaleLinear<number, number>;
 }
 
@@ -15,6 +20,15 @@ export type LineChartProps = LineChartOwnProps &
   React.SVGProps<SVGPathElement> &
   LinePathProps<TimeseriesPoint<number>>;
 
+/**
+ * LineChart
+ *
+ * @param timeseries
+ * @param xScale
+ * @param yScale
+ *
+ * @returns SVG Path element
+ */
 const LineChart: React.FC<LineChartProps> = ({
   timeseries,
   xScale,

--- a/packages/ui-components/src/components/LineChart/index.ts
+++ b/packages/ui-components/src/components/LineChart/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LineChart";

--- a/packages/ui-components/src/components/LineChart/index.ts
+++ b/packages/ui-components/src/components/LineChart/index.ts
@@ -1,1 +1,3 @@
 export { default } from "./LineChart";
+import { LineChartProps } from "./LineChart";
+export type { LineChartProps };

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -8,6 +8,7 @@ export { default as LegendThreshold } from "./components/LegendThreshold";
 export type { LegendThresholdProps } from "./components/LegendThreshold";
 export { default as LegendCategorical } from "./components/LegendCategorical";
 export type { LegendCategoricalProps } from "./components/LegendCategorical";
+export { default as LineChart } from "./components/LineChart";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
@@ -55,5 +56,3 @@ declare module "@mui/material/styles" {
     };
   }
 }
-
-export { default as LineChart } from "./components/LineChart";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -55,3 +55,5 @@ declare module "@mui/material/styles" {
     };
   }
 }
+
+export { default as LineChart } from "./components/LineChart";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -9,6 +9,7 @@ export type { LegendThresholdProps } from "./components/LegendThreshold";
 export { default as LegendCategorical } from "./components/LegendCategorical";
 export type { LegendCategoricalProps } from "./components/LegendCategorical";
 export { default as LineChart } from "./components/LineChart";
+export type { LineChartProps } from "./components/LineChart";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -2912,7 +2912,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@visx/curve@2.1.0":
+"@visx/curve@2.1.0", "@visx/curve@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@visx/curve/-/curve-2.1.0.tgz#f614bfe3db66df7db7382db7a75ced1506b94602"
   integrity sha512-9b6JOnx91gmOQiSPhUOxdsvcnW88fgqfTPKoVgQxidMsD/I3wksixtwo8TR/vtEz2aHzzsEEhlv1qK7Y3yaSDw==

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -7,6 +7,15 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-1.0.1.tgz#a4c629a16279085abf7958f4a735a0c3b9aee848"
   integrity sha512-i4k08njxovn3m1jy1mYvCJJv7fLvSpsVwaiocNGB+WC8x44TOxsQuX8iQM62IMKXtu+/5uBIEgn+3QcbT2QLuw==
 
+"@actnowcoalition/metrics@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.0.1.tgz#0ee136ae83451d2a507ffbffd72b74162f4109bd"
+  integrity sha512-ctHPAvwDTt4bt20PurlFCZaCTMokP1gOJgvMzujrrW+PzW00tRLFNeMGWVjGg26gnPqNRQ/kPeW8k+/Alqahgw==
+  dependencies:
+    "@actnowcoalition/assert" "^1.0.0"
+    "@actnowcoalition/time-utils" "^1.0.1"
+    lodash "^4.17.21"
+
 "@actnowcoalition/regions@^1.1.6":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@actnowcoalition/regions/-/regions-1.1.6.tgz#c12ca335cb65afe2ebc08309f0ea012f15a74ea0"
@@ -14,6 +23,15 @@
   dependencies:
     "@actnowcoalition/assert" "^1.0.0"
     lodash "^4.17.21"
+
+"@actnowcoalition/time-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/time-utils/-/time-utils-1.0.1.tgz#4caf60c55764a73ec31be223cefee880568204b9"
+  integrity sha512-IKquf6m4tu4k6GUTWEvw8wL+sVRnyOOztXotEwM2WdCPNlHd4nPX3X1ZdVoOKPqdF7kIeplu1y7sFjhIpnmABA==
+  dependencies:
+    "@actnowcoalition/assert" "^1.0.0"
+    "@types/luxon" "^2.3.2"
+    luxon "^2.4.0"
 
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
@@ -2596,12 +2614,29 @@
   dependencies:
     "@types/d3-color" "^1"
 
+"@types/d3-path@^1", "@types/d3-path@^1.0.8":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
+  integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
+
+"@types/d3-random@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-random/-/d3-random-2.2.1.tgz#551edbb71cb317dea2cf9c76ebe059d311eefacb"
+  integrity sha512-5vvxn6//poNeOxt1ZwC7QU//dG9QqABjy1T7fP/xmFHY95GnaOw3yABf29hiu5SR1Oo34XcpyHFbzod+vemQjA==
+
 "@types/d3-scale@^3.3.0":
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-3.3.2.tgz#18c94e90f4f1c6b1ee14a70f14bfca2bd1c61d06"
   integrity sha512-gGqr7x1ost9px3FvIfUMi5XA/F/yAf4UkUDtdQhpH92XCT0Oa7zkkRzY61gPVJq+DxpHn/btouw5ohWkbBsCzQ==
   dependencies:
     "@types/d3-time" "^2"
+
+"@types/d3-shape@^1.3.1":
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-1.3.8.tgz#c3c15ec7436b4ce24e38de517586850f1fea8e89"
+  integrity sha512-gqfnMz6Fd5H6GOLYixOZP/xlrMtJms9BaS+6oWxTKHNqPGZ93BkWWupQSCYm6YHqx6h9wjRupuJb90bun6ZaYg==
+  dependencies:
+    "@types/d3-path" "^1"
 
 "@types/d3-time@^2", "@types/d3-time@^2.0.0":
   version "2.1.1"
@@ -2697,10 +2732,15 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/lodash@^4.14.167":
+"@types/lodash@^4.14.167", "@types/lodash@^4.14.172":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
   integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
+"@types/luxon@^2.3.2":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-2.4.0.tgz#897d3abc23b68d78b69d76a12c21e01eb5adab95"
+  integrity sha512-oCavjEjRXuR6URJEtQm0eBdfsBiEcGBZbq21of8iGkeKxU1+1xgKuFPClaBZl2KB8ZZBSWlgk61tH6Mf+nvZVw==
 
 "@types/mdast@^3.0.0":
   version "3.0.10"
@@ -2872,7 +2912,15 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@visx/group@^2.10.0":
+"@visx/curve@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@visx/curve/-/curve-2.1.0.tgz#f614bfe3db66df7db7382db7a75ced1506b94602"
+  integrity sha512-9b6JOnx91gmOQiSPhUOxdsvcnW88fgqfTPKoVgQxidMsD/I3wksixtwo8TR/vtEz2aHzzsEEhlv1qK7Y3yaSDw==
+  dependencies:
+    "@types/d3-shape" "^1.3.1"
+    d3-shape "^1.0.6"
+
+"@visx/group@2.10.0", "@visx/group@^2.10.0":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@visx/group/-/group-2.10.0.tgz#95839851832545621eb0d091866a61dafe552ae1"
   integrity sha512-DNJDX71f65Et1+UgQvYlZbE66owYUAfcxTkC96Db6TnxV221VKI3T5l23UWbnMzwFBP9dR3PWUjjqhhF12N5pA==
@@ -2881,7 +2929,15 @@
     classnames "^2.3.1"
     prop-types "^15.6.2"
 
-"@visx/scale@^2.2.2":
+"@visx/mock-data@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@visx/mock-data/-/mock-data-2.1.2.tgz#e3e2130d5617694a34e62dcfa7ede3275db72ccd"
+  integrity sha512-6xUVP56tiPwVi3BxvoXPQzDYWG6iX2nnOlsHEYsHgK8gHq1r7AhjQtdbQUX7QF0QkmkJM0cW8TBjZ2e+dItB8Q==
+  dependencies:
+    "@types/d3-random" "^2.2.0"
+    d3-random "^2.2.2"
+
+"@visx/scale@2.2.2", "@visx/scale@^2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@visx/scale/-/scale-2.2.2.tgz#b8eafabdcf92bb45ab196058fe184772ad80fd25"
   integrity sha512-3aDySGUTpe6VykDQmF+g2nz5paFu9iSPTcCOEgkcru0/v5tmGzUdvivy8CkYbr87HN73V/Jc53lGm+kJUQcLBw==
@@ -2892,6 +2948,24 @@
     d3-interpolate "^1.4.0"
     d3-scale "^3.3.0"
     d3-time "^2.1.1"
+
+"@visx/shape@^2.12.2":
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/@visx/shape/-/shape-2.12.2.tgz#81ed88bf823aa84a4f5f32a9c9daf8371a606897"
+  integrity sha512-4gN0fyHWYXiJ+Ck8VAazXX0i8TOnLJvOc5jZBnaJDVxgnSIfCjJn0+Nsy96l9Dy/bCMTh4DBYUBv9k+YICBUOA==
+  dependencies:
+    "@types/d3-path" "^1.0.8"
+    "@types/d3-shape" "^1.3.1"
+    "@types/lodash" "^4.14.172"
+    "@types/react" "*"
+    "@visx/curve" "2.1.0"
+    "@visx/group" "2.10.0"
+    "@visx/scale" "2.2.2"
+    classnames "^2.3.1"
+    d3-path "^1.0.5"
+    d3-shape "^1.2.0"
+    lodash "^4.17.21"
+    prop-types "^15.5.10"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -4659,6 +4733,16 @@ d3-interpolate@^1.4.0:
   dependencies:
     d3-color "1"
 
+d3-path@1, d3-path@^1.0.5:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+
+d3-random@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-2.2.2.tgz#5eebd209ef4e45a2b362b019c1fb21c2c98cbb6e"
+  integrity sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==
+
 d3-scale@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.3.0.tgz#28c600b29f47e5b9cd2df9749c206727966203f3"
@@ -4669,6 +4753,13 @@ d3-scale@^3.3.0:
     d3-interpolate "1.2.0 - 2"
     d3-time "^2.1.1"
     d3-time-format "2 - 3"
+
+d3-shape@^1.0.6, d3-shape@^1.2.0:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
+  integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+  dependencies:
+    d3-path "1"
 
 "d3-time-format@2 - 3":
   version "3.0.0"
@@ -7065,6 +7156,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+luxon@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.5.0.tgz#098090f67d690b247e83c090267a60b1aa8ea96c"
+  integrity sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A==
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -8684,7 +8780,7 @@ prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@actnowcoalition/assert@^1.0.0":
+"@actnowcoalition/assert@^1.0.0", "@actnowcoalition/assert@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-1.0.1.tgz#a4c629a16279085abf7958f4a735a0c3b9aee848"
   integrity sha512-i4k08njxovn3m1jy1mYvCJJv7fLvSpsVwaiocNGB+WC8x44TOxsQuX8iQM62IMKXtu+/5uBIEgn+3QcbT2QLuw==


### PR DESCRIPTION
Implements the LineChart component. See [Chart API Design](https://www.dropbox.com/scl/fi/snrqj20p0uoxr9phynbtu/Chart-API-Design.paper?dl=0&rlkey=3onvrnbe1753bc7v3tpey3do6) for a quick introduction to how we expect to build charts.

The component takes the props of the SVG [`path`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path) element so we can have the same styling flexibility as the `path` element, but set some reasonable defaults for `stroke` and `strokeWidth` to make sure it renders with default values (by default the line is not visible). It also accepts the props of [`LinePath`](https://airbnb.io/visx/docs/shape#LinePath) (from the visx library) so we can customize some line generation settings.

## Changes

- Implement the `LineChart` as a basic building block for more complex charts.
- Adds the `@visx/mock-data` package to use some mock data as dev dependency. Note: Once we merge #30, we could replace this with the `MockDataProvider`

![image](https://user-images.githubusercontent.com/114084/184166062-6491addc-f45d-4fe8-bef4-8ae041916126.png)

Note: It might be better to pass `x` and `y` instead of the scales (to have some extra flexibility on the accessors), but it feels unnecessary given that we are passing a `Timeseries<number>`, which is guaranteed to have `TimeseriesPoint<number>` and thus `date` and `value`.