### PR TITLE
Fix useData() hooks and add testing.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:@typescript-eslint/recommended"
   ],
   "parser": "@typescript-eslint/parser",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/parser": "^5.23.0",
     "eslint": "^8.15.0",
     "eslint-plugin-react": "^7.29.4",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.1",
     "jest": "^28.1.0",
     "lint-staged": "^12.4.1",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/metrics",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Classes for representing metrics and loading metric data",
   "repository": {
     "type": "git",
@@ -24,14 +24,16 @@
     "build": "yarn build:esm && yarn build:cjs"
   },
   "devDependencies": {
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/lodash": "^4.14.182",
+    "react-test-renderer": "^18.2.0",
     "typescript": "^4.6.4"
   },
   "sideEffects": false,
   "dependencies": {
     "@actnowcoalition/assert": "^1.0.0",
-    "@actnowcoalition/regions": "^1.1.7",
     "@actnowcoalition/number-format": "^1.1.1",
+    "@actnowcoalition/regions": "^1.1.7",
     "@actnowcoalition/time-utils": "^1.0.1",
     "lodash": "^4.17.21",
     "react": "^18.2.0"

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react-hooks";
 
 import { states } from "@actnowcoalition/regions";
 
-import { MetricCatalog } from "./MetricCatalog";
+import { MetricCatalog, useCachedArrayIfEqual } from "./MetricCatalog";
 import { SnapshotJSON } from "../data";
 import { MockDataProvider, StaticValueDataProvider } from "../data_providers";
 
@@ -219,5 +219,36 @@ describe("MetricCatalog", () => {
     expect(
       result.current.data?.metricData(testRegionCA, metricPi).currentValue
     ).toBe(Math.PI);
+  });
+});
+
+describe("useCachedArrayIfEqual()", () => {
+  test("example", () => {
+    // Render with an initial array.
+    const initialArray = ["testing"];
+    const { result, rerender } = renderHook(
+      ({ array }) => useCachedArrayIfEqual(array),
+      {
+        initialProps: {
+          array: initialArray,
+        },
+      }
+    );
+    expect(result.current).toBe(initialArray);
+
+    // Re-render with a different array instance but the same values.
+    // Should still return the original array instance.
+    rerender({ array: ["testing"] });
+    expect(result.current).toBe(initialArray);
+
+    // Re-render with a different array instance and different values.
+    const newArray = ["testing", "new"];
+    rerender({ array: newArray });
+    expect(result.current).toBe(newArray);
+
+    // Re-render with a different array instance but same values again.
+    // Should still return the original array instance.
+    rerender({ array: ["testing", "new"] });
+    expect(result.current).toBe(newArray);
   });
 });

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
@@ -1,3 +1,5 @@
+import { renderHook } from "@testing-library/react-hooks";
+
 import { states } from "@actnowcoalition/regions";
 
 import { MetricCatalog } from "./MetricCatalog";
@@ -146,5 +148,76 @@ describe("MetricCatalog", () => {
     );
     expect(typeof data.currentValue).toEqual("number");
     expect(data.timeseries.hasData()).toEqual(true);
+  });
+
+  test("useDataForRegionsAndMetrics()", async () => {
+    // This test makes sure that the hook gracefully handles being rendered
+    // repeatedly with the same set of metrics / regions, even if the arrays
+    // are not the exact same instances. In particular, each render should
+    // not trigger additional metric fetches.
+
+    const dataProviders = [
+      new StaticValueDataProvider(),
+      new MockDataProvider(),
+    ];
+    const catalog = new MetricCatalog(testMetricDefs, dataProviders);
+    const metricPi = catalog.getMetric(MetricId.PI);
+    const metricCases = catalog.getMetric(MetricId.MOCK_CASES);
+
+    // Before we render the hook, the catalog should not have done any data fetches.
+    let expectedFetches = 0;
+    expect(catalog.dataFetchesCount).toBe(expectedFetches);
+
+    // Render the hook initially.
+    const { result, waitForNextUpdate, rerender } = renderHook(
+      ({ regions, metrics }) =>
+        catalog.useDataForRegionsAndMetrics(regions, metrics),
+      {
+        initialProps: {
+          regions: [testRegionCA, testRegionWA],
+          metrics: [metricPi, metricCases],
+        },
+      }
+    );
+
+    // The catalog should have performed a data fetch, but since it's anync,
+    // initially the hook won't return data.
+    expect(catalog.dataFetchesCount).toBe(++expectedFetches);
+    expect(result.current.data).toStrictEqual(undefined);
+    // Wait for initial async fetch to finish.
+    await waitForNextUpdate();
+    expect(
+      result.current.data?.metricData(testRegionCA, metricPi).currentValue
+    ).toBe(Math.PI);
+
+    // Render the hook again with new regions / metrics array instances but
+    // containing the same values.  This should not perform a fetch.
+    rerender({
+      regions: [testRegionCA, testRegionWA],
+      metrics: [metricPi, metricCases],
+    });
+    expect(catalog.dataFetchesCount).toBe(expectedFetches);
+
+    // Render the hook again with different regions.  This should perform a fetch.
+    rerender({ regions: [testRegionCA], metrics: [metricPi, metricCases] });
+    expect(catalog.dataFetchesCount).toBe(++expectedFetches);
+    // Wait for async fetch to return the new data.
+    await waitForNextUpdate();
+    expect(result.current.data?.hasRegionData(testRegionWA)).toBe(false);
+    expect(
+      result.current.data?.metricData(testRegionCA, metricPi).currentValue
+    ).toBe(Math.PI);
+
+    // Render the hook again with different metrics.  This should perform a fetch.
+    rerender({ regions: [testRegionCA], metrics: [metricPi] });
+    expect(catalog.dataFetchesCount).toBe(++expectedFetches);
+    // Wait for async fetch to return the new data.
+    await waitForNextUpdate();
+    expect(
+      result.current.data?.regionData(testRegionCA).hasMetricData(metricCases)
+    ).toBe(false);
+    expect(
+      result.current.data?.metricData(testRegionCA, metricPi).currentValue
+    ).toBe(Math.PI);
   });
 });

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import groupBy from "lodash/groupBy";
+import isEqual from "lodash/isEqual";
 import keyBy from "lodash/keyBy";
 import uniq from "lodash/uniq";
 
@@ -32,6 +33,15 @@ export class MetricCatalog {
   readonly options: MetricCatalogOptions;
 
   private readonly metricsById: { [id: string]: Metric };
+
+  /**
+   * Count of times that the MetricCatalog has had to fetch data from one or
+   * more data providers (e.g. any of the fetchData() methods were called, or a
+   * useData() hook was called with new metrics / regions).
+   *
+   * Used for debugging / testing.
+   */
+  dataFetchesCount = 0;
 
   /**
    * Constructs a new {@link MetricCatalog} from the given metrics, data providers, and options.
@@ -133,6 +143,8 @@ export class MetricCatalog {
     metrics: Array<string | Metric>,
     includeTimeseries = true
   ): Promise<MultiRegionMultiMetricDataStore> {
+    this.dataFetchesCount++;
+
     const resolvedMetrics = metrics.map((m) =>
       typeof m === "string" ? this.getMetric(m) : m
     );
@@ -194,20 +206,13 @@ export class MetricCatalog {
     metric: string | Metric,
     includeTimeseries = true
   ): DataOrError<MetricData> {
-    const [data, setData] = useState<MetricData>();
-    useEffect(() => {
-      this.fetchData(region, metric, includeTimeseries)
-        .then((data) => {
-          setData(data);
-        })
-        .catch((error) => {
-          console.error(
-            `Error fetching metric data for ${metric} for ${region.regionId}: ${error}`
-          );
-          return { error };
-        });
-    }, [region, metric]);
-    return { data };
+    const { data: dataStore, error } = this.useDataForMetrics(
+      region,
+      [metric],
+      includeTimeseries
+    );
+    const data = dataStore?.metricData(metric);
+    return { data, error };
   }
 
   /**
@@ -220,29 +225,16 @@ export class MetricCatalog {
    */
   useDataForMetrics(
     region: Region,
-    metrics: string[] | Metric[],
+    metrics: Array<string | Metric>,
     includeTimeseries = true
   ): DataOrError<MultiMetricDataStore> {
-    const [data, setData] = useState<MultiMetricDataStore>();
-    // TODO(michael): This is a hack. We have to turn metricList into a string
-    // to pass to the useEffect hook since useEffect doesn't do deep equality on
-    // arrays. We probably need to do something similar for regions or else find
-    // another workaround.
-    const metricList = JSON.stringify(metrics);
-    useEffect(() => {
-      const metrics = JSON.parse(metricList);
-      this.fetchDataForMetrics(region, metrics, includeTimeseries)
-        .then((metricDataStore) => {
-          setData(metricDataStore);
-        })
-        .catch((error) => {
-          console.error(
-            `Error fetching metric data for ${region.regionId}: ${error}`
-          );
-          return { error };
-        });
-    }, [metricList, region]);
-    return { data };
+    const { data: dataStore, error } = this.useDataForRegionsAndMetrics(
+      [region],
+      metrics,
+      includeTimeseries
+    );
+    const data = dataStore?.regionData(region);
+    return { data, error };
   }
 
   /**
@@ -255,27 +247,19 @@ export class MetricCatalog {
    */
   useDataForRegionsAndMetrics(
     regions: Region[],
-    metrics: string[] | Metric[],
+    metrics: Array<string | Metric>,
     includeTimeseries = true
   ): DataOrError<MultiRegionMultiMetricDataStore> {
-    const [data, setData] = useState<MultiRegionMultiMetricDataStore>();
-    // TODO(michael): This is a hack. We have to turn metricList into a string
-    // to pass to the useEffect hook since useEffect doesn't do deep equality on
-    // arrays. We probably need to do something similar for regions or else find
-    // another workaround.
-    const metricList = JSON.stringify(metrics);
-    useEffect(() => {
-      const metrics = JSON.parse(metricList);
-      this.fetchDataForMetricsAndRegions(regions, metrics, includeTimeseries)
-        .then((multiRegionMetricDataStore) => {
-          setData(multiRegionMetricDataStore);
-        })
-        .catch((error) => {
-          console.error(`Error fetching metric data: ${error}`);
-          return { error };
-        });
-    }, [metricList, regions]);
-    return { data };
+    // ESLint complains about calling hooks from classes (React Hook
+    // "useDataForRegionsAndMetrics" cannot be called in a class component.) but
+    // this isn't actually a class component.  It's just a class.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    return useDataForRegionsAndMetrics(
+      /*catalog=*/ this,
+      regions,
+      metrics,
+      includeTimeseries
+    );
   }
 }
 
@@ -287,3 +271,59 @@ export class MetricCatalog {
  * 3. The data failed to load. (data is nil, error is not nil)
  */
 export type DataOrError<T> = { data?: T; error?: Error };
+
+function useDataForRegionsAndMetrics(
+  catalog: MetricCatalog,
+  regions: Region[],
+  metrics: Array<string | Metric>,
+  includeTimeseries = true
+): DataOrError<MultiRegionMultiMetricDataStore> {
+  const [data, setData] = useState<MultiRegionMultiMetricDataStore>();
+  let resolvedMetrics = metrics.map((m) =>
+    typeof m === "string" ? catalog.getMetric(m) : m
+  );
+
+  // In order to allow people to pass in a new array of regions / metrics that
+  // contain the same regions / metrics as before without triggering additional
+  // fetches, we need this caching trick.
+  resolvedMetrics = useCachedArrayIfEqual(resolvedMetrics);
+  regions = useCachedArrayIfEqual(regions);
+
+  useEffect(() => {
+    catalog
+      .fetchDataForMetricsAndRegions(
+        regions,
+        resolvedMetrics,
+        includeTimeseries
+      )
+      .then((multiRegionMetricDataStore) => {
+        setData(multiRegionMetricDataStore);
+      })
+      .catch((error) => {
+        console.error(`Error fetching metric data: ${error}`);
+        return { error };
+      });
+  }, [catalog, resolvedMetrics, regions, includeTimeseries]);
+  return { data };
+}
+
+/**
+ * Helper react hook to cache / return an array value, as long as the contents
+ * are equal.
+ *
+ * As long as the new array contains the exact same values (i.e. each item `===`
+ * the previous values), then the original cached array will be returned. This is
+ * useful when using the array as a dependency in react, e.g. with `useEffect()`
+ * where you want to avoid re-running the effect as long as the array is equal
+ * to the old array.
+ *
+ * @param value New array to check against the cached array.
+ * @returns The cached array if its contents is exactly equal to the new value, else the new value.
+ */
+function useCachedArrayIfEqual<T>(value: Array<T>): Array<T> {
+  const ref = useRef(value);
+  if (!isEqual(ref.current, value)) {
+    ref.current = value;
+  }
+  return ref.current;
+}

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.ts
@@ -320,7 +320,7 @@ function useDataForRegionsAndMetrics(
  * @param value New array to check against the cached array.
  * @returns The cached array if its contents is exactly equal to the new value, else the new value.
  */
-function useCachedArrayIfEqual<T>(value: Array<T>): Array<T> {
+export function useCachedArrayIfEqual<T>(value: Array<T>): Array<T> {
   const ref = useRef(value);
   if (!isEqual(ref.current, value)) {
     ref.current = value;

--- a/packages/metrics/yarn.lock
+++ b/packages/metrics/yarn.lock
@@ -29,6 +29,21 @@
     "@types/luxon" "^2.3.2"
     luxon "^2.4.0"
 
+"@babel/runtime@^7.12.5":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@types/lodash@^4.14.182":
   version "4.14.182"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
@@ -61,10 +76,56 @@ luxon@^2.4.0:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.5.0.tgz#098090f67d690b247e83c090267a60b1aa8ea96c"
   integrity sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A==
 
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-shallow-renderer@^16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.2.0.tgz#1dd912bd908ff26da5b9fca4fd1c489b9523d37e"
+  integrity sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==
+  dependencies:
+    react-is "^18.2.0"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.0"
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+  dependencies:
+    loose-envify "^1.1.0"
+
+regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3024,6 +3024,14 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/user-event@^13.2.1":
   version "13.5.0"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
@@ -6290,6 +6298,11 @@ escodegen@^2.0.0:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
 eslint-plugin-react@^7.29.4:
   version "7.29.4"
@@ -11113,6 +11126,13 @@ react-element-to-jsx-string@^14.3.4:
     is-plain-object "5.0.0"
     react-is "17.0.2"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -11127,6 +11147,11 @@ react-is@17.0.2, react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -11136,11 +11161,6 @@ react-is@^18.0.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
   integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
-
-react-is@^18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
-  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-markdown@^8.0.3:
   version "8.0.3"
@@ -11172,6 +11192,23 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-shallow-renderer@^16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.2.0.tgz#1dd912bd908ff26da5b9fca4fd1c489b9523d37e"
+  integrity sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==
+  dependencies:
+    react-is "^18.2.0"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.0"
 
 react-transition-group@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
The existing useData() hooks didn't gracefully handle passing the same metrics / regions on every render if the actual array instances changed, e.g.: This would cause an infinite re-render:

```
catalog.useDataForRegionsAndMetrics([region], [metric])
```

Because the array instances would be differente every time.  The core fix is to add a `useCachedArrayIfEqual()` helper that preserves the original array reference if the contents are the same.

This PR also:
* Adds a test to validate the hook behaves correctly now.
* Enables `plugin:react-hooks/recommended` eslint checks.