### PR TITLE
Implement `LabelIcon` component

### DIFF
--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
+import LabelIcon from ".";
+
+export default {
+  title: "Components/LabelIcon",
+  component: LabelIcon,
+} as ComponentMeta<typeof LabelIcon>;
+
+const Template: ComponentStory<typeof LabelIcon> = (args) => (
+  <div style={{ width: 300 }}>
+    <LabelIcon {...args} />
+  </div>
+);
+
+export const Example = Template.bind({});
+Example.args = { children: "Weekly new cases" };
+
+export const LongName = Template.bind({});
+LongName.args = { children: "Super long metric name to test text wrapping" };
+
+export const Custom = Template.bind({});
+Custom.args = {
+  children: "Learn more",
+  color: "primary",
+  variant: "labelSmall",
+  endIcon: <LibraryBooksIcon fontSize="small" color="inherit" />,
+};

--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Stack, Typography, TypographyProps } from "@mui/material";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+
+const LabelIcon: React.FC<TypographyProps & { endIcon?: React.ReactNode }> = ({
+  endIcon = <ArrowForwardIcon fontSize="small" color="inherit" />,
+  children,
+  variant = "labelLarge",
+  ...otherTypographyProps
+}) => {
+  return (
+    <Typography variant={variant} {...otherTypographyProps}>
+      <Stack direction="row" spacing={1} alignItems="center">
+        <span>{children}</span>
+        {endIcon}
+      </Stack>
+    </Typography>
+  );
+};
+
+export default LabelIcon;

--- a/packages/ui-components/src/components/LabelIcon/index.ts
+++ b/packages/ui-components/src/components/LabelIcon/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LabelIcon";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -89,3 +89,5 @@ export { AxisLeft, AxisBottom } from "./components/Axis";
 export type { AxisLeftProps, AxisBottomProps } from "./components/Axis";
 export { default as Markdown } from "./components/Markdown";
 export { default as USNationalMap } from "./components/USNationalMap";
+
+export { default as LabelIcon } from "./components/LabelIcon";


### PR DESCRIPTION
Close #105 

I made the component a bit more versatile, it accepts any typography `variant` and `endIcon` with `labelLarge` and the arrow forward icon respectively.

![image](https://user-images.githubusercontent.com/114084/187570751-3ffdf1b3-37d2-497b-93eb-d92c80a3346e.png)
