### PR TITLE
Upgrade @actnowcoalition/regions for metrics

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/metrics",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Classes for representing metrics and loading metric data",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   "dependencies": {
     "@actnowcoalition/assert": "^1.0.0",
     "@actnowcoalition/number-format": "^1.1.1",
-    "@actnowcoalition/regions": "^1.1.7",
+    "@actnowcoalition/regions": "^1.3.0",
     "@actnowcoalition/time-utils": "^1.0.1",
     "@types/papaparse": "^5.3.3",
     "lodash": "^4.17.21",

--- a/packages/metrics/yarn.lock
+++ b/packages/metrics/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/number-format/-/number-format-1.1.1.tgz#e69680ea88bac2cbfaab4b1a3e4a5ae4a7c90f28"
   integrity sha512-lwqiDceGOXKZDzOa9cZKzFggxu/ZakocxBDzxBKt/DJT+yGBJXuujRbFD9iEz8753p32FCUWKtgQXvpmN1wjSA==
 
-"@actnowcoalition/regions@^1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/regions/-/regions-1.1.7.tgz#bf8445f4ba06c8eeaed2f46a952f877d8f6b2c6e"
-  integrity sha512-q56uBjJ4lV7DD6FiFxzsEuK6y5TmtF7xM+rkPPH6NrP/1p42dx1cBCJbCez4e0DBH1d4UMWdtC8R21fM5e1+vg==
+"@actnowcoalition/regions@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/regions/-/regions-1.3.0.tgz#cfcffb920149f5e647bbc9c5e288981f47437bca"
+  integrity sha512-gblC/nl4CwVBcMRqnRxlr91NljqDck3uBSfDfT8hsTparaFDwVB0CBVPofjQE2lXProbnH2jBap7akIjRpxk/Q==
   dependencies:
     "@actnowcoalition/assert" "^1.0.0"
     lodash "^4.17.21"


### PR DESCRIPTION
I tried to use `MetricData(metric, region, value)` when implementing the MetricOverview component, but I couldn't because the version of `@actnowcoalition/regions` in `ui-components` and `metrics` are different. This PR updates `metrics` to use the latest `@actnowcoalition/regions`.