### PR TITLE
Update button styling and add stories

### DIFF
--- a/packages/ui-components/src/stories/Buttons.stories.tsx
+++ b/packages/ui-components/src/stories/Buttons.stories.tsx
@@ -24,7 +24,7 @@ export const Variants = () => (
 );
 
 export const Icon = () => (
-  <IconButton aria-label="delete" color="primary">
+  <IconButton aria-label="share on Facebook" color="primary">
     <FacebookIcon />
   </IconButton>
 );

--- a/packages/ui-components/src/stories/Buttons.stories.tsx
+++ b/packages/ui-components/src/stories/Buttons.stories.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Stack, Button, ButtonGroup, IconButton } from "@mui/material";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import FacebookIcon from "@mui/icons-material/Facebook";
+import TwitterIcon from "@mui/icons-material/Twitter";
+import LinkIcon from "@mui/icons-material/Link";
+
+export default {
+  title: "Design System/Buttons",
+};
+
+export const Variants = () => (
+  <Stack direction="row" spacing={2}>
+    <Button variant="contained" endIcon={<ArrowForwardIcon />}>
+      Contained
+    </Button>
+    <Button variant="outlined" endIcon={<ArrowForwardIcon />}>
+      Outlined
+    </Button>
+    <Button variant="text" endIcon={<ArrowForwardIcon />}>
+      Text
+    </Button>
+  </Stack>
+);
+
+export const Icon = () => (
+  <IconButton aria-label="delete" color="primary">
+    <FacebookIcon />
+  </IconButton>
+);
+
+export const Group = () => (
+  <ButtonGroup>
+    <Button endIcon={<LinkIcon />}>Copy Link</Button>
+    <Button endIcon={<TwitterIcon />}>Twitter</Button>
+    <Button endIcon={<FacebookIcon />}>Facebook</Button>
+  </ButtonGroup>
+);

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -1,6 +1,7 @@
 /** MUI theme components */
 import { ThemeOptions, createTheme } from "@mui/material";
 import typography, { typographyConstants } from "./typography";
+import palette from "./palette";
 
 const referenceTheme = createTheme();
 
@@ -13,6 +14,9 @@ const components: ThemeOptions["components"] = {
         fontSize: typography.labelLarge.fontSize,
         fontWeight: typography.labelLarge.fontWeight,
         lineHeight: typography.labelLarge.lineHeight,
+      },
+      outlinedPrimary: {
+        borderColor: palette.border.default,
       },
     },
   },

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -1,11 +1,21 @@
 /** MUI theme components */
-
-import { createTheme } from "@mui/material/styles";
-import { typographyConstants } from "./typography";
+import { ThemeOptions, createTheme } from "@mui/material";
+import typography, { typographyConstants } from "./typography";
 
 const referenceTheme = createTheme();
 
-const components = {
+const components: ThemeOptions["components"] = {
+  MuiButton: {
+    styleOverrides: {
+      root: {
+        textTransform: "none",
+        fontFamily: typography.labelLarge.fontFamily,
+        fontSize: typography.labelLarge.fontSize,
+        fontWeight: typography.labelLarge.fontWeight,
+        lineHeight: typography.labelLarge.lineHeight,
+      },
+    },
+  },
   MuiTooltip: {
     styleOverrides: {
       tooltip: {


### PR DESCRIPTION
Close #84 - Update the styling of Button to match the design system.

**Before**

<img width="396" alt="image" src="https://user-images.githubusercontent.com/114084/186287043-3f205161-1421-4e95-9704-725251352517.png">

**After**

<img width="397" alt="image" src="https://user-images.githubusercontent.com/114084/186287001-204fb191-257c-4ddd-be6e-e458506924be.png">

## Changes

- Update the `components` section of the theme to match [ActNow-Design-System → Button](https://www.figma.com/file/YN7x6bJmSfRHaovP5ABKu2/ActNow-Design-System?node-id=276%3A20245)
- Add some stories for the Button component