### PR TITLE
Add PureDate class to time-utils package.

### DIFF
--- a/packages/time-utils/package.json
+++ b/packages/time-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/time-utils",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "Utility functions to handle and format time",
   "repository": {
     "type": "git",

--- a/packages/time-utils/src/PureDate/PureDate.test.ts
+++ b/packages/time-utils/src/PureDate/PureDate.test.ts
@@ -1,0 +1,48 @@
+import { PureDate } from "./PureDate";
+
+describe("PureDate", () => {
+  test("isValid", () => {
+    expect(PureDate.isValid(new Date("2021-01-01"))).toBe(true);
+    expect(PureDate.isValid(new Date("2021-01-01 00:00:00 PST"))).toBe(false);
+    expect(PureDate.isValid(new Date("2021-01-01 00:00:00 UTC"))).toBe(true);
+  });
+
+  test("addDays", () => {
+    expect(new PureDate("2020-01-01").addDays(1)).toEqual(
+      new PureDate("2020-01-02")
+    );
+    expect(new PureDate("2020-01-01").addDays(-1)).toEqual(
+      new PureDate("2019-12-31")
+    );
+
+    // Daylight savings started 2020-03-08. Make sure it doesn't cause an issue.
+    expect(new PureDate("2020-03-06").addDays(4)).toEqual(
+      new PureDate("2020-03-10")
+    );
+
+    // Arbitrary large delta
+    expect(new PureDate("1850-01-01").addDays(100000)).toEqual(
+      new PureDate("2123-10-17")
+    );
+  });
+
+  test("next", () => {
+    expect(new PureDate("2020-01-01").next).toEqual(new PureDate("2020-01-02"));
+  });
+
+  test("prev", () => {
+    expect(new PureDate("2020-01-01").prev).toEqual(new PureDate("2019-12-31"));
+  });
+
+  test("subtract", () => {
+    // Daylight savings started 2020-03-08. Make sure it doesn't cause an issue.
+    expect(
+      new PureDate("2020-03-10").subtract(new PureDate("2020-03-06"))
+    ).toEqual(4);
+
+    // Arbitrary large delta
+    expect(
+      new PureDate("2123-10-17").subtract(new PureDate("1850-01-01"))
+    ).toEqual(100000);
+  });
+});

--- a/packages/time-utils/src/PureDate/PureDate.ts
+++ b/packages/time-utils/src/PureDate/PureDate.ts
@@ -1,0 +1,79 @@
+import { assert } from "@actnowcoalition/assert";
+
+/**
+ * Represents a pure date (with no time component).  Useful for e.g.
+ * representing dates in a timeseries.
+ *
+ * Internally the date is stored as a JS `Date` object in the UTC timezone with
+ * midnight (00:00:00) as the time component.
+ */
+export class PureDate {
+  /**
+   * Returns a JS `Date` instance representing this date, with the time component set
+   * to midnight UTC.
+   */
+  readonly jsDate: Date;
+
+  /**
+   * Constructs a new PureDate from a JS `Date` object or a YYYY-MM-DD string.
+   * Throws an exception if the provided `date` has a nonzero time component.
+   *
+   * @param date Either a JS `Date` object or a YYYY-MM-DD string.
+   */
+  constructor(date: Date | string) {
+    // TODO(michael): Perhaps we should be more strict on validating the string format.
+    const jsDate = typeof date === "string" ? new Date(date) : date;
+    assert(
+      PureDate.isValid(jsDate),
+      `Invalid PureDate contains nonzero timestamp: ${date}`
+    );
+    this.jsDate = jsDate;
+  }
+
+  /**
+   * Checks if a `Date` object is valid as a `PureDate` (i.e. contains no time
+   * component in UTC).
+   *
+   * @param jsDate The date to check.
+   * @returns True if the date is valid, false otherwise.
+   */
+  static isValid(jsDate: Date): boolean {
+    return jsDate.toISOString().endsWith("T00:00:00.000Z");
+  }
+
+  /** Returns a `PureDate` representing the day after the current date. */
+  get next(): PureDate {
+    return this.addDays(1);
+  }
+
+  /** Returns a `PureDate` representing the day before the current date. */
+  get prev(): PureDate {
+    return this.addDays(-1);
+  }
+
+  /** Returns a `PureDate` representing a date `days` ahead of the current date. */
+  addDays(days: number): PureDate {
+    const newDate = new Date(this.jsDate);
+    newDate.setUTCDate(newDate.getUTCDate() + days);
+    return new PureDate(newDate);
+  }
+
+  /**
+   * Returns the number of days between the current date and the provided
+   * `other` date.
+   *
+   * @param other The other date to compare against.
+   * @returns The number of days between the current date and the provided other date.
+   */
+  subtract(other: PureDate): number {
+    // HACK: We use Math.round() which allows us to not worry about daylight saving time.
+    return Math.round(
+      (this.jsDate.getTime() - other.jsDate.getTime()) / (1000 * 3600 * 24)
+    );
+  }
+
+  /** Returns a string representation of this PureDate. */
+  toString(): string {
+    return this.jsDate.toISOString().replace(/T.*/, "");
+  }
+}

--- a/packages/time-utils/src/PureDate/index.ts
+++ b/packages/time-utils/src/PureDate/index.ts
@@ -1,0 +1,1 @@
+export { PureDate } from "./PureDate";

--- a/packages/time-utils/src/index.ts
+++ b/packages/time-utils/src/index.ts
@@ -1,6 +1,8 @@
 import { DateTime, Duration } from "luxon";
 import { assert } from "@actnowcoalition/assert";
 
+export * from "./PureDate";
+
 export enum DateFormat {
   YYYY_MM_DD = "yyyy-MM-dd", // 2020-03-01
   MM_DD_YYYY = "MM/dd/yyyy", // 03/01/2020


### PR DESCRIPTION
This makes it easier to deal with "pure" dates (with no time component) like we use in Timeseries.

This came in handy when trying to write a 7-day rolling average function.