### PR TITLE
Export MetricCategory

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/metrics",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Classes for representing metrics and loading metric data",
   "repository": {
     "type": "git",

--- a/packages/metrics/src/Metric/index.ts
+++ b/packages/metrics/src/Metric/index.ts
@@ -1,4 +1,5 @@
 export { Metric } from "./Metric";
 export type { MetricDataReference } from "./MetricDataReference";
 export type { MetricDefinition } from "./MetricDefinition";
+export type { MetricCategory } from "./MetricCategory";
 export type { MetricLevel, MetricLevelSet } from "./MetricLevel";


### PR DESCRIPTION
`MetricCategory` is needed in #131 but is not currently exported 