### PR TITLE
Add Metric.getColor() and extend Metric.formatValue().

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/metrics",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Classes for representing metrics and loading metric data",
   "repository": {
     "type": "git",

--- a/packages/metrics/src/Metric/Metric.test.ts
+++ b/packages/metrics/src/Metric/Metric.test.ts
@@ -108,6 +108,14 @@ describe("Metric", () => {
     expect(metric.formatValue("raw value")).toBe("raw value");
   });
 
+  test("formatValue() on metric with categories", () => {
+    const metric = new Metric({
+      ...testMetricDef,
+      categories: testCategories,
+    });
+    expect(metric.formatValue("no")).toStrictEqual(testCategories[0].label);
+  });
+
   test("roundValue() with default options", () => {
     const metric = new Metric(testMetricDef);
     expect(metric.roundValue(123.15)).toBe(123.2);
@@ -137,5 +145,25 @@ describe("Metric", () => {
     expect(() => {
       metric.getCategory("none");
     }).toThrow("No matching");
+  });
+
+  test("getColor() on metric with categories", () => {
+    const metric = new Metric({
+      ...testMetricDef,
+      categories: testCategories,
+    });
+    expect(metric.getColor("no")).toStrictEqual(testCategories[0].color);
+  });
+
+  test("getColor() on metric with thresholds", () => {
+    const metric = new Metric(
+      {
+        ...testMetricDef,
+        thresholds: [10, 20],
+      },
+      testCatalogOptions
+    );
+    expect(metric.getColor(5)).toBe(testLevelSet.levels[0].color);
+    expect(metric.getColor(null)).toBe(testLevelSet.defaultLevel.color);
   });
 });

--- a/packages/metrics/src/Metric/Metric.ts
+++ b/packages/metrics/src/Metric/Metric.ts
@@ -1,7 +1,7 @@
 import last from "lodash/last";
 import isEqual from "lodash/isEqual";
 
-import { assert } from "@actnowcoalition/assert";
+import { assert, fail } from "@actnowcoalition/assert";
 import { isFinite } from "@actnowcoalition/number-format";
 
 import { MetricDataReference } from "./MetricDataReference";
@@ -174,7 +174,9 @@ export class Metric {
    * @returns The formatted value.
    */
   formatValue(value: unknown, nullValueCopy = ""): string {
-    if (typeof value === "string") {
+    if (this.categories) {
+      return this.getCategory(value).label;
+    } else if (typeof value === "string") {
       return value;
     } else if (!isFinite(value)) {
       return nullValueCopy;
@@ -202,6 +204,23 @@ export class Metric {
       decimalPlaces += 2;
     }
     return Number(value.toFixed(decimalPlaces));
+  }
+
+  /**
+   * Looks up the color to use for the specified value either using the defined
+   * metric categories or metric thresholds.
+   *
+   * @param value Value to get color for.
+   * @returns Color to use for value.
+   */
+  getColor(value: unknown): string {
+    if (this.categories) {
+      return this.getCategory(value).color;
+    } else if (this.thresholds) {
+      return this.getLevel(value).color;
+    } else {
+      fail("Can only color metrics with thresholds or categories.");
+    }
   }
 
   /** Returns a string that helps identify this metric, e.g. for debugging purposes. */

--- a/packages/metrics/src/data/MetricData.ts
+++ b/packages/metrics/src/data/MetricData.ts
@@ -190,4 +190,13 @@ export class MetricData<T = unknown> {
   roundValue(): number | null {
     return this.metric.roundValue(this.currentValue);
   }
+
+  /**
+   * Uses this metric's grading logic or categories to color the `currentValue`.
+   *
+   * @returns The color associated with the metric's value.
+   */
+  getColor(): string {
+    return this.metric.getColor(this.currentValue);
+  }
 }


### PR DESCRIPTION
* Metric.getColor() (and MetricData.getColor()) will look up the correct color to use for the metric value using the defined thresholds or categories.
* I also extended Metric.formatValue() to handle metrics with categories.