### PR TITLE
Implement MetricDot component

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/ui-components",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "UI components for Act Now",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@actnowcoalition/metrics": "^0.0.7",
+    "@actnowcoalition/metrics": "^0.0.10",
     "@actnowcoalition/number-format": "^1.1.1",
     "@actnowcoalition/regions": "^1.3.0",
     "@emotion/react": "^11.9.3",

--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { Stack, Typography, TypographyProps } from "@mui/material";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 
-const LabelIcon: React.FC<TypographyProps & { endIcon?: React.ReactNode }> = ({
+export interface LabelIconProps extends TypographyProps {
+  /** Icon to show at the end of the label (ArrowForward by default) */
+  endIcon?: React.ReactNode;
+}
+
+const LabelIcon: React.FC<LabelIconProps> = ({
   endIcon = <ArrowForwardIcon fontSize="small" color="inherit" />,
   children,
   variant = "labelLarge",

--- a/packages/ui-components/src/components/LabelIcon/index.ts
+++ b/packages/ui-components/src/components/LabelIcon/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./LabelIcon";
+export type { LabelIconProps } from "./LabelIcon";

--- a/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import MetricDot from ".";
+import { states } from "@actnowcoalition/regions";
+import { MetricId } from "../../stories/mockMetricCatalog";
+
+export default {
+  title: "Metrics/MetricDot",
+  component: MetricDot,
+} as ComponentMeta<typeof MetricDot>;
+
+const Template: ComponentStory<typeof MetricDot> = (args) => (
+  <MetricDot {...args} />
+);
+
+const washingtonState = states.findByRegionIdStrict("53");
+
+export const MetricWithLevels = Template.bind({});
+MetricWithLevels.args = {
+  metric: MetricId.MOCK_CASES,
+  region: washingtonState,
+};
+
+export const MetricWithoutLevels = Template.bind({});
+MetricWithoutLevels.args = {
+  metric: MetricId.PI,
+  region: washingtonState,
+};

--- a/packages/ui-components/src/components/MetricDot/MetricDot.style.ts
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.style.ts
@@ -1,0 +1,16 @@
+import { styled } from "../../styles";
+
+export const Dot = styled("div")`
+  height: ${({ theme }) => theme.spacing(1)};
+  width: ${({ theme }) => theme.spacing(1)};
+  border-radius: 50%;
+`;
+
+/**
+ * The PlaceholderDot is used to keep spacing consistent as metric data is
+ * loaded, or when metrics without levels are shown alongside metrics with
+ * levels.
+ */
+export const PlaceholderDot = styled(Dot)`
+  background-color: transparent;
+`;

--- a/packages/ui-components/src/components/MetricDot/MetricDot.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Region } from "@actnowcoalition/regions";
+import { Metric } from "@actnowcoalition/metrics";
+import { useMetricCatalog } from "../MetricCatalogContext";
+import { Dot, PlaceholderDot } from "./MetricDot.style";
+
+export interface MetricDotProps {
+  /** Region for which we want to represent the current level */
+  region: Region;
+  /** Metric for which we want to represent the current level */
+  metric: Metric | string;
+}
+
+/**
+ * The MetricDot component shows a colored dot that represents current level
+ * or category for a given metric and region. The component is still rendered
+ * for metrics that don't have levels or categories to keep spacing and
+ * alignment consistent across metrics.
+ */
+const MetricDot: React.FC<MetricDotProps> = ({
+  region,
+  metric: metricOrId,
+}) => {
+  const metricCatalog = useMetricCatalog();
+  // TODO: Maybe add a method to the metricCatalog?
+  const metric =
+    typeof metricOrId === "string"
+      ? metricCatalog.getMetric(metricOrId)
+      : metricOrId;
+
+  if (!metric.levelSet || !metric.categories) {
+    return <PlaceholderDot />;
+  }
+
+  const { data, error } = metricCatalog.useData(region, metric);
+  if (error || !data) {
+    return <PlaceholderDot />;
+  }
+
+  // TODO: Find out accessibility best practices for this component
+  const color = metric.getColor(data.currentValue);
+  return <Dot style={{ backgroundColor: color }} />;
+};
+
+export default MetricDot;

--- a/packages/ui-components/src/components/MetricDot/MetricDot.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.tsx
@@ -28,7 +28,7 @@ const MetricDot: React.FC<MetricDotProps> = ({
       ? metricCatalog.getMetric(metricOrId)
       : metricOrId;
 
-  if (!metric.levelSet || !metric.categories) {
+  if (!(metric.levelSet || metric.categories)) {
     return <PlaceholderDot />;
   }
 
@@ -38,8 +38,8 @@ const MetricDot: React.FC<MetricDotProps> = ({
   }
 
   // TODO: Find out accessibility best practices for this component
-  const color = metric.getColor(data.currentValue);
-  return <Dot style={{ backgroundColor: color }} />;
+  const backgroundColor = metric.getColor(data.currentValue);
+  return <Dot style={{ backgroundColor }} />;
 };
 
 export default MetricDot;

--- a/packages/ui-components/src/components/MetricDot/MetricDot.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.tsx
@@ -12,7 +12,7 @@ export interface MetricDotProps {
 }
 
 /**
- * The MetricDot component shows a colored dot that represents current level
+ * The MetricDot component shows a colored dot that represents the current level
  * or category for a given metric and region. The component is still rendered
  * for metrics that don't have levels or categories to keep spacing and
  * alignment consistent across metrics.

--- a/packages/ui-components/src/components/MetricDot/index.ts
+++ b/packages/ui-components/src/components/MetricDot/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./MetricDot";
+export type { MetricDotProps } from "./MetricDot";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -93,3 +93,7 @@ export { default as Markdown } from "./components/Markdown";
 export { default as USNationalMap } from "./components/USNationalMap";
 
 export { default as LabelIcon } from "./components/LabelIcon";
+export type { LabelIconProps } from "./components/LabelIcon";
+
+export { default as MetricDot } from "./components/MetricDot";
+export type { MetricDotProps } from "./components/MetricDot";

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -43,9 +43,9 @@ const metricLevelSets = [
   {
     id: "cases_mock",
     levels: [
-      { id: "low", color: theme.palette.severity[100] },
-      { id: "medium", color: theme.palette.severity[200] },
-      { id: "high", color: theme.palette.severity[500] },
+      { id: "low", name: "low", color: theme.palette.severity[100] },
+      { id: "medium", name: "medium", color: theme.palette.severity[200] },
+      { id: "high", name: "high", color: theme.palette.severity[500] },
     ],
     defaultLevel: { id: "unknown", color: theme.palette.border.default },
   },

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -4,6 +4,7 @@ import {
   MockDataProvider,
   StaticValueDataProvider,
 } from "@actnowcoalition/metrics";
+import { theme } from "../styles";
 
 export enum MetricId {
   PI = "pi",
@@ -28,6 +29,8 @@ const testMetricDefs: MetricDefinition[] = [
       providerId: "mock",
       startDate: "2020-01-01",
     },
+    thresholds: [10, 100],
+    levelSetId: "cases_mock",
   },
 ];
 
@@ -35,7 +38,22 @@ export const dataProviders = [
   new MockDataProvider(),
   new StaticValueDataProvider(),
 ];
-export const metricCatalog = new MetricCatalog(testMetricDefs, dataProviders);
+
+const metricLevelSets = [
+  {
+    id: "cases_mock",
+    levels: [
+      { id: "low", color: theme.palette.severity[100] },
+      { id: "medium", color: theme.palette.severity[200] },
+      { id: "high", color: theme.palette.severity[500] },
+    ],
+    defaultLevel: { id: "unknown", color: theme.palette.border.default },
+  },
+];
+
+export const metricCatalog = new MetricCatalog(testMetricDefs, dataProviders, {
+  metricLevelSets,
+});
 
 // Exporting a second metric catalog to confirm that the closest
 // MetricCatalocProvider instance is used

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -7,15 +7,15 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-1.0.1.tgz#a4c629a16279085abf7958f4a735a0c3b9aee848"
   integrity sha512-i4k08njxovn3m1jy1mYvCJJv7fLvSpsVwaiocNGB+WC8x44TOxsQuX8iQM62IMKXtu+/5uBIEgn+3QcbT2QLuw==
 
-"@actnowcoalition/metrics@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.0.7.tgz#7860cc3017739846b5db8ff70c89deadc76ca542"
-  integrity sha512-uOxGhcILqgIDireIyYmNwCV7f5G752QyAobaahlOLyMDC2qPOH4cX5ml/i7h3Y/DL6mPP7BDMHXPxBZNK8W14A==
+"@actnowcoalition/metrics@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.0.10.tgz#ff18d23b2f8bcd4ba7831f0a00ce819ca782f216"
+  integrity sha512-q0YynG1Fh7Vd0BGpUIPP1ZX1u/T1/dBqnon7Lwf1gSwL5hx/l3MpHf7Ewx0cDTItv9XicyLUKdvuLuQQ6/xEWA==
   dependencies:
     "@actnowcoalition/assert" "^1.0.0"
     "@actnowcoalition/number-format" "^1.1.1"
     "@actnowcoalition/regions" "^1.3.0"
-    "@actnowcoalition/time-utils" "^1.0.1"
+    "@actnowcoalition/time-utils" "^1.1.0"
     "@types/papaparse" "^5.3.3"
     lodash "^4.17.21"
     papaparse "^5.3.2"
@@ -33,10 +33,10 @@
     "@actnowcoalition/assert" "^1.0.0"
     lodash "^4.17.21"
 
-"@actnowcoalition/time-utils@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/time-utils/-/time-utils-1.0.1.tgz#4caf60c55764a73ec31be223cefee880568204b9"
-  integrity sha512-IKquf6m4tu4k6GUTWEvw8wL+sVRnyOOztXotEwM2WdCPNlHd4nPX3X1ZdVoOKPqdF7kIeplu1y7sFjhIpnmABA==
+"@actnowcoalition/time-utils@^1.1.0":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/time-utils/-/time-utils-1.1.2.tgz#c09a31e6828387b18dff636d653f362f5d581920"
+  integrity sha512-4aAF3S4EIBBM4Knm0/IF9l3ij7G8CIEMJx5N9VmCl4RHccFFIj4RPi0BTobDuK62J3zAiR5/SwVsfzsGdhw9Vw==
   dependencies:
     "@actnowcoalition/assert" "^1.0.0"
     "@types/luxon" "^2.3.2"


### PR DESCRIPTION
Close #121 

<img width="37" alt="image" src="https://user-images.githubusercontent.com/114084/187799822-1af88f22-90af-43f2-b34e-1a9da57af64c.png">

## Changes

- Implement MetricDot component
- Update @actnowcoalition/metrics to the latest version so we can use `metric.getColor`
- Drive-by: Declare and export the `LabelIconProps` interface

## Notes

- We need to do a bit of research before we make this component accessible, so punting on that for now.