### PR TITLE
Add typography variants to the theme

### DIFF
--- a/packages/ui-components/.storybook/preview-head.html
+++ b/packages/ui-components/.storybook/preview-head.html
@@ -2,3 +2,13 @@
   rel="stylesheet"
   href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&family=Roboto:wght@300;400;500;700&display=swap"
 />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&display=swap"
+  rel="stylesheet"
+/>
+<link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+  rel="stylesheet"
+/>

--- a/packages/ui-components/.storybook/preview.tsx
+++ b/packages/ui-components/.storybook/preview.tsx
@@ -19,6 +19,12 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  options: {
+    storySort: {
+      method: "alphabetical",
+      order: ["Design System", "Components", "Charts"],
+    },
+  },
 };
 
 export const decorators = [themeDecorator];

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -33,6 +33,11 @@ declare module "@mui/material/Typography" {
   interface TypographyPropsVariantOverrides {
     paragraphSmall: true;
     paragraphLarge: true;
+    labelSmall: true;
+    labelLarge: true;
+    dataEmphasizedSmall: true;
+    dataEmphasizedLarge: true;
+    dataTabular: true;
   }
 }
 

--- a/packages/ui-components/src/stories/Typography.stories.tsx
+++ b/packages/ui-components/src/stories/Typography.stories.tsx
@@ -17,6 +17,7 @@ const textSampleParagraphLarge = `Lorem ipsum dolor sit amet, consectetur adipis
 `;
 const textSampleParagraphSmall = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas metus est, fermentum sit amet ullamcorper at, venenatis eget lectus. Nunc ac augue eros. Ut gravida accumsan enim id maximus.`;
 
+// TODO(Pablo): How can I get this type from the theme?
 type TypographyVariant =
   | "h1"
   | "h2"

--- a/packages/ui-components/src/stories/Typography.stories.tsx
+++ b/packages/ui-components/src/stories/Typography.stories.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { ComponentMeta } from "@storybook/react";
+import { Typography, Grid, Box } from "@mui/material";
+
+export default {
+  title: "Design System/Typography",
+  component: Typography,
+} as ComponentMeta<typeof Typography>;
+
+const textSampleData = "123.4";
+const textSampleShort = "Lorem ipsum dolor sit amet";
+const textSampleParagraphLarge = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas metus est, fermentum sit amet ullamcorper at, venenatis eget lectus. Nunc ac augue eros. Ut gravida accumsan enim id maximus.
+
+- Incentivize the installation of EV charging infrastructure beyond the city's current requirements.
+- Publicize community-wide energy data. 
+- Establish and track metrics related to energy equity. 
+`;
+const textSampleParagraphSmall = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas metus est, fermentum sit amet ullamcorper at, venenatis eget lectus. Nunc ac augue eros. Ut gravida accumsan enim id maximus.`;
+
+type TypographyVariant =
+  | "h1"
+  | "h2"
+  | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
+  | "paragraphLarge"
+  | "paragraphSmall"
+  | "labelLarge"
+  | "labelSmall"
+  | "dataEmphasizedLarge"
+  | "dataEmphasizedSmall"
+  | "dataTabular"
+  | "overline";
+
+const variantList: { variant: TypographyVariant; textSample: string }[] = [
+  { variant: "h1", textSample: textSampleShort },
+  { variant: "h2", textSample: textSampleShort },
+  { variant: "h3", textSample: textSampleShort },
+  { variant: "h4", textSample: textSampleShort },
+  { variant: "h5", textSample: textSampleShort },
+  { variant: "h6", textSample: textSampleShort },
+  { variant: "labelLarge", textSample: textSampleShort },
+  { variant: "labelSmall", textSample: textSampleShort },
+  { variant: "paragraphLarge", textSample: textSampleParagraphLarge },
+  { variant: "paragraphSmall", textSample: textSampleParagraphSmall },
+  { variant: "dataEmphasizedLarge", textSample: textSampleData },
+  { variant: "dataEmphasizedSmall", textSample: textSampleData },
+  { variant: "dataTabular", textSample: textSampleData },
+  { variant: "overline", textSample: textSampleShort },
+];
+
+export const All = () => (
+  <Box>
+    {variantList.map((item) => (
+      <Grid key={`item-${item.variant}`} container mt={2}>
+        <Grid item sm={4} xs={12} p={{ sm: 1, xs: 0.5 }}>
+          <Typography variant="labelSmall">{item.variant}</Typography>
+        </Grid>
+        <Grid item sm={8} xs={12} p={{ sm: 1, xs: 0.5 }}>
+          <Typography variant={item.variant}>{item.textSample}</Typography>
+        </Grid>
+      </Grid>
+    ))}
+  </Box>
+);

--- a/packages/ui-components/src/styles/theme/interfaces.ts
+++ b/packages/ui-components/src/styles/theme/interfaces.ts
@@ -1,8 +1,30 @@
 /** Theme interfaces */
 import { TypographyOptions } from "@mui/material/styles/createTypography";
+import React from "react";
 
 /** Typography */
 export interface ExtendedTypographyOptions extends TypographyOptions {
+  /** Used for metric/location/human names (e.g. overview, search results) */
+  labelSmall: React.CSSProperties;
+  /**
+   * Used for metric/location/human names (e.g. overview, search results),
+   * but inside constrained areas (e.g. table header, tags)
+   */
+  labelLarge: React.CSSProperties;
+
+  /** Used when text doesn’t need to stand out (e.g. footnotes) or inside
+   * constrained areas (e.g. labels in charts) */
   paragraphSmall: React.CSSProperties;
+
+  /** Used for general text purposes */
   paragraphLarge: React.CSSProperties;
+
+  /** Used in tabs and overviews, but inside constrained areas */
+  dataEmphasizedSmall: React.CSSProperties;
+
+  /** Used in tabs and overviews */
+  dataEmphasizedLarge: React.CSSProperties;
+
+  /** Used in tables */
+  dataTabular: React.CSSProperties;
 }

--- a/packages/ui-components/src/styles/theme/interfaces.ts
+++ b/packages/ui-components/src/styles/theme/interfaces.ts
@@ -4,27 +4,11 @@ import React from "react";
 
 /** Typography */
 export interface ExtendedTypographyOptions extends TypographyOptions {
-  /** Used for metric/location/human names (e.g. overview, search results) */
   labelSmall: React.CSSProperties;
-  /**
-   * Used for metric/location/human names (e.g. overview, search results),
-   * but inside constrained areas (e.g. table header, tags)
-   */
   labelLarge: React.CSSProperties;
-
-  /** Used when text doesn’t need to stand out (e.g. footnotes) or inside
-   * constrained areas (e.g. labels in charts) */
   paragraphSmall: React.CSSProperties;
-
-  /** Used for general text purposes */
   paragraphLarge: React.CSSProperties;
-
-  /** Used in tabs and overviews, but inside constrained areas */
   dataEmphasizedSmall: React.CSSProperties;
-
-  /** Used in tabs and overviews */
   dataEmphasizedLarge: React.CSSProperties;
-
-  /** Used in tables */
   dataTabular: React.CSSProperties;
 }

--- a/packages/ui-components/src/styles/theme/theme.ts
+++ b/packages/ui-components/src/styles/theme/theme.ts
@@ -1,4 +1,4 @@
-import { createTheme } from "@mui/material/styles";
+import { createTheme, responsiveFontSizes } from "@mui/material/styles";
 import palette from "./palette";
 import typography from "./typography";
 
@@ -12,7 +12,7 @@ const themeConfig = {
   typography,
 };
 
-const theme = createTheme(themeConfig);
+const theme = responsiveFontSizes(createTheme(themeConfig));
 
 export { themeConfig };
 export default theme;

--- a/packages/ui-components/src/styles/theme/typography.ts
+++ b/packages/ui-components/src/styles/theme/typography.ts
@@ -25,6 +25,9 @@ const typographyConstants = {
   fontSizeBase: "1rem",
   fontSizeDSmall: "1.125rem",
   fontSizeDLarge: "1.5rem",
+  fontSizeH1: "2.75rem",
+  fontSizeH2: "2rem",
+  fontSizeH3: "1.125rem",
 
   lineHeightSmall: 1,
   lineHeightMedium: 1.25,
@@ -35,21 +38,21 @@ const typography: ExtendedTypographyOptions = {
   fontFamily: typographyConstants.fontFamily,
 
   h1: {
-    fontSize: "2.75rem",
+    fontSize: typographyConstants.fontSizeH1,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
     color: palette.secondary.dark,
   },
 
   h2: {
-    fontSize: "2rem",
+    fontSize: typographyConstants.fontSizeH2,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
     color: palette.secondary.dark,
   },
 
   h3: {
-    fontSize: "1.125rem",
+    fontSize: typographyConstants.fontSizeH3,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
     color: palette.secondary.dark,

--- a/packages/ui-components/src/styles/theme/typography.ts
+++ b/packages/ui-components/src/styles/theme/typography.ts
@@ -1,22 +1,100 @@
 import palette from "./palette";
 import { ExtendedTypographyOptions } from "./interfaces";
 
+/**
+ * Note: The default theme includes some fonts that need to be included at the
+ * app level. Here are the link elements to include the fonts below. If a
+ * specific project uses a different set of fonts, they will need to customize
+ * the theme in consequence.
+ *
+ * <link rel="preconnect" href="https://fonts.googleapis.com">
+ * <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+ * <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+ * <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&display=swap" rel="stylesheet">
+ */
 const typographyConstants = {
-  fontFamily: "Arial",
+  fontFamily: "'Inter', sans-serif;",
+  fontFamilyMono: "'Source Code Pro', monospace;",
 
   fontWeightRegular: 400,
   fontWeightMedium: 500,
   fontWeightBold: 700,
 
+  fontSizeOSmall: ".75rem",
   fontSizePSmall: ".875rem",
   fontSizeBase: "1rem",
+  fontSizeDSmall: "1.125rem",
+  fontSizeDLarge: "1.5rem",
 
   lineHeightSmall: 1,
+  lineHeightMedium: 1.25,
   lineHeightBase: 1.5,
 };
 
 const typography: ExtendedTypographyOptions = {
   fontFamily: typographyConstants.fontFamily,
+
+  h1: {
+    fontSize: "2.75rem",
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+  },
+
+  h2: {
+    fontSize: "2rem",
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+  },
+
+  h3: {
+    fontSize: "1.125rem",
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+  },
+
+  /**
+   * TODO (Pablo): The design system doesn't include styled for h4 - h6, so
+   * I'm including it with the same style as h3 while we get the final styles.
+   */
+  h4: {
+    fontSize: typographyConstants.fontSizeBase,
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+  },
+
+  h5: {
+    fontSize: typographyConstants.fontSizeBase,
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+  },
+
+  h6: {
+    fontSize: typographyConstants.fontSizeBase,
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+  },
+
+  labelSmall: {
+    fontFamily: typographyConstants.fontFamily,
+    fontSize: typographyConstants.fontSizePSmall,
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightBase,
+    color: palette.secondary.dark,
+  },
+
+  labelLarge: {
+    fontFamily: typographyConstants.fontFamily,
+    fontSize: typographyConstants.fontSizeBase,
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightBase,
+    color: palette.secondary.dark,
+  },
 
   paragraphSmall: {
     fontFamily: typographyConstants.fontFamily,
@@ -24,10 +102,44 @@ const typography: ExtendedTypographyOptions = {
     lineHeight: typographyConstants.lineHeightSmall,
     color: palette.secondary.light,
   },
+
   paragraphLarge: {
     fontFamily: typographyConstants.fontFamily,
     fontSize: typographyConstants.fontSizeBase,
     lineHeight: typographyConstants.lineHeightBase,
+  },
+
+  dataEmphasizedSmall: {
+    fontFamily: typographyConstants.fontFamilyMono,
+    fontSize: typographyConstants.fontSizeDSmall,
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+  },
+
+  dataEmphasizedLarge: {
+    fontFamily: typographyConstants.fontFamilyMono,
+    fontSize: typographyConstants.fontSizeDLarge,
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+  },
+
+  dataTabular: {
+    fontFamily: typographyConstants.fontFamilyMono,
+    fontSize: typographyConstants.fontSizePSmall,
+    fontWeight: typographyConstants.fontWeightRegular,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.main,
+  },
+
+  overline: {
+    fontFamily: typographyConstants.fontFamily,
+    fontSize: typographyConstants.fontSizeOSmall,
+    fontWeight: typographyConstants.fontWeightBold,
+    lineHeight: typographyConstants.lineHeightMedium,
+    color: palette.secondary.dark,
+    textTransform: "uppercase",
   },
 };
 


### PR DESCRIPTION
Close #75 - Implement typography variants (theme)

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/114084/184950160-2c637af5-3ce8-493a-b205-ca9975fd417d.png">


## Changes

- Updated the font-family to `Inter` for the default theme, and added `Source Code Pro` as monospaced font.
- Added the design system variants to Typography
- Added a story to show Typography variants
- Updated the Storybook config to sort stories, and added the new fonts to the `preview-head.html` file.
- Export the theme with `responsiveFontSizes`, to automatically adjust font sizes under each breakpoint.
- Added styles for `h4` - `h6` (same as `h3`) so we have a good fallback in case we need them

## Notes

- The design system doesn't include specific breakpoints, it only has **mobile**, **tablet** and **desktop**. We need to check with Josh what's the pixel value for these breakpoints.
- The font size for headings is modified based on breakpoints on the design system, I just set the defaults for desktop and added `responsiveFontSizes` to scale them automatically. We can sync with Josh later to confirm whether that's good enough (or adjust as needed).