### PR TITLE
use context theme for legend threshold tick labels

### DIFF
--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.style.ts
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.style.ts
@@ -2,11 +2,13 @@ import { styled } from "../../styles";
 import isValidProp from "@emotion/is-prop-valid";
 import { css } from "@emotion/react";
 
-// TODO: Typography should be "paragraph.small", update once we update the theme.
 export const TickLabel = styled("text")`
   text-anchor: middle;
   dominant-baseline: hanging;
-  fill: ${({ theme }) => theme.palette.text.primary};
+  fill: ${({ theme }) => theme.typography.paragraphSmall.color};
+  font-family: ${({ theme }) => theme.typography.paragraphSmall.fontFamily};
+  font-size: ${({ theme }) => theme.typography.paragraphSmall.fontSize};
+  font-weight: ${({ theme }) => theme.typography.paragraphSmall.fontWeight};
 `;
 
 export const TickMark = styled("line")`


### PR DESCRIPTION
Now that the typography types are fixed, we can use the `paragraphSmall` typography variables to style the tick labels for `LegendThreshold`