### PR TITLE
Disable maps, update types on theme and styled

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/ui-components",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "UI components for Act Now",
   "repository": {
     "type": "git",

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.style.ts
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.style.ts
@@ -7,6 +7,6 @@ export const Square = styled("div", { shouldForwardProp: isValidProp })<{
   min-width: 20px;
   height: 20px;
   border-radius: 4px;
-  margin-right: ${(props) => props.theme.spacing(1)};
+  margin-right: ${({ theme }) => theme.spacing(1)};
   background-color: ${(props) => props.color};
 `;

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -31,6 +31,26 @@ declare module "@mui/material/styles" {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface DefaultTheme extends Theme {}
 
+  interface TypographyVariants {
+    paragraphSmall: React.CSSProperties;
+    paragraphLarge: React.CSSProperties;
+    labelSmall: React.CSSProperties;
+    labelLarge: React.CSSProperties;
+    dataEmphasizedSmall: React.CSSProperties;
+    dataEmphasizedLarge: React.CSSProperties;
+    dataTabular: React.CSSProperties;
+  }
+
+  interface TypographyVariantsOptions {
+    paragraphSmall?: React.CSSProperties;
+    paragraphLarge?: React.CSSProperties;
+    labelSmall?: React.CSSProperties;
+    labelLarge?: React.CSSProperties;
+    dataEmphasizedSmall?: React.CSSProperties;
+    dataEmphasizedLarge?: React.CSSProperties;
+    dataTabular?: React.CSSProperties;
+  }
+
   interface Palette {
     border: {
       default: string;
@@ -69,4 +89,4 @@ export { default as RegionSearch } from "./components/RegionSearch";
 // export { default as Markdown } from "./components/Markdown";
 export { AxisLeft, AxisBottom } from "./components/Axis";
 export type { AxisLeftProps, AxisBottomProps } from "./components/Axis";
-export { default as USNationalMap } from "./components/USNationalMap";
+// export { default as USNationalMap } from "./components/USNationalMap";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -85,8 +85,9 @@ export type { LineChartProps, LineChartOwnProps } from "./components/LineChart";
 export { default as ProgressBar } from "./components/ProgressBar";
 export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
-// Note (8/10/22) - Markdown is causing a bug. Commenting it out until fixed.
-// export { default as Markdown } from "./components/Markdown";
 export { AxisLeft, AxisBottom } from "./components/Axis";
 export type { AxisLeftProps, AxisBottomProps } from "./components/Axis";
+// Note (8/10/22) - Markdown is causing a bug. Commenting it out until fixed.
+// export { default as Markdown } from "./components/Markdown";
+// Note (8/29/22) - Same problem with d3-geo, commenting out until fixed.
 // export { default as USNationalMap } from "./components/USNationalMap";

--- a/packages/ui-components/src/styles/index.ts
+++ b/packages/ui-components/src/styles/index.ts
@@ -1,4 +1,6 @@
-import { styled } from "@mui/material";
+import { createStyled } from "@mui/system";
 import theme, { themeConfig } from "./theme";
+
+const styled = createStyled({ defaultTheme: theme });
 
 export { styled, theme, themeConfig };


### PR DESCRIPTION
Next.js is incorrectly failing when building, saying that d3-geo and (previously) `react-markdown` are not using `import` to load ES modules:

```
**Error: Must use import to load ES Module: /Users/pablonavarro/code/actnow/hackathon-july-2022/node_modules/d3-geo/src/index.js**
**require() of ES modules is not supported.**
**require() of /Users/pablonavarro/code/actnow/hackathon-july-2022/node_modules/d3-geo/src/index.js from /Users/pablonavarro/code/actnow/hackathon-july-2022/node_modules/geo-albers-usa-territories/dist/geo-albers-usa-territories.js is an ES module file as it is a .js file whose nearest parent package.json contains “type”: “module” which defines all .js files in that package scope as ES modules.**
**Instead rename index.js to end in .cjs, change the requiring code to use import(), or remove “type”: “module” from /Users/pablonavarro/code/actnow/hackathon-july-2022/node_modules/d3-geo/package.json.**
## This error happened while generating the page. Any console logs will be displayed in the terminal window.
```

I'm commenting out the export of `USNationalMap` while we find a better fix.

I also discovered that the types for the typography variants were not being recognized when using `styled`. The fix involved 2 changes:

- Use `createStyled` to recognize our theme as the default theme
- Update the module augmentation according to the docs https://mui.com/material-ui/customization/typography/#adding-amp-disabling-variants (this fixes autocompletion when using custom typography variants such as `paragraphSmall` in components).