### PR TITLE
use time-utils' `isoDateOnlyString()` in metrics package 

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -38,7 +38,7 @@
     "@actnowcoalition/assert": "^1.0.0",
     "@actnowcoalition/number-format": "^1.1.1",
     "@actnowcoalition/regions": "^1.3.0",
-    "@actnowcoalition/time-utils": "^1.0.1",
+    "@actnowcoalition/time-utils": "^1.0.2",
     "@types/papaparse": "^5.3.3",
     "lodash": "^4.17.21",
     "papaparse": "^5.3.2"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/metrics",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Classes for representing metrics and loading metric data",
   "repository": {
     "type": "git",

--- a/packages/metrics/src/Timeseries/Timeseries.ts
+++ b/packages/metrics/src/Timeseries/Timeseries.ts
@@ -6,7 +6,7 @@ import minBy from "lodash/minBy";
 
 import { assert } from "@actnowcoalition/assert";
 import { isFinite } from "@actnowcoalition/number-format";
-import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
+import { isoDateOnlyString } from "@actnowcoalition/time-utils";
 
 /** A single, serialized point in a timeseries containing a date-string and a value. */
 export interface TimeseriesPointJSON {
@@ -198,7 +198,7 @@ export class Timeseries<T = unknown> {
     this.points.forEach((p) => {
       assert(
         isFinite(p.value),
-        `Found non-numeric (or non-finite) value in timeseries. date=${Timeseries.isoDateString(
+        `Found non-numeric (or non-finite) value in timeseries. date=${isoDateOnlyString(
           p.date
         )} value=${p.value}`
       );
@@ -216,7 +216,7 @@ export class Timeseries<T = unknown> {
     this.points.forEach((p) => {
       assert(
         typeof p.value === "boolean",
-        `Found non-boolean value in timeseries. date=${Timeseries.isoDateString(
+        `Found non-boolean value in timeseries. date=${isoDateOnlyString(
           p.date
         )} value=${p.value}`
       );
@@ -234,7 +234,7 @@ export class Timeseries<T = unknown> {
     this.points.forEach((p) => {
       assert(
         typeof p.value === "string",
-        `Found non-string value in timeseries. date=${Timeseries.isoDateString(
+        `Found non-string value in timeseries. date=${isoDateOnlyString(
           p.date
         )} value=${p.value}`
       );
@@ -343,11 +343,6 @@ export class Timeseries<T = unknown> {
     });
   }
 
-  private static isoDateString(date: Date): string {
-    // Dates are guaranteed not to have a time component so we just return the ISO date.
-    return formatUTCDateTime(date, DateFormat.YYYY_MM_DD);
-  }
-
   /**
    * Construct a Timeseries instance from JSON timeseries points.
    *
@@ -369,7 +364,7 @@ export class Timeseries<T = unknown> {
   toJSON(): TimeseriesPointJSON[] {
     const timeseriesPointJSONs: TimeseriesPointJSON[] = this.points.map(
       (point) => ({
-        date: Timeseries.isoDateString(point.date),
+        date: isoDateOnlyString(point.date),
         value: point.value,
       })
     );

--- a/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
+++ b/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
@@ -8,6 +8,7 @@ import { MultiMetricDataStore } from "./MultiMetricDataStore";
 import { MetricData } from "./MetricData";
 import { Metric } from "../Metric";
 import { StaticValueDataProvider } from "../data_providers";
+import { isoDateOnlyString } from "@actnowcoalition/time-utils";
 
 const testRegion = states.findByRegionIdStrict("12");
 const testMetric = new Metric({
@@ -23,8 +24,8 @@ const testProvider = new StaticValueDataProvider();
 // The snapshot JSON that corresponds to the data for `testRegion` and `testMetric`.
 const testSnapshot: SnapshotJSON = {
   metadata: {
-    createdDate: new Date().toISOString().split("T")[0],
-    latestDate: "2022-01-02T00:00:00.000Z",
+    createdDate: isoDateOnlyString(new Date()),
+    latestDate: "2022-01-02",
   },
   data: {
     "12": {

--- a/packages/metrics/src/data/MultiRegionMultiMetricDataStore.ts
+++ b/packages/metrics/src/data/MultiRegionMultiMetricDataStore.ts
@@ -7,6 +7,7 @@ import { MetricData } from "./MetricData";
 import { MetricToDataMap, MultiMetricDataStore } from "./MultiMetricDataStore";
 import { Metric } from "../Metric";
 import { Timeseries, TimeseriesPointJSON } from "../Timeseries";
+import { isoDateOnlyString } from "@actnowcoalition/time-utils";
 
 /**
  * JSON format of a data snapshot representing the contents of a
@@ -180,8 +181,8 @@ export class MultiRegionMultiMetricDataStore<T = unknown> {
 
     return {
       metadata: {
-        createdDate: new Date().toISOString().split("T")[0],
-        latestDate: maxDate?.toISOString() ?? null,
+        createdDate: isoDateOnlyString(new Date()),
+        latestDate: maxDate ? isoDateOnlyString(maxDate) : null,
       },
       data: records,
     };

--- a/packages/metrics/src/data_providers/CsvDataProvider.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.ts
@@ -30,9 +30,11 @@ export interface CsvDataProviderOptions {
  *
  * Assumes data is in wide form (variables as columns, indexed by region and date columns.)
  * E.g:
+ * ```
  * |region |date       |var1 |var2 |
  * |TX     |2022-02-01 |12   |45   |
  * |CA     |2022-02-01 |31   |66   |
+ * ```
  */
 export class CsvDataProvider extends CachingMetricDataProviderBase {
   private readonly regionColumn: string;

--- a/packages/metrics/src/data_providers/data_provider_utils.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.ts
@@ -3,7 +3,6 @@ import { Region } from "@actnowcoalition/regions";
 import { Metric } from "../Metric";
 import { MetricData } from "../data";
 import { Timeseries } from "../Timeseries";
-import { parseDateString } from "@actnowcoalition/time-utils";
 
 export type DataRow = { [key: string]: unknown };
 
@@ -66,7 +65,7 @@ export function dataRowsToMetricData(
         `Date column must be a string. ${typeof row[dateKey]} found.`
       );
       return {
-        date: stripTime(parseDateString(row[dateKey] as string)),
+        date: new Date(row[dateKey] as string),
         value: row[metricKey] as unknown,
       };
     })
@@ -77,16 +76,4 @@ export function dataRowsToMetricData(
     timeseries.last?.value ?? null,
     timeseries
   );
-}
-
-/**
- * Remove hours minutes and seconds from Javascript Date object.
- *
- * TODO: Merge this logic with Timeseries.isoDateString() and move to time-utils package.
- *
- * @param date Date object to truncate.
- */
-function stripTime(date: Date): Date {
-  const truncatedDate = date.toISOString().split("T")[0];
-  return new Date(truncatedDate);
 }

--- a/packages/metrics/yarn.lock
+++ b/packages/metrics/yarn.lock
@@ -20,10 +20,10 @@
     "@actnowcoalition/assert" "^1.0.0"
     lodash "^4.17.21"
 
-"@actnowcoalition/time-utils@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/time-utils/-/time-utils-1.0.1.tgz#4caf60c55764a73ec31be223cefee880568204b9"
-  integrity sha512-IKquf6m4tu4k6GUTWEvw8wL+sVRnyOOztXotEwM2WdCPNlHd4nPX3X1ZdVoOKPqdF7kIeplu1y7sFjhIpnmABA==
+"@actnowcoalition/time-utils@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/time-utils/-/time-utils-1.0.2.tgz#b0566583becfbe3744cb99d0a95c02ba3f903a05"
+  integrity sha512-oqafwdmOXGt6dpZkveD8UMD3lM2OJHY6ROOPtwEBhYbXTH4H49dW1V6K+w9UhYObKXGYrmnDrpgnEiRRJTYKzQ==
   dependencies:
     "@actnowcoalition/assert" "^1.0.0"
     "@types/luxon" "^2.3.2"


### PR DESCRIPTION
follow up from #98 