### PR TITLE
Setup `MetricCatalogProvider` and `useMetricContext` hook

### DIFF
--- a/packages/ui-components/.storybook/preview.tsx
+++ b/packages/ui-components/.storybook/preview.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
+import { MetricCatalogProvider } from "../src/components/MetricCatalogContext";
+import { metricCatalog } from "../src/stories/mockMetricCatalog";
 import { theme } from "../src/styles";
 
 // Wraps stories with the MUI Theme provider
@@ -9,6 +11,12 @@ const themeDecorator = (Story) => (
     <CssBaseline />
     <Story />
   </ThemeProvider>
+);
+
+const metricCatalogDecorator = (Story) => (
+  <MetricCatalogProvider metricCatalog={metricCatalog}>
+    <Story />
+  </MetricCatalogProvider>
 );
 
 export const parameters = {
@@ -27,4 +35,4 @@ export const parameters = {
   },
 };
 
-export const decorators = [themeDecorator];
+export const decorators = [themeDecorator, metricCatalogDecorator];

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
@@ -4,13 +4,6 @@ import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 import { useMetricCatalog } from "./MetricCatalogContext";
 
-/**
- * Example of a metric-aware component
- *
- * @param metric
- * @param region
- * @returns React.ReactNode
- */
 const MetricAwareDemo: React.FC<{
   metric: Metric | string;
   region: Region;

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Stack, Typography } from "@mui/material";
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+import { useMetricCatalog } from "./MetricCatalogContext";
+
+/**
+ * Example of a metric-aware component
+ *
+ * @param metric
+ * @param region
+ * @returns React.ReactNode
+ */
+const MetricAwareDemo: React.FC<{
+  metric: Metric | string;
+  region: Region;
+}> = ({ metric: metricOrId, region }) => {
+  // Access the metric catalog from the context
+  const metricCatalog = useMetricCatalog();
+
+  // Metric instance from the catalog (or from the props)
+  const metric =
+    typeof metricOrId === "string"
+      ? metricCatalog.getMetric(metricOrId)
+      : metricOrId;
+
+  // Get data from the metric catalog
+  const { data, error } = metricCatalog.useData(region, metric);
+
+  // The component needs to handle error and loading states
+  if (error || !data) {
+    return <>{error ? `${error}` : "..."}</>;
+  }
+
+  return (
+    <Stack sx={{ p: 2, backgroundColor: "#fafafa", borderRadius: 0.5 }}>
+      <Typography variant="labelLarge">{metric.name}</Typography>
+      <Typography variant="dataEmphasizedLarge">
+        {metric.formatValue(data.currentValue)}
+      </Typography>
+      <Typography variant="paragraphSmall">{metric.extendedName}</Typography>
+    </Stack>
+  );
+};
+
+export default MetricAwareDemo;

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -10,8 +10,10 @@ export default {
   component: MetricCatalogProvider,
 } as ComponentMeta<typeof MetricCatalogProvider>;
 
-// Storybook already has a decorator with a MetricCatalogProvider, this one
-// is provided as usage example.
+// Storybook already has a decorator which wraps each story on a
+// `MetricCatalogProvider`, this one is provided as usage example and to
+// confirm that the hook uses the value of the closest `MetricCatalogProvider`
+// ancestor.
 const Template: ComponentStory<typeof MetricCatalogProvider> = (args) => (
   <MetricCatalogProvider metricCatalog={metricCatalogB}>
     {args.children}

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { states } from "@actnowcoalition/regions";
+import { MetricCatalog, MetricDefinition } from "@actnowcoalition/metrics";
 import { MetricCatalogProvider } from "./MetricCatalogContext";
-import { metricCatalogB, MetricId } from "../../stories/mockMetricCatalog";
+import { MetricId, dataProviders } from "../../stories/mockMetricCatalog";
 import MetricAwareDemo from "./MetricAwareDemo";
 
 export default {
@@ -10,12 +11,35 @@ export default {
   component: MetricCatalogProvider,
 } as ComponentMeta<typeof MetricCatalogProvider>;
 
-// Storybook already has a decorator which wraps each story on a
-// `MetricCatalogProvider`, this one is provided as usage example and to
-// confirm that the hook uses the value of the closest `MetricCatalogProvider`
-// ancestor.
+// Setting up a custom metricCatalog to confirm that the MetricCatalogProvider
+// closets to the component using the hook prevails.
+const metricDefs: MetricDefinition[] = [
+  {
+    id: MetricId.PI,
+    name: "Pi",
+    extendedName:
+      "Pi - The ratio of a circle's circumference to its diameter (should be formatted as 3.1)",
+    dataReference: {
+      providerId: "static",
+      value: Math.PI,
+    },
+    formatOptions: { maximumSignificantDigits: 2 },
+  },
+  {
+    id: MetricId.MOCK_CASES,
+    name: "Cases Per 100k (mock)",
+    extendedName: "Cases per 100k population (using mock data)",
+    dataReference: {
+      providerId: "mock",
+      startDate: "2020-01-01",
+    },
+  },
+];
+
+const metricCatalog = new MetricCatalog(metricDefs, dataProviders);
+
 const Template: ComponentStory<typeof MetricCatalogProvider> = (args) => (
-  <MetricCatalogProvider metricCatalog={metricCatalogB}>
+  <MetricCatalogProvider metricCatalog={metricCatalog}>
     {args.children}
   </MetricCatalogProvider>
 );

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -34,6 +34,9 @@ Static.args = {
   children: <MetricAwareDemo metric={MetricId.PI} region={washingtonState} />,
 };
 
+// This story is not directly wrapped on MetricCatalogProvider, so is
+// using the MetricCatalogProvider setup as a decorator in
+// .storybook/preview.tsx
 export const UsingDecorator = () => (
   <MetricAwareDemo metric={MetricId.PI} region={washingtonState} />
 );

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { states } from "@actnowcoalition/regions";
+import { MetricCatalogProvider } from "./MetricCatalogContext";
+import { metricCatalogB, MetricId } from "../../stories/mockMetricCatalog";
+import MetricAwareDemo from "./MetricAwareDemo";
+
+export default {
+  title: "Components/MetricCatalogContext",
+  component: MetricCatalogProvider,
+} as ComponentMeta<typeof MetricCatalogProvider>;
+
+// Storybook already has a decorator with a MetricCatalogProvider, this one
+// is provided as usage example.
+const Template: ComponentStory<typeof MetricCatalogProvider> = (args) => (
+  <MetricCatalogProvider metricCatalog={metricCatalogB}>
+    {args.children}
+  </MetricCatalogProvider>
+);
+
+const washingtonState = states.findByRegionIdStrict("53");
+
+export const Mock = Template.bind({});
+Mock.args = {
+  children: (
+    <MetricAwareDemo metric={MetricId.MOCK_CASES} region={washingtonState} />
+  ),
+};
+
+export const Static = Template.bind({});
+Static.args = {
+  children: <MetricAwareDemo metric={MetricId.PI} region={washingtonState} />,
+};
+
+export const UsingDecorator = () => (
+  <MetricAwareDemo metric={MetricId.PI} region={washingtonState} />
+);

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
@@ -1,0 +1,68 @@
+import { MetricCatalog } from "@actnowcoalition/metrics";
+import React, { createContext, useContext } from "react";
+
+const defaultMetricCatalog = new MetricCatalog([], []);
+
+const MetricCatalogContext = createContext<MetricCatalog>(defaultMetricCatalog);
+
+/**
+ * The `MetricCatalogProvider` component and `useMetricCatalog` hook provide
+ * convenient  access to the app-level `metricCatalog` instance. It relies on
+ * React context, so make sure that `MetricCatalogProvider` is a parent of
+ * the component that calls `useMetricCatalog`.
+ *
+ * The best way to do this in Next.js applications is to wrap the page
+ * component in _app.tsx.
+ *
+ * @example
+ * ```tsx
+ * // _app.tsx
+ * import { metricCatalog } from "src/common/metrics"
+ *
+ * // ...
+ * <ThemeProvider theme={theme}>
+ *   <MetricCatalogProvider metricCatalog={metricCatalog}>
+ *     <Component {...pageProps} />
+ *   </MetricCatalog>
+ * </ThemeProvider>
+ * ```
+ *
+ * Any component that wants to use the metric catalog will usually need to have
+ * one or more metrics (or metric IDs) and regions as props, and then use the
+ * `useMetricCatalog` hook to fetch the data.
+ *
+ * @example
+ * ```tsx
+ * interface MetricAwareProps {
+ *   region: Region;
+ *   metrics: Metric[];
+ * };
+ *
+ * const MetricAware: React.FC<MetricAwareProps> = ({ region, metrics }) => {
+ *    const metricCatalog = useMetricCatalog();
+ *    const { data, error } = metricCatalog.useDataForMetrics(region, metrics);
+ *   // ...render component
+ * ```
+ *
+ * @param metricCatalog The MetricCatalog instance that we want to make available.
+ * @param children The component tree that we want to have access to the metric catalog.
+ * @returns React.ContextProvider with the given metricCatalog
+ */
+export const MetricCatalogProvider: React.FC<{
+  metricCatalog: MetricCatalog;
+  children: React.ReactNode;
+}> = ({ metricCatalog, children }) => (
+  <MetricCatalogContext.Provider value={metricCatalog}>
+    {children}
+  </MetricCatalogContext.Provider>
+);
+
+/**
+ * Hook to access the app-level MetricCatalog. See MetricCatalogProvider for
+ * usage examples.
+ *
+ * @returns MetricCatalog instance.
+ */
+export function useMetricCatalog() {
+  return useContext(MetricCatalogContext);
+}

--- a/packages/ui-components/src/components/MetricCatalogContext/index.ts
+++ b/packages/ui-components/src/components/MetricCatalogContext/index.ts
@@ -1,4 +1,1 @@
-export {
-  MetricCatalogProvider,
-  useMetricCatalog,
-} from "./MetricCatalogContext";
+export * from "./MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricCatalogContext/index.ts
+++ b/packages/ui-components/src/components/MetricCatalogContext/index.ts
@@ -1,0 +1,4 @@
+export {
+  MetricCatalogProvider,
+  useMetricCatalog,
+} from "./MetricCatalogContext";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -91,3 +91,5 @@ export type { AxisLeftProps, AxisBottomProps } from "./components/Axis";
 // export { default as Markdown } from "./components/Markdown";
 // Note (8/29/22) - Same problem with d3-geo, commenting out until fixed.
 // export { default as USNationalMap } from "./components/USNationalMap";
+
+export { default as MetricCatalogContext } from "./components/MetricCatalogContext";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -92,4 +92,7 @@ export type { AxisLeftProps, AxisBottomProps } from "./components/Axis";
 // Note (8/29/22) - Same problem with d3-geo, commenting out until fixed.
 // export { default as USNationalMap } from "./components/USNationalMap";
 
-export { default as MetricCatalogContext } from "./components/MetricCatalogContext";
+export {
+  MetricCatalogProvider,
+  useMetricCatalog,
+} from "./components/MetricCatalogContext";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -87,12 +87,8 @@ export type { ProgressBarProps } from "./components/ProgressBar";
 export { default as RegionSearch } from "./components/RegionSearch";
 export { AxisLeft, AxisBottom } from "./components/Axis";
 export type { AxisLeftProps, AxisBottomProps } from "./components/Axis";
+export * from "./components/MetricCatalogContext";
 // Note (8/10/22) - Markdown is causing a bug. Commenting it out until fixed.
 // export { default as Markdown } from "./components/Markdown";
 // Note (8/29/22) - Same problem with d3-geo, commenting out until fixed.
 // export { default as USNationalMap } from "./components/USNationalMap";
-
-export {
-  MetricCatalogProvider,
-  useMetricCatalog,
-} from "./components/MetricCatalogContext";

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -1,0 +1,62 @@
+import {
+  MetricDefinition,
+  MetricCatalog,
+  MockDataProvider,
+  StaticValueDataProvider,
+} from "@actnowcoalition/metrics";
+
+export enum MetricId {
+  PI = "pi",
+  MOCK_CASES = "mock_cases",
+}
+
+const testMetricDefs: MetricDefinition[] = [
+  {
+    id: MetricId.PI,
+    name: "Pi",
+    extendedName: "Pi - The ratio of a circle's circumference to its diameter",
+    dataReference: {
+      providerId: "static",
+      value: 3.141592653589793,
+    },
+    formatOptions: { minimumFractionDigits: 5 },
+  },
+  {
+    id: MetricId.MOCK_CASES,
+    name: "Cases Per 100k (mock)",
+    extendedName: "Cases per 100k population (using mock data)",
+    dataReference: {
+      providerId: "mock",
+      startDate: "2020-01-01",
+    },
+  },
+];
+
+const dataProviders = [new MockDataProvider(), new StaticValueDataProvider()];
+export const metricCatalog = new MetricCatalog(testMetricDefs, dataProviders);
+
+// Exporting a second metric catalog to confirm that the closest
+// MetricCatalocProvider instance is used
+const metricDefsB: MetricDefinition[] = [
+  {
+    id: MetricId.PI,
+    name: "Pi",
+    extendedName: "Pi - The ratio of a circle's circumference to its diameter",
+    dataReference: {
+      providerId: "static",
+      value: 2,
+    },
+    formatOptions: { minimumFractionDigits: 2 },
+  },
+  {
+    id: MetricId.MOCK_CASES,
+    name: "Cases Per 100k (mock)",
+    extendedName: "Cases per 100k population (using mock data)",
+    dataReference: {
+      providerId: "mock",
+      startDate: "2020-01-01",
+    },
+  },
+];
+
+export const metricCatalogB = new MetricCatalog(metricDefsB, dataProviders);

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -19,7 +19,6 @@ const testMetricDefs: MetricDefinition[] = [
       providerId: "static",
       value: 3.141592653589793,
     },
-    formatOptions: { minimumFractionDigits: 5 },
   },
   {
     id: MetricId.MOCK_CASES,
@@ -32,7 +31,10 @@ const testMetricDefs: MetricDefinition[] = [
   },
 ];
 
-const dataProviders = [new MockDataProvider(), new StaticValueDataProvider()];
+export const dataProviders = [
+  new MockDataProvider(),
+  new StaticValueDataProvider(),
+];
 export const metricCatalog = new MetricCatalog(testMetricDefs, dataProviders);
 
 // Exporting a second metric catalog to confirm that the closest

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -44,7 +44,7 @@ const metricDefsB: MetricDefinition[] = [
     extendedName: "Pi - The ratio of a circle's circumference to its diameter",
     dataReference: {
       providerId: "static",
-      value: 2,
+      value: Math.PI,
     },
     formatOptions: { minimumFractionDigits: 2 },
   },


### PR DESCRIPTION
Implements the `MetricCatalogProvider` component and corresponding `useMetricContext` hook. I added some stories to demonstrate how to use the provider and hook, and added a decorator so the metric catalog context is available for Storybook.