### PR TITLE
Metrics / CsvDataProvider fixes / tweaks.

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/metrics",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Classes for representing metrics and loading metric data",
   "repository": {
     "type": "git",
@@ -26,8 +26,12 @@
   "devDependencies": {
     "@testing-library/react-hooks": "^8.0.1",
     "@types/lodash": "^4.14.182",
+    "react": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "typescript": "^4.6.4"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0"
   },
   "sideEffects": false,
   "dependencies": {
@@ -37,7 +41,6 @@
     "@actnowcoalition/time-utils": "^1.0.1",
     "@types/papaparse": "^5.3.3",
     "lodash": "^4.17.21",
-    "papaparse": "^5.3.2",
-    "react": "^18.2.0"
+    "papaparse": "^5.3.2"
   }
 }

--- a/packages/metrics/src/data_providers/CsvDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.test.ts
@@ -3,11 +3,13 @@ import { Metric } from "../Metric";
 import { states } from "@actnowcoalition/regions";
 
 const mockCsv = `region,cool_metric
-                  36,150
-                  12,`;
+36,150
+12,`;
+
 const csvTimeseries = `region,date,cool_metric
-                        36,2022-08-02,150
-                        12,2022-08-02,`;
+36,2022-08-02,150
+12,2022-08-02,`;
+
 const newYork = states.findByRegionIdStrict("36");
 const testMetric = new Metric({
   id: "metric",

--- a/packages/metrics/src/data_providers/data_provider_utils.test.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.test.ts
@@ -52,41 +52,22 @@ describe("dataRowsToMetricData()", () => {
         /*dateKey=*/ "date"
       );
     }).toThrow();
-    expect(() => {
-      dataRowsToMetricData(
-        dataRows,
-        newYork,
-        testMetric,
-        column,
-        /*dateKey=*/ "date"
-      );
-    }).toThrow();
   });
 
-  test("dataRowsToMetricData() fails when there's no data for region.", () => {
+  test("dataRowsToMetricData() returns null data when there's no data for region.", () => {
     const column = testMetric.dataReference?.column as string;
     const dataRows: Dictionary<DataRow[]> = groupBy(
       [{ date: "2022-08-01", region: "12", cool_metric: 100 }],
       (row) => row.region
     );
-    expect(() => {
-      dataRowsToMetricData(
-        dataRows,
-        newYork,
-        testMetric,
-        column,
-        /*dateKey=*/ "date"
-      );
-    }).toThrow();
-    expect(() => {
-      dataRowsToMetricData(
-        dataRows,
-        newYork,
-        testMetric,
-        column,
-        /*dateKey=*/ "date"
-      );
-    }).toThrow();
+    const data = dataRowsToMetricData(
+      dataRows,
+      newYork,
+      testMetric,
+      column,
+      /*dateKey=*/ "date"
+    );
+    expect(data.currentValue).toBe(null);
   });
 
   test("dataRowsToMetricData() succeeds when metric data is null.", async () => {
@@ -95,15 +76,6 @@ describe("dataRowsToMetricData()", () => {
       [{ date: "2022-08-01", region: "36", cool_metric: null }],
       (row) => row.region
     );
-    expect(
-      dataRowsToMetricData(
-        dataRows,
-        newYork,
-        testMetric,
-        column,
-        /*dateKey=*/ "date"
-      ).currentValue
-    ).toBe(null);
     expect(
       dataRowsToMetricData(
         dataRows,
@@ -139,15 +111,14 @@ describe("dataRowToMetricData()", () => {
     }).toThrow();
   });
 
-  test("dataRowToMetricData() fails when there's no data for region.", () => {
+  test("dataRowToMetricData() returns null data when there's no data for region.", () => {
     const column = testMetric.dataReference?.column as string;
     const dataRows: Dictionary<DataRow[]> = groupBy(
       [{ region: "12", cool_metric: 100 }],
       (row) => row.region
     );
-    expect(() => {
-      dataRowToMetricData(dataRows, newYork, testMetric, column);
-    }).toThrow();
+    const data = dataRowToMetricData(dataRows, newYork, testMetric, column);
+    expect(data.currentValue).toBe(null);
   });
 
   test("dataRowToMetricData() succeeds when metric data is null", () => {

--- a/packages/metrics/src/data_providers/data_provider_utils.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.ts
@@ -24,14 +24,20 @@ export function dataRowToMetricData(
   metric: Metric,
   metricKey: string
 ) {
-  const rows = dataRowsByRegionId[region.regionId];
-  assert(
-    rows.length === 1,
-    `Expected exactly 1 entry for region ${region.regionId} and metric ${metric.id} but found: ${rows.length}`
-  );
-  const value = rows[0][metricKey];
-  assert(value !== undefined, `Metric key ${metricKey} missing.`);
-  return new MetricData(metric, region, value);
+  const rows = dataRowsByRegionId[region.regionId] ?? [];
+  if (rows.length === 0) {
+    return new MetricData(metric, region, /*currentValue=*/ null);
+  } else {
+    assert(
+      rows.length === 1,
+      `Expected no more than 1 entry for region ${region.regionId} and metric ` +
+        `${metric.id} but found: ${rows.length}. If this is timeseries data, ` +
+        `specify a dateColumn when creating the CsvDataProvider.`
+    );
+    const value = rows[0][metricKey];
+    assert(value !== undefined, `Metric key ${metricKey} missing.`);
+    return new MetricData(metric, region, value);
+  }
 }
 
 /**
@@ -51,8 +57,7 @@ export function dataRowsToMetricData(
   metricKey: string,
   dateKey: string
 ) {
-  const rows = dataRowsByRegionId[region.regionId];
-  assert(rows, `No data found for region ${region.regionId}.`);
+  const rows = dataRowsByRegionId[region.regionId] ?? [];
   const timeseries = new Timeseries(
     rows.map((row) => {
       assert(row[metricKey] !== undefined, `Metric key ${metricKey} missing.`);

--- a/packages/metrics/src/data_providers/index.ts
+++ b/packages/metrics/src/data_providers/index.ts
@@ -3,3 +3,5 @@ export type { MetricDataProvider } from "./MetricDataProvider";
 export { MockDataProvider } from "./MockDataProvider";
 export type { MockDataReferenceFields } from "./MockDataProvider";
 export { StaticValueDataProvider } from "./StaticValueDataProvider";
+export { CsvDataProvider } from "./CsvDataProvider";
+export type { CsvDataProviderOptions } from "./CsvDataProvider";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3321,6 +3321,13 @@
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.4.tgz#30eb872153c7ead3e8688c476054ddca004115f6"
   integrity sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==
 
+"@types/papaparse@^5.3.3":
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/@types/papaparse/-/papaparse-5.3.4.tgz#57f7366540a349675c4fa57ef01e5c8775aced2b"
+  integrity sha512-61/jki1Ri+v1/Fobrf4rlIo6ExNM8P0CHYwId8wkrC2WiKfDwiRtn/hiAa6jXj8vPa4oFZ14uFKME547V4VGyQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -10445,6 +10452,11 @@ pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
+papaparse@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.2.tgz#d1abed498a0ee299f103130a6109720404fbd467"
+  integrity sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw==
 
 parallel-transform@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
Few minor fixes uncovered while integrating with hackathon repo:

* Make react a peerDependency instead of normal dependency to avoid multiple versions of react being included.
* Export `CsvDataProvider` and `CsvDataProviderOptions` so that they can be used outside the package.
* Always preserve the region column as a raw string when parsing CSV data (to avoid turning fips codes into numbers).
* Gracefully return null data instead of throwing an error when there's no data for a particular region + metric combo.
* Handle when we fail to fetch the CSV from the given URL and give a useful error.  Before it was ending up getting parsed as an empty CSV.
* Allow empty lines in CSV file.  Needed this since pandas seems to leave a trailing empty line when you use `to_csv()`.