### PR TITLE
Add `legendCatagories` to `MetricDefinition` and `Metric`

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/metrics",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Classes for representing metrics and loading metric data",
   "repository": {
     "type": "git",

--- a/packages/metrics/src/Metric/Metric.test.ts
+++ b/packages/metrics/src/Metric/Metric.test.ts
@@ -22,6 +22,12 @@ const testLevelSet: MetricLevelSet = {
   ],
 };
 
+// Example of a typical testCategories to be used by metrics.
+const testCategories: MetricCategory[] = [
+  { label: "Not started", color: "red", value: "no" },
+  { label: "Done", color: "green", value: "yes" },
+];
+
 // Example of typical MetricCatalogOptions, including a default metric level set.
 const testCatalogOptions: MetricCatalogOptions = {
   metricLevelSets: [testLevelSet],
@@ -115,18 +121,13 @@ describe("Metric", () => {
     expect(metric.roundValue(0.123)).toBe(0.12);
   });
 
-  test("getCategory() with string value and no match.", () => {
-    const testCategories: MetricCategory[] = [
-      { label: "Not started", color: "red", value: "no" },
-      { label: "Done", color: "green", value: "yes" },
-    ];
+  test("getCategory() fails with no matching value.", () => {
     const metric = new Metric({
       ...testMetricDef,
       categories: testCategories,
     });
-    expect(metric.getCategory("no")).toStrictEqual(testCategories[0]);
     expect(() => {
       metric.getCategory("none");
-    }).toThrow("No matching category");
+    }).toThrow("No matching");
   });
 });

--- a/packages/metrics/src/Metric/Metric.test.ts
+++ b/packages/metrics/src/Metric/Metric.test.ts
@@ -2,6 +2,7 @@ import { Metric } from "./Metric";
 import { MetricLevelSet } from "./MetricLevel";
 import { MetricDefinition } from "./MetricDefinition";
 import { MetricCatalogOptions } from "../MetricCatalog";
+import { MetricCategory } from "./MetricCategory";
 
 // Example of a typical metric with mostly default options.
 const testMetricDef: MetricDefinition = {
@@ -112,5 +113,20 @@ describe("Metric", () => {
       formatOptions: { style: "percent", maximumFractionDigits: 0 },
     });
     expect(metric.roundValue(0.123)).toBe(0.12);
+  });
+
+  test("getCategory() with string value and no match.", () => {
+    const testCategories: MetricCategory[] = [
+      { label: "Not started", color: "red", value: "no" },
+      { label: "Done", color: "green", value: "yes" },
+    ];
+    const metric = new Metric({
+      ...testMetricDef,
+      categories: testCategories,
+    });
+    expect(metric.getCategory("no")).toStrictEqual(testCategories[0]);
+    expect(() => {
+      metric.getCategory("none");
+    }).toThrow("No matching category");
   });
 });

--- a/packages/metrics/src/Metric/Metric.test.ts
+++ b/packages/metrics/src/Metric/Metric.test.ts
@@ -121,6 +121,14 @@ describe("Metric", () => {
     expect(metric.roundValue(0.123)).toBe(0.12);
   });
 
+  test("getCategory() with string values", () => {
+    const metric = new Metric({
+      ...testMetricDef,
+      categories: testCategories,
+    });
+    expect(metric.getCategory("no")).toStrictEqual(testCategories[0]);
+  });
+
   test("getCategory() fails with no matching value.", () => {
     const metric = new Metric({
       ...testMetricDef,

--- a/packages/metrics/src/Metric/Metric.ts
+++ b/packages/metrics/src/Metric/Metric.ts
@@ -38,6 +38,12 @@ export class Metric {
   readonly levelSetId: string;
   /** {@inheritDoc MetricDefinition.formatOptions} */
   readonly formatOptions: Intl.NumberFormatOptions;
+  /** {@inheritDoc MetricDefinition.legendCatagories} */
+  readonly legendCatagories?: {
+    label: string;
+    color: string;
+    [extra: string]: unknown;
+  }[];
   /** {@inheritDoc MetricDefinition.extra} */
   readonly extra?: Record<string, unknown>;
 
@@ -72,6 +78,7 @@ export class Metric {
     this.levelSetId = def.levelSetId ?? "default";
     this.levelSet = (levelSets || []).find((ls) => ls.id === this.levelSetId);
     this.formatOptions = def.formatOptions ?? DEFAULT_FORMAT_OPTIONS;
+    this.legendCatagories = def.legendCatagories;
 
     assert(
       this.thresholds === undefined ||

--- a/packages/metrics/src/Metric/Metric.ts
+++ b/packages/metrics/src/Metric/Metric.ts
@@ -6,6 +6,7 @@ import { isFinite } from "@actnowcoalition/number-format";
 
 import { MetricDataReference } from "./MetricDataReference";
 import { MetricLevel, MetricLevelSet } from "./MetricLevel";
+import { MetricCategory } from "./MetricCategory";
 import { MetricDefinition } from "./MetricDefinition";
 import { MetricCatalogOptions } from "../MetricCatalog";
 
@@ -38,12 +39,8 @@ export class Metric {
   readonly levelSetId: string;
   /** {@inheritDoc MetricDefinition.formatOptions} */
   readonly formatOptions: Intl.NumberFormatOptions;
-  /** {@inheritDoc MetricDefinition.legendCatagories} */
-  readonly legendCatagories?: {
-    label: string;
-    color: string;
-    [extra: string]: unknown;
-  }[];
+  /** {@inheritDoc MetricDefinition.categories} */
+  readonly categories?: Array<MetricCategory>;
   /** {@inheritDoc MetricDefinition.extra} */
   readonly extra?: Record<string, unknown>;
 
@@ -78,7 +75,12 @@ export class Metric {
     this.levelSetId = def.levelSetId ?? "default";
     this.levelSet = (levelSets || []).find((ls) => ls.id === this.levelSetId);
     this.formatOptions = def.formatOptions ?? DEFAULT_FORMAT_OPTIONS;
-    this.legendCatagories = def.legendCatagories;
+    this.categories = def.categories;
+
+    assert(
+      !(this.categories && this.thresholds),
+      "Categories and levels should not both be defined."
+    );
 
     assert(
       this.thresholds === undefined ||
@@ -142,6 +144,26 @@ export class Metric {
     const lastLevel = last(this.levelSet.levels);
     assert(lastLevel);
     return lastLevel;
+  }
+
+  /**
+   * Finds the corresponding category for a given value.
+   *
+   * Throws an error if no matching category is found.
+   *
+   * @param value Value to find category for.
+   * @returns Category the value belongs to.
+   */
+  getCategory(value: unknown): MetricCategory {
+    assert(
+      this.categories !== undefined,
+      "No categories defined for this metric."
+    );
+    const category = this.categories.find(
+      (category) => value === category.value
+    );
+    assert(category, `No matching category found for value ${value}.`);
+    return category;
   }
 
   /**

--- a/packages/metrics/src/Metric/MetricCategory.ts
+++ b/packages/metrics/src/Metric/MetricCategory.ts
@@ -1,0 +1,21 @@
+/**
+ * A category for representing a discrete metric values.
+ *
+ * Categories for a metric are defined in the
+ * {@link MetricDefinition.categories} property, and the given category
+ * for a metric value is extracted from {@link Metric.categories} using
+ * {@link Metric.getCategory}.
+ *
+ * @example
+ * ```
+ * { label: "Unfinished", "color": "red", "value": "no" }
+ * ```
+ */
+export interface MetricCategory {
+  /** Name or description of the category.  */
+  label: string;
+  /** Color of the category. */
+  color: string;
+  /** Metric value that corresponds/maps to this MetricCategory */
+  value: unknown;
+}

--- a/packages/metrics/src/Metric/MetricCategory.ts
+++ b/packages/metrics/src/Metric/MetricCategory.ts
@@ -1,5 +1,5 @@
 /**
- * A category for representing a discrete metric values.
+ * A category for representing discrete metric values.
  *
  * Categories for a metric are defined in the
  * {@link MetricDefinition.categories} property, and the given category

--- a/packages/metrics/src/Metric/MetricDefinition.ts
+++ b/packages/metrics/src/Metric/MetricDefinition.ts
@@ -53,6 +53,15 @@ export interface MetricDefinition {
   levelSetId?: string;
 
   /**
+   * Legends for representing categorical metrics.
+   */
+  legendCatagories?: {
+    label: string;
+    color: string;
+    [extra: string]: unknown;
+  }[];
+
+  /**
    * Specifies options used to format the metric value when it is displayed.
    */
   formatOptions?: Intl.NumberFormatOptions;

--- a/packages/metrics/src/Metric/MetricDefinition.ts
+++ b/packages/metrics/src/Metric/MetricDefinition.ts
@@ -1,3 +1,4 @@
+import { MetricCategory } from "./MetricCategory";
 import { MetricDataReference } from "./MetricDataReference";
 
 /**
@@ -53,13 +54,9 @@ export interface MetricDefinition {
   levelSetId?: string;
 
   /**
-   * Legends for representing categorical metrics.
+   * Categories used for representing or displaying a discrete metric (e.g. "Yes", "No").
    */
-  legendCatagories?: {
-    label: string;
-    color: string;
-    [extra: string]: unknown;
-  }[];
+  categories?: Array<MetricCategory>;
 
   /**
    * Specifies options used to format the metric value when it is displayed.


### PR DESCRIPTION
For eventual use with [`LegendCategorical()`](https://github.com/covid-projections/act-now-packages/tree/develop/packages/ui-components/src/components/LegendCategorical), or similar components

