### PR TITLE
Implement BarChart component

### DIFF
--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -23,7 +23,9 @@ const fill = "#2a9d8f";
 
 const Template: ComponentStory<typeof BarChart> = (args) => (
   <svg width={width} height={height} style={{ border: "solid 1px #eee" }}>
-    <BarChart {...args} />
+    <Group left={padding} top={padding}>
+      <BarChart {...args} />
+    </Group>
   </svg>
 );
 
@@ -61,22 +63,25 @@ Example.args = {
   timeseries,
   xScale,
   yScale,
-  fill: fill,
+  fill,
+  barWidth: dayWidth - 3,
 };
 
 export const WithLineChart = () => (
   <svg width={width} height={height} style={{ border: "solid 1px #eee" }}>
     <Group top={padding} left={padding}>
       <rect width={innerWidth} height={innerHeight} fill="#eee" />
-      <BarChart
-        timeseries={timeseries}
-        xScale={xScale}
-        yScale={yScale}
-        fill={fill}
-        fillOpacity={0.3}
-        barWidth={dayWidth - 2}
-      />
       <Group left={0.5 * dayWidth}>
+        <Group left={-0.5 * dayWidth}>
+          <BarChart
+            timeseries={timeseries}
+            xScale={xScale}
+            yScale={yScale}
+            fill={fill}
+            fillOpacity={0.3}
+            barWidth={dayWidth - 2}
+          />
+        </Group>
         {timeseries.points.map((p, i) => (
           <circle
             key={`dot-${i}`}

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { scaleLinear, scaleBand } from "@visx/scale";
+import { scaleLinear, scaleTime } from "@visx/scale";
 import { appleStock } from "@visx/mock-data";
+
 import { assert } from "@actnowcoalition/assert";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+
 import BarChart from ".";
+import LineChart from "../LineChart";
 
 export default {
-  title: "Components/BarChart",
+  title: "Charts/BarChart",
   component: BarChart,
 } as ComponentMeta<typeof BarChart>;
 
@@ -30,16 +33,15 @@ const points = appleStock.map(
 
 const timeseries = new Timeseries(points).filterToDateRange({
   startAt: new Date("2008-01-01"),
-  endAt: new Date("2008-06-30"),
+  endAt: new Date("2008-03-31"),
 });
 assert(timeseries.hasData(), `Timeseries cannot be empty`);
 
-const { minValue, maxValue } = timeseries;
+const { minDate, maxDate, minValue, maxValue } = timeseries;
 
-const xScale = scaleBand({
-  domain: timeseries.dates,
+const xScale = scaleTime({
+  domain: [minDate, maxDate],
   range: [0, width],
-  padding: 0.2,
 });
 
 const yScale = scaleLinear({
@@ -52,4 +54,27 @@ Example.args = {
   timeseries,
   xScale,
   yScale,
+  fill: "#ddd",
 };
+
+const xScaleLine = scaleTime({ domain: [minDate, maxDate], range: [0, width] });
+const yScaleLine = scaleLinear({
+  domain: [minValue, maxValue],
+  range: [height, 0],
+});
+
+export const WithLineChart = () => (
+  <svg width={width} height={height}>
+    <BarChart
+      timeseries={timeseries}
+      xScale={xScale}
+      yScale={yScale}
+      fillOpacity={0.3}
+    />
+    <LineChart
+      timeseries={timeseries}
+      xScale={xScaleLine}
+      yScale={yScaleLine}
+    />
+  </svg>
+);

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -69,30 +69,34 @@ Example.args = {
 
 export const WithLineChart = () => (
   <svg width={width} height={height} style={{ border: "solid 1px #eee" }}>
-    <Group top={padding} left={padding}>
-      <rect width={innerWidth} height={innerHeight} fill="#eee" />
-      <Group left={0.5 * dayWidth}>
-        <Group left={-0.5 * dayWidth}>
-          <BarChart
-            timeseries={timeseries}
-            xScale={xScale}
-            yScale={yScale}
-            fill={fill}
-            fillOpacity={0.3}
-            barWidth={dayWidth - 2}
-          />
-        </Group>
-        {timeseries.points.map((p, i) => (
-          <circle
-            key={`dot-${i}`}
-            cx={xScale(p.date)}
-            cy={yScale(p.value)}
-            r={4}
-            fill="black"
-          />
-        ))}
-        <LineChart timeseries={timeseries} xScale={xScale} yScale={yScale} />
+    <rect
+      y={padding}
+      x={padding}
+      width={innerWidth}
+      height={innerHeight}
+      fill="#eee"
+    />
+    <Group top={padding} left={padding + 0.5 * dayWidth}>
+      <Group left={-0.5 * dayWidth}>
+        <BarChart
+          timeseries={timeseries}
+          xScale={xScale}
+          yScale={yScale}
+          fill={fill}
+          fillOpacity={0.3}
+          barWidth={dayWidth - 2}
+        />
       </Group>
+      {timeseries.points.map((p, i) => (
+        <circle
+          key={`dot-${i}`}
+          cx={xScale(p.date)}
+          cy={yScale(p.value)}
+          r={4}
+          fill="black"
+        />
+      ))}
+      <LineChart timeseries={timeseries} xScale={xScale} yScale={yScale} />
     </Group>
   </svg>
 );

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -17,6 +17,7 @@ export default {
 
 const [width, height] = [600, 400];
 const padding = 30;
+const barPadding = 3;
 const innerWidth = width - 2 * padding;
 const innerHeight = height - 2 * padding;
 const fill = "#2a9d8f";
@@ -64,7 +65,7 @@ Example.args = {
   xScale,
   yScale,
   fill,
-  barWidth: dayWidth - 3,
+  barWidth: dayWidth - barPadding,
 };
 
 export const WithLineChart = () => (
@@ -84,7 +85,7 @@ export const WithLineChart = () => (
           yScale={yScale}
           fill={fill}
           fillOpacity={0.3}
-          barWidth={dayWidth - 2}
+          barWidth={dayWidth - barPadding}
         />
       </Group>
       {timeseries.points.map((p, i) => (

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -15,7 +15,7 @@ export default {
 } as ComponentMeta<typeof BarChart>;
 
 const [width, height] = [600, 400];
-const padding = 10;
+const padding = 5;
 const color = "#2a9d8f";
 
 const Template: ComponentStory<typeof BarChart> = (args) => (
@@ -65,7 +65,7 @@ const yScaleLine = scaleLinear({
 });
 
 export const WithLineChart = () => (
-  <svg width={width} height={height}>
+  <svg width={width} height={height} style={{ border: "solid 1px #eee" }}>
     <BarChart
       timeseries={timeseries}
       xScale={xScale}

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -15,6 +15,8 @@ export default {
 } as ComponentMeta<typeof BarChart>;
 
 const [width, height] = [600, 400];
+const padding = 10;
+const color = "#2a9d8f";
 
 const Template: ComponentStory<typeof BarChart> = (args) => (
   <svg width={width} height={height} style={{ border: "solid 1px #eee" }}>
@@ -41,7 +43,7 @@ const { minDate, maxDate, minValue, maxValue } = timeseries;
 
 const xScale = scaleTime({
   domain: [minDate, maxDate],
-  range: [0, width],
+  range: [padding, width - 2 * padding],
 });
 
 const yScale = scaleLinear({
@@ -54,12 +56,11 @@ Example.args = {
   timeseries,
   xScale,
   yScale,
-  fill: "#ddd",
+  fill: color,
 };
 
-const xScaleLine = scaleTime({ domain: [minDate, maxDate], range: [0, width] });
 const yScaleLine = scaleLinear({
-  domain: [minValue, maxValue],
+  domain: yScale.domain(),
   range: [height, 0],
 });
 
@@ -69,12 +70,9 @@ export const WithLineChart = () => (
       timeseries={timeseries}
       xScale={xScale}
       yScale={yScale}
+      fill={color}
       fillOpacity={0.3}
     />
-    <LineChart
-      timeseries={timeseries}
-      xScale={xScaleLine}
-      yScale={yScaleLine}
-    />
+    <LineChart timeseries={timeseries} xScale={xScale} yScale={yScaleLine} />
   </svg>
 );

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { scaleLinear, scaleBand } from "@visx/scale";
+import { appleStock } from "@visx/mock-data";
+import { assert } from "@actnowcoalition/assert";
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+import BarChart from ".";
+
+export default {
+  title: "Components/BarChart",
+  component: BarChart,
+} as ComponentMeta<typeof BarChart>;
+
+const [width, height] = [600, 400];
+
+const Template: ComponentStory<typeof BarChart> = (args) => (
+  <svg width={width} height={height} style={{ border: "solid 1px #eee" }}>
+    <BarChart {...args} />
+  </svg>
+);
+
+// We format the points from appleStock to match TimeseriesPoint<number>
+// so we can use them to initialize Timeseries.
+const points = appleStock.map(
+  (p: { date: string; close: number }): TimeseriesPoint<number> => ({
+    date: new Date(p.date.substring(0, 10)),
+    value: p.close,
+  })
+);
+
+const timeseries = new Timeseries(points).filterToDateRange({
+  startAt: new Date("2008-01-01"),
+  endAt: new Date("2008-06-30"),
+});
+assert(timeseries.hasData(), `Timeseries cannot be empty`);
+
+const { minValue, maxValue } = timeseries;
+
+const xScale = scaleBand({
+  domain: timeseries.dates,
+  range: [0, width],
+  padding: 0.2,
+});
+
+const yScale = scaleLinear({
+  domain: [minValue, maxValue],
+  range: [0, height],
+});
+
+export const Example = Template.bind({});
+Example.args = {
+  timeseries,
+  xScale,
+  yScale,
+};

--- a/packages/ui-components/src/components/BarChart/BarChart.style.ts
+++ b/packages/ui-components/src/components/BarChart/BarChart.style.ts
@@ -1,3 +1,0 @@
-import { styled } from "../../styles";
-
-export const Container = styled("div")``;

--- a/packages/ui-components/src/components/BarChart/BarChart.style.ts
+++ b/packages/ui-components/src/components/BarChart/BarChart.style.ts
@@ -1,0 +1,3 @@
+import { styled } from "../../styles";
+
+export const Container = styled("div")``;

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -14,9 +14,7 @@ export interface BarChartOwnProps {
   /** d3-scale to transform point values to pixel positions on the y-axis */
   yScale: ScaleLinear<number, number>;
 
-  /** Width of each bar, in pixels. By default, the barWidth will be set to
-   * the distance between 2 consecutive days.
-   */
+  /** Width of each bar, in pixels (2px by default) */
   barWidth?: number;
 }
 
@@ -59,15 +57,7 @@ const BarChart: React.FC<BarChartProps> = ({
   barWidth = 2,
   ...rectProps
 }) => {
-  // We need minDate to calculate the bar width, so we return early if the
-  // timeseries is empty.
-  if (!timeseries.hasData()) {
-    return null;
-  }
-
-  const [yStart, yEnd] = yScale.range();
-  const maxHeight = Math.max(yStart, yEnd);
-
+  const [yStart] = yScale.range();
   return (
     <Group>
       {timeseries.points.map((p, i) => {
@@ -76,9 +66,9 @@ const BarChart: React.FC<BarChartProps> = ({
           <rect
             key={`bar-${i}`}
             x={xScale(p.date)}
-            y={rectY}
+            y={Math.min(rectY, yStart)}
             width={barWidth}
-            height={maxHeight - rectY}
+            height={Math.abs(rectY - yStart)}
             fill="#000"
             {...rectProps}
           />

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -1,43 +1,99 @@
 import React from "react";
-import { ScaleBand, ScaleLinear } from "d3-scale";
+import { ScaleLinear, ScaleTime } from "d3-scale";
+import { Group } from "@visx/group";
 
 import { Timeseries } from "@actnowcoalition/metrics";
 
-interface BarChartOwnProps {
+export interface BarChartOwnProps {
+  /** Timeseries used to draw the line chart */
   timeseries: Timeseries<number>;
-  xScale: ScaleBand<Date>;
+
+  /** Scale to transform point dates to pixel positions on the x-axis */
+  xScale: ScaleTime<number, number>;
+
+  /** Scale to transform point values to piel position on the y-axis */
   yScale: ScaleLinear<number, number>;
+
+  /** Width of each bar, in pixels */
+  barWidth?: number;
 }
 
-type BarChartProps = BarChartOwnProps & React.SVGProps<SVGRectElement>;
+export type BarChartProps = BarChartOwnProps & React.SVGProps<SVGRectElement>;
 
+/**
+ * BarChart is a chart to represent a Timeseries as a series of bars, one bar
+ * for each point in the series.
+ *
+ * The horizontal center of the rectangles will be aligned with the date of its
+ * corresponding point, make sure to adjust the chart paddings accordingly.
+ *
+ * By default, the bar width corresponds to the distance between two
+ * consecutive days.
+ *
+ * @example
+ * ```tsx
+ * const xScale = scaleTime({ domain: [minDate, maxDate], range: [0, width] });
+ * const yScale = scaleLinear({ domain: [minValue, maxValue], range: [0, height] });
+ *
+ * <svg width={width} height={height}>
+ *   <BarChart
+ *     timeseries={timeseries}
+ *     xScale={xScale}
+ *     yScale={yScale}
+ *   />
+ * </svg>
+ * ```
+ *
+ * @param timeseries Timeseries to represent as a bar chart.
+ * @param xScale d3-scale to transform dates into pixel positions on the x-axis
+ * @param yScale d3-scale to transform values into pixel heights of each bar.
+ * @param barWidth width (in pixels) of each bar.
+ *
+ * @returns An SVG Group element
+ */
 const BarChart: React.FC<BarChartProps> = ({
   timeseries,
   xScale,
   yScale,
+  barWidth,
   ...rectProps
 }) => {
-  const [minHeight, maxHeight] = yScale.range();
-  const barWidth = xScale.bandwidth();
+  // We need minDate to calculate the bar width, so we return early if the
+  // timeseries is empty.
+  if (!timeseries.hasData()) {
+    return null;
+  }
+
+  const { minDate } = timeseries;
+  const rectWidth =
+    barWidth ?? Math.floor(xScale(nextDay(minDate)) - xScale(minDate));
+
+  const [, maxHeight] = yScale.range();
 
   return (
-    <>
+    <Group left={-0.5 * rectWidth}>
       {timeseries.points.map((p, i) => {
         const barHeight = yScale(p.value);
         return (
           <rect
             key={`bar-${i}`}
             x={xScale(p.date)}
-            y={maxHeight - minHeight - barHeight}
-            width={barWidth}
+            y={maxHeight - barHeight}
+            width={rectWidth}
             height={barHeight}
             fill="#000"
             {...rectProps}
           />
         );
       })}
-    </>
+    </Group>
   );
 };
 
 export default BarChart;
+
+// Given a date, it returns the date of the next day
+function nextDay(date: Date): Date {
+  const unixTimeMilliseconds = date.getTime();
+  return new Date(unixTimeMilliseconds + 1000 * 24 * 60 * 60);
+}

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -33,7 +33,7 @@ export type BarChartProps = BarChartOwnProps & React.SVGProps<SVGRectElement>;
  * @example
  * ```tsx
  * const xScale = scaleTime({ domain: [minDate, maxDate], range: [0, width] });
- * const yScale = scaleLinear({ domain: [minValue, maxValue], range: [0, height] });
+ * const yScale = scaleLinear({ domain: [minValue, maxValue], range: [height, 0] });
  *
  * <svg width={width} height={height}>
  *   <BarChart
@@ -55,7 +55,7 @@ const BarChart: React.FC<BarChartProps> = ({
   timeseries,
   xScale,
   yScale,
-  barWidth,
+  barWidth = 2,
   ...rectProps
 }) => {
   // We need minDate to calculate the bar width, so we return early if the
@@ -64,23 +64,20 @@ const BarChart: React.FC<BarChartProps> = ({
     return null;
   }
 
-  const { minDate } = timeseries;
-  const rectWidth =
-    barWidth ?? Math.floor(xScale(nextDay(minDate)) - xScale(minDate));
-
-  const [, maxHeight] = yScale.range();
+  const [yStart, yEnd] = yScale.range();
+  const maxHeight = Math.max(yStart, yEnd);
 
   return (
-    <Group left={-0.5 * rectWidth}>
+    <Group>
       {timeseries.points.map((p, i) => {
-        const barHeight = yScale(p.value);
+        const rectY = yScale(p.value);
         return (
           <rect
             key={`bar-${i}`}
             x={xScale(p.date)}
-            y={maxHeight - barHeight}
-            width={rectWidth}
-            height={barHeight}
+            y={rectY}
+            width={barWidth}
+            height={maxHeight - rectY}
             fill="#000"
             {...rectProps}
           />
@@ -91,9 +88,3 @@ const BarChart: React.FC<BarChartProps> = ({
 };
 
 export default BarChart;
-
-// Given a date, it returns the date of the next day
-function nextDay(date: Date): Date {
-  const unixTimeMilliseconds = date.getTime();
-  return new Date(unixTimeMilliseconds + 1000 * 24 * 60 * 60);
-}

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { ScaleBand, ScaleLinear } from "d3-scale";
+
+import { Timeseries } from "@actnowcoalition/metrics";
+
+interface BarChartOwnProps {
+  timeseries: Timeseries<number>;
+  xScale: ScaleBand<Date>;
+  yScale: ScaleLinear<number, number>;
+}
+
+type BarChartProps = BarChartOwnProps & React.SVGProps<SVGRectElement>;
+
+const BarChart: React.FC<BarChartProps> = ({
+  timeseries,
+  xScale,
+  yScale,
+  ...rectProps
+}) => {
+  const [minHeight, maxHeight] = yScale.range();
+  const barWidth = xScale.bandwidth();
+
+  return (
+    <>
+      {timeseries.points.map((p, i) => {
+        const barHeight = yScale(p.value);
+        return (
+          <rect
+            key={`bar-${i}`}
+            x={xScale(p.date)}
+            y={maxHeight - minHeight - barHeight}
+            width={barWidth}
+            height={barHeight}
+            fill="#000"
+            {...rectProps}
+          />
+        );
+      })}
+    </>
+  );
+};
+
+export default BarChart;

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -25,8 +25,9 @@ export type BarChartProps = BarChartOwnProps & React.SVGProps<SVGRectElement>;
  * for each point in the series.
  *
  * Note that the left edge of each rectangle will be aligned with the date of
- * the data point. Make sure to adjust the chart paddings accordingly (see
- * Storybook for an example).
+ * the data point, which can cause the last bar to be outside the charting
+ * area. Make sure to adjust the chart paddings accordingly (see Storybook
+ * for an example).
  *
  * By default, the bar width corresponds to the distance between two
  * consecutive days.

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -14,7 +14,9 @@ export interface BarChartOwnProps {
   /** d3-scale to transform point values to pixel position on the y-axis */
   yScale: ScaleLinear<number, number>;
 
-  /** Width of each bar, in pixels */
+  /** Width of each bar, in pixels. By default, the barWidth will be set to
+   * the distance between 2 consecutive days.
+   */
   barWidth?: number;
 }
 
@@ -28,9 +30,6 @@ export type BarChartProps = BarChartOwnProps & React.SVGProps<SVGRectElement>;
  * the data point, which can cause the last bar to be outside the charting
  * area. Make sure to adjust the chart paddings accordingly (see Storybook
  * for an example).
- *
- * By default, the bar width corresponds to the distance between two
- * consecutive days.
  *
  * @example
  * ```tsx

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -8,10 +8,10 @@ export interface BarChartOwnProps {
   /** Timeseries used to draw the line chart */
   timeseries: Timeseries<number>;
 
-  /** Scale to transform point dates to pixel positions on the x-axis */
+  /** d3-scale to transform point dates to pixel positions on the x-axis */
   xScale: ScaleTime<number, number>;
 
-  /** Scale to transform point values to piel position on the y-axis */
+  /** d3-scale to transform point values to pixel position on the y-axis */
   yScale: ScaleLinear<number, number>;
 
   /** Width of each bar, in pixels */
@@ -24,15 +24,15 @@ export type BarChartProps = BarChartOwnProps & React.SVGProps<SVGRectElement>;
  * BarChart is a chart to represent a Timeseries as a series of bars, one bar
  * for each point in the series.
  *
- * The horizontal center of the rectangles will be aligned with the date of its
- * corresponding point, make sure to adjust the chart paddings accordingly.
+ * Note that the left edge of each rectangle will be aligned
+ * with the date of the data point
  *
  * By default, the bar width corresponds to the distance between two
  * consecutive days.
  *
  * @example
  * ```tsx
- * const xScale = scaleTime({ domain: [minDate, maxDate], range: [0, width] });
+ * const xScale = scaleUtc({ domain: [minDate, maxDate], range: [0, width] });
  * const yScale = scaleLinear({ domain: [minValue, maxValue], range: [height, 0] });
  *
  * <svg width={width} height={height}>

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -5,13 +5,13 @@ import { Group } from "@visx/group";
 import { Timeseries } from "@actnowcoalition/metrics";
 
 export interface BarChartOwnProps {
-  /** Timeseries used to draw the line chart */
+  /** Timeseries used to draw the bar chart */
   timeseries: Timeseries<number>;
 
   /** d3-scale to transform point dates to pixel positions on the x-axis */
   xScale: ScaleTime<number, number>;
 
-  /** d3-scale to transform point values to pixel position on the y-axis */
+  /** d3-scale to transform point values to pixel positions on the y-axis */
   yScale: ScaleLinear<number, number>;
 
   /** Width of each bar, in pixels. By default, the barWidth will be set to

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -24,8 +24,9 @@ export type BarChartProps = BarChartOwnProps & React.SVGProps<SVGRectElement>;
  * BarChart is a chart to represent a Timeseries as a series of bars, one bar
  * for each point in the series.
  *
- * Note that the left edge of each rectangle will be aligned
- * with the date of the data point
+ * Note that the left edge of each rectangle will be aligned with the date of
+ * the data point. Make sure to adjust the chart paddings accordingly (see
+ * Storybook for an example).
  *
  * By default, the bar width corresponds to the distance between two
  * consecutive days.

--- a/packages/ui-components/src/components/BarChart/index.ts
+++ b/packages/ui-components/src/components/BarChart/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BarChart";

--- a/packages/ui-components/src/components/BarChart/index.ts
+++ b/packages/ui-components/src/components/BarChart/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./BarChart";
-export type { BarChartProps } from "./BarChart";
+export type { BarChartProps, BarChartOwnProps } from "./BarChart";

--- a/packages/ui-components/src/components/BarChart/index.ts
+++ b/packages/ui-components/src/components/BarChart/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./BarChart";
+export type { BarChartProps } from "./BarChart";

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -12,7 +12,7 @@ export interface LineChartOwnProps {
   /** d3-scale to transform point dates to pixel positions on the x-axis */
   xScale: ScaleTime<number, number>;
 
-  /** d3-scale to transform point values to piel position on the y-axis */
+  /** d3-scale to transform point values to pixel positions on the y-axis */
   yScale: ScaleLinear<number, number>;
 }
 
@@ -31,7 +31,7 @@ export type LineChartProps = LineChartOwnProps &
  * @example
  * ```tsx
  * const xScale = scaleTime({ domain: [minDate, maxDate], range: [0, 200] });
- * const yScale = scaleLinear({ domain: [minVal, maxVal], range: [0, 100] });
+ * const yScale = scaleLinear({ domain: [minVal, maxVal], range: [100, 0] });
  *
  * return (
  *   <svg>

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -29,21 +29,23 @@ export type LineChartProps = LineChartOwnProps &
  * Storybook for a working example.
  *
  * @example
- *    const xScale = scaleLinear({ domain: [minDate, maxDate], range: [0, 200] });
- *    const yScale = scaleLinear({ domain: [minVal, maxVal], range: [0, 100] });
+ * ```tsx
+ * const xScale = scaleTime({ domain: [minDate, maxDate], range: [0, 200] });
+ * const yScale = scaleLinear({ domain: [minVal, maxVal], range: [0, 100] });
  *
- *    return (
- *      <svg>
- *        <BarChart ... />
- *        <LineChart
- *          timeseries={timeseries}
- *          xScale={p => xScale(p.date)}
- *          yScale={p => yScale(p.value)}
- *          stroke="blue"
- *          strokeDasharray="4 4"
- *        />
- *      </svg>
- *    );
+ * return (
+ *   <svg>
+ *     <BarChart ... />
+ *     <LineChart
+ *       timeseries={timeseries}
+ *       xScale={xScale}
+ *       yScale={yScale}
+ *       stroke="blue"
+ *       strokeDasharray="4 4"
+ *     />
+ *   </svg>
+ * );
+ * ```
  *
  * @param timeseries Timeseries to represent as a line.
  * @param xScale d3-scale to transform point dates to pixel positions on the x-axis.

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -9,10 +9,10 @@ export interface LineChartOwnProps {
   /** Timeseries used to draw the line chart */
   timeseries: Timeseries<number>;
 
-  /** Scale to transform point dates to pixel positions on the x-axis */
+  /** d3-scale to transform point dates to pixel positions on the x-axis */
   xScale: ScaleTime<number, number>;
 
-  /** Scale to transform point values to piel position on the y-axis */
+  /** d3-scale to transform point values to piel position on the y-axis */
   yScale: ScaleLinear<number, number>;
 }
 

--- a/packages/ui-components/src/components/LineChart/index.ts
+++ b/packages/ui-components/src/components/LineChart/index.ts
@@ -1,3 +1,2 @@
 export { default } from "./LineChart";
-import { LineChartProps } from "./LineChart";
-export type { LineChartProps };
+export type { LineChartProps, LineChartOwnProps } from "./LineChart";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -4,6 +4,7 @@ import { Theme } from "@mui/material/styles";
 export { themeConfig } from "./styles";
 
 /** UI Components and props */
+export { default as BarChart } from "./components/BarChart";
 export { default as LegendThreshold } from "./components/LegendThreshold";
 export type { LegendThresholdProps } from "./components/LegendThreshold";
 export { default as LegendCategorical } from "./components/LegendCategorical";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -5,6 +5,7 @@ export { themeConfig } from "./styles";
 
 /** UI Components and props */
 export { default as BarChart } from "./components/BarChart";
+export type { BarChartProps } from "./components/BarChart";
 export { default as LegendThreshold } from "./components/LegendThreshold";
 export type { LegendThresholdProps } from "./components/LegendThreshold";
 export { default as LegendCategorical } from "./components/LegendCategorical";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -5,13 +5,13 @@ export { themeConfig } from "./styles";
 
 /** UI Components and props */
 export { default as BarChart } from "./components/BarChart";
-export type { BarChartProps } from "./components/BarChart";
+export type { BarChartProps, BarChartOwnProps } from "./components/BarChart";
 export { default as LegendThreshold } from "./components/LegendThreshold";
 export type { LegendThresholdProps } from "./components/LegendThreshold";
 export { default as LegendCategorical } from "./components/LegendCategorical";
 export type { LegendCategoricalProps } from "./components/LegendCategorical";
 export { default as LineChart } from "./components/LineChart";
-export type { LineChartProps } from "./components/LineChart";
+export type { LineChartProps, LineChartOwnProps } from "./components/LineChart";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/pull/62 - Implements BarChart component. 

<img width="606" alt="image" src="https://user-images.githubusercontent.com/114084/184712191-dfd833bb-3a63-4b41-8473-7902ea1ff42e.png">

**Edit**: I updated the `BarChart` API to match `LineChart` as suggested by @mikelehen, that was great feedback. I documented the rationale for the updated choices in the [Chart API Design](https://www.dropbox.com/scl/fi/snrqj20p0uoxr9phynbtu/Chart-API-Design.paper?dl=0&rlkey=3onvrnbe1753bc7v3tpey3do6#:uid=247458956670909809575882&h2=Coordinate-System-and-Scales) paper doc to better explain some adjustments that we need to make when combining line and bar charts.

I also updated the example to make it easier to see the bars/offsets

<img width="611" alt="image" src="https://user-images.githubusercontent.com/114084/185996259-b45b56aa-c4b1-4b09-95a6-65c546bae1ce.png">

