### PR TITLE
Implement `MetricOverview` component

### DIFF
--- a/packages/ui-components/.storybook/preview.tsx
+++ b/packages/ui-components/.storybook/preview.tsx
@@ -10,9 +10,6 @@ import { theme } from "../src/styles";
  * if they use different contexts. I noticed that if the ThemeProvider is the
  * outer provider, the styles for variant="paragraphSmall" on Typography are
  * not correctly applied.
- *
- * I combined both providers into one decorator to make the nesting order more
- * explicit.
  */
 const appDecorator = (Story) => (
   <MetricCatalogProvider metricCatalog={metricCatalog}>

--- a/packages/ui-components/.storybook/preview.tsx
+++ b/packages/ui-components/.storybook/preview.tsx
@@ -5,17 +5,21 @@ import { MetricCatalogProvider } from "../src/components/MetricCatalogContext";
 import { metricCatalog } from "../src/stories/mockMetricCatalog";
 import { theme } from "../src/styles";
 
-// Wraps stories with the MUI Theme provider
-const themeDecorator = (Story) => (
-  <ThemeProvider theme={theme}>
-    <CssBaseline />
-    <Story />
-  </ThemeProvider>
-);
-
-const metricCatalogDecorator = (Story) => (
+/**
+ * Note (Pablo): It seems that the order of the context providers matter, even
+ * if they use different contexts. I noticed that if the ThemeProvider is the
+ * outer provider, the styles for variant="paragraphSmall" on Typography are
+ * not correctly applied.
+ *
+ * I combined both providers into one decorator to make the nesting order more
+ * explicit.
+ */
+const appDecorator = (Story) => (
   <MetricCatalogProvider metricCatalog={metricCatalog}>
-    <Story />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Story />
+    </ThemeProvider>
   </MetricCatalogProvider>
 );
 
@@ -35,4 +39,4 @@ export const parameters = {
   },
 };
 
-export const decorators = [themeDecorator, metricCatalogDecorator];
+export const decorators = [appDecorator];

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/ui-components",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "UI components for Act Now",
   "repository": {
     "type": "git",

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Typography } from "@mui/material";
+import { states } from "@actnowcoalition/regions";
+import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
+import { MetricOverview } from ".";
+
+export default {
+  title: "Metrics/MetricOverview",
+  component: MetricOverview,
+} as ComponentMeta<typeof MetricOverview>;
+
+const Template: ComponentStory<typeof MetricOverview> = (args) => (
+  <div
+    style={{
+      width: args.orientation === "vertical" ? 160 : 320,
+      border: "dashed 1px #eee",
+    }}
+  >
+    <MetricOverview {...args} />
+  </div>
+);
+
+const ChartPlaceholder = () => (
+  <div
+    style={{
+      backgroundColor: "#eee",
+      borderRadius: 4,
+      display: "grid",
+      placeItems: "center",
+      textTransform: "uppercase",
+      minHeight: 72,
+    }}
+  >
+    <Typography variant="overline">placeholder</Typography>
+  </div>
+);
+
+const metricCases = metricCatalog.getMetric(MetricId.MOCK_CASES);
+const newYorkState = states.findByRegionIdStrict("36");
+
+export const DefaultProps = Template.bind({});
+DefaultProps.args = {
+  region: newYorkState,
+  metric: MetricId.MOCK_CASES,
+};
+
+export const WithSupportingText = Template.bind({});
+WithSupportingText.args = {
+  region: newYorkState,
+  metric: MetricId.MOCK_CASES,
+  supportingText: metricCases.extendedName,
+};
+
+export const VerticalWithChart = Template.bind({});
+VerticalWithChart.args = {
+  region: newYorkState,
+  metric: MetricId.MOCK_CASES,
+  metricChart: <ChartPlaceholder />,
+  supportingText: metricCases.extendedName,
+};
+
+export const DefaultHorizontal = Template.bind({});
+DefaultHorizontal.args = {
+  region: newYorkState,
+  metric: MetricId.MOCK_CASES,
+  orientation: "horizontal",
+};
+
+export const HorizontalWithSupportingText = Template.bind({});
+HorizontalWithSupportingText.args = {
+  region: newYorkState,
+  metric: MetricId.MOCK_CASES,
+  supportingText: metricCases.extendedName,
+  orientation: "horizontal",
+};

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.style.ts
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.style.ts
@@ -1,3 +1,0 @@
-import { styled } from "../../styles";
-
-export const Container = styled("div")``;

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.style.ts
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.style.ts
@@ -1,0 +1,3 @@
+import { styled } from "../../styles";
+
+export const Container = styled("div")``;

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Stack, Typography } from "@mui/material";
+import { Region } from "@actnowcoalition/regions";
+import { Metric } from "@actnowcoalition/metrics";
+import { useMetricCatalog } from "../MetricCatalogContext";
+import { LabelIcon } from "../LabelIcon";
+import { MetricValue } from "../MetricValue";
+
+export interface MetricOverviewProps {
+  /** Region for which we want to show the metric overview */
+  region: Region;
+  /** Metric for which we want to show the metric overview */
+  metric: Metric | string;
+  /** Optional supporting text for the metric */
+  supportingText?: string;
+  /** Optional metricChart. It only renders if orientation="vertical" */
+  metricChart?: React.ReactNode;
+  /**
+   * Orientation of the component. The metricChart only renders if
+   * orientation="vertical"
+   */
+  orientation?: "horizontal" | "vertical";
+}
+
+export const MetricOverview: React.FC<MetricOverviewProps> = ({
+  region,
+  metric: metricOrId,
+  metricChart,
+  supportingText,
+  orientation = "vertical",
+}) => {
+  const metricCatalog = useMetricCatalog();
+  const metric = metricCatalog.getMetric(metricOrId);
+
+  if (orientation === "vertical") {
+    return (
+      <Stack direction="column" spacing={1}>
+        <LabelIcon>{metric.name}</LabelIcon>
+        <MetricValue region={region} metric={metric} />
+        {metricChart}
+        {supportingText && (
+          <Typography variant="paragraphSmall">{supportingText}</Typography>
+        )}
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack direction="column" spacing={0.5}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <LabelIcon>{metric.name}</LabelIcon>
+        <MetricValue
+          variant="dataEmphasizedSmall"
+          region={region}
+          metric={metric}
+        />
+      </Stack>
+      {supportingText && (
+        <Typography variant="paragraphSmall">{supportingText}</Typography>
+      )}
+    </Stack>
+  );
+};

--- a/packages/ui-components/src/components/MetricOverview/index.ts
+++ b/packages/ui-components/src/components/MetricOverview/index.ts
@@ -1,0 +1,1 @@
+export * from "./MetricOverview";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -86,6 +86,7 @@ export * from "./components/Markdown";
 export * from "./components/MetricCatalogContext";
 export * from "./components/MetricDot";
 export * from "./components/MetricLegendCategorical";
+export * from "./components/MetricOverview";
 export * from "./components/MetricValue";
 export * from "./components/ProgressBar";
 export * from "./components/RegionSearch";


### PR DESCRIPTION
Close #95 - Implement MetricOverview component

**Vertical**

<img width="335" alt="image" src="https://user-images.githubusercontent.com/114084/188022980-65e97072-8701-4568-bfb5-0b5992c69dc5.png">


**Horizontal**

<img width="336" alt="image" src="https://user-images.githubusercontent.com/114084/188023004-ac8c606f-c2a2-416a-aa89-d9a5a2c42931.png">

## Notes

- The styling for paragraphSmall was not being applied correctly, I added a note in `.storybook/preview.tsx` (it seems that the order of the decorators matters, even if they don't use the same context)
- I added the prop `orientation` to the component so we can use version both on mobile or desktop (instead of assuming that we will always want horizontal on mobile).