### PR TITLE
Prototype: BaseTable with row and column pinning

### DIFF
--- a/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
@@ -29,6 +29,7 @@ const Template: Story<BaseTableProps<Row>> = (args) => (
 const rows: Row[] = states.all.map((region: Region) => ({ region }));
 
 const columnName: ColumnDefinition<Row> = {
+  id: "name",
   name: "Name",
   rows,
   sticky: true,
@@ -45,6 +46,7 @@ const columnName: ColumnDefinition<Row> = {
 };
 
 const columnPopulation: ColumnDefinition<Row> = {
+  id: "population",
   name: "Population",
   rows,
   renderHeader: ({ column }) => (

--- a/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
 import { Region, states } from "@actnowcoalition/regions";
 import { BaseTable, BaseTableColumn, BaseTableProps } from ".";
+import { TableCellHead, TableCell } from "./BaseTable.style";
 
 export default {
   title: "Components/BaseTable",
@@ -31,15 +32,29 @@ const columnName: BaseTableColumn<Row> = {
   name: "Name",
   rows,
   sticky: true,
-  renderCell: ({ row }) => <>{row.region.fullName}</>,
-  renderHeader: ({ column }) => <>{column.name}</>,
+  renderHeader: ({ column }) => (
+    <TableCellHead stickyRow={true} stickyColumn={column.sticky}>
+      {column.name}
+    </TableCellHead>
+  ),
+  renderCell: ({ row }) => (
+    <TableCell stickyColumn={columnName.sticky}>
+      {row.region.fullName}
+    </TableCell>
+  ),
 };
 
 const columnPopulation: BaseTableColumn<Row> = {
   name: "Population",
   rows,
-  renderCell: ({ row }) => <>{row.region.population}</>,
-  renderHeader: ({ column }) => <>{column.name}</>,
+  renderHeader: ({ column }) => (
+    <TableCellHead align="right" stickyRow={true} stickyColumn={column.sticky}>
+      {column.name}
+    </TableCellHead>
+  ),
+  renderCell: ({ row }) => (
+    <TableCell align="right">{row.region.population}</TableCell>
+  ),
 };
 
 const columns: BaseTableColumn<Row>[] = [

--- a/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
 import { Region, states } from "@actnowcoalition/regions";
-import { BaseTable, BaseTableColumn, BaseTableProps } from ".";
+import { BaseTable, ColumnDefinition, BaseTableProps } from ".";
 import { TableCellHead, TableCell } from "./BaseTable.style";
 
 export default {
@@ -28,7 +28,7 @@ const Template: Story<BaseTableProps<Row>> = (args) => (
 
 const rows: Row[] = states.all.map((region: Region) => ({ region }));
 
-const columnName: BaseTableColumn<Row> = {
+const columnName: ColumnDefinition<Row> = {
   name: "Name",
   rows,
   sticky: true,
@@ -44,7 +44,7 @@ const columnName: BaseTableColumn<Row> = {
   ),
 };
 
-const columnPopulation: BaseTableColumn<Row> = {
+const columnPopulation: ColumnDefinition<Row> = {
   name: "Population",
   rows,
   renderHeader: ({ column }) => (
@@ -57,7 +57,7 @@ const columnPopulation: BaseTableColumn<Row> = {
   ),
 };
 
-const columns: BaseTableColumn<Row>[] = [
+const columns: ColumnDefinition<Row>[] = [
   columnName,
   columnPopulation,
   columnPopulation,

--- a/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
@@ -13,7 +13,14 @@ interface Row {
 }
 
 const Template: Story<BaseTableProps<Row>> = (args) => (
-  <div style={{ width: 400, height: 400, overflow: "auto" }}>
+  <div
+    style={{
+      width: 400,
+      height: 400,
+      overflow: "auto",
+      border: "solid 1px #0969da",
+    }}
+  >
     <BaseTable<Row> {...args} />
   </div>
 );

--- a/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.stories.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Story, ComponentMeta } from "@storybook/react";
+import { Region, states } from "@actnowcoalition/regions";
+import { BaseTable, BaseTableColumn, BaseTableProps } from ".";
+
+export default {
+  title: "Components/BaseTable",
+  component: BaseTable,
+} as ComponentMeta<typeof BaseTable>;
+
+interface Row {
+  region: Region;
+}
+
+const Template: Story<BaseTableProps<Row>> = (args) => (
+  <div style={{ width: 400, height: 400, overflow: "auto" }}>
+    <BaseTable<Row> {...args} />
+  </div>
+);
+
+const rows: Row[] = states.all.map((region: Region) => ({ region }));
+
+const columnName: BaseTableColumn<Row> = {
+  name: "Name",
+  rows,
+  sticky: true,
+  renderCell: ({ row }) => <>{row.region.fullName}</>,
+  renderHeader: ({ column }) => <>{column.name}</>,
+};
+
+const columnPopulation: BaseTableColumn<Row> = {
+  name: "Population",
+  rows,
+  renderCell: ({ row }) => <>{row.region.population}</>,
+  renderHeader: ({ column }) => <>{column.name}</>,
+};
+
+const columns: BaseTableColumn<Row>[] = [
+  columnName,
+  columnPopulation,
+  columnPopulation,
+  columnPopulation,
+  columnPopulation,
+];
+
+export const Example = Template.bind({});
+Example.args = { rows, columns };

--- a/packages/ui-components/src/components/BaseTable/BaseTable.style.ts
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.style.ts
@@ -38,11 +38,20 @@ const cssStickyRowAndColumn = css`
   background-color: #eee;
 `;
 
-export const TableCell = styled(MuiTableCell)<{ stickyColumn?: boolean }>`
+const isStickyProp = (propName: string) =>
+  !["stickyRow", "stickyColumn"].includes(propName);
+
+export const TableCell = styled(MuiTableCell, {
+  shouldForwardProp: isStickyProp,
+})<{
+  stickyColumn?: boolean;
+}>`
   ${({ stickyColumn }) => (stickyColumn ? cssStickyColumn : null)}
 `;
 
-export const TableCellHead = styled(TableCell)<{
+export const TableCellHead = styled(TableCell, {
+  shouldForwardProp: isStickyProp,
+})<{
   stickyRow?: boolean;
   stickyColumn?: boolean;
 }>`

--- a/packages/ui-components/src/components/BaseTable/BaseTable.style.ts
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.style.ts
@@ -48,6 +48,7 @@ export const TableCell = styled(MuiTableCell, {
 export const TableCellHead = styled(TableCell, {
   shouldForwardProp: isValidProp,
 })<{ stickyRow?: boolean; stickyColumn?: boolean }>`
+  font-weight: ${({ theme }) => theme.typography.fontWeightBold};
   ${({ stickyRow }) => (stickyRow ? cssStickyRow : null)}
   ${({ stickyRow, stickyColumn }) =>
     stickyRow && stickyColumn ? cssStickyRowAndColumn : null}

--- a/packages/ui-components/src/components/BaseTable/BaseTable.style.ts
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.style.ts
@@ -1,4 +1,3 @@
-import isValidProp from "@emotion/is-prop-valid";
 import {
   Table as MuiTable,
   TableBody as MuiTableBody,
@@ -21,7 +20,7 @@ const cssStickyColumn = css`
   left: 0;
   position: sticky;
   z-index: 2;
-  background-color: #eee;
+  background-color: #fafafa;
 `;
 
 const cssStickyRow = css`
@@ -39,15 +38,14 @@ const cssStickyRowAndColumn = css`
   background-color: #eee;
 `;
 
-export const TableCell = styled(MuiTableCell, {
-  shouldForwardProp: isValidProp,
-})<{ stickyColumn?: boolean }>`
+export const TableCell = styled(MuiTableCell)<{ stickyColumn?: boolean }>`
   ${({ stickyColumn }) => (stickyColumn ? cssStickyColumn : null)}
 `;
 
-export const TableCellHead = styled(TableCell, {
-  shouldForwardProp: isValidProp,
-})<{ stickyRow?: boolean; stickyColumn?: boolean }>`
+export const TableCellHead = styled(TableCell)<{
+  stickyRow?: boolean;
+  stickyColumn?: boolean;
+}>`
   font-weight: ${({ theme }) => theme.typography.fontWeightBold};
   ${({ stickyRow }) => (stickyRow ? cssStickyRow : null)}
   ${({ stickyRow, stickyColumn }) =>

--- a/packages/ui-components/src/components/BaseTable/BaseTable.style.ts
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.style.ts
@@ -1,0 +1,54 @@
+import isValidProp from "@emotion/is-prop-valid";
+import {
+  Table as MuiTable,
+  TableBody as MuiTableBody,
+  TableCell as MuiTableCell,
+  TableHead as MuiTableHead,
+  TableRow as MuiTableRow,
+} from "@mui/material";
+import { css } from "@emotion/react";
+import { styled } from "../../styles";
+
+export const Table = styled(MuiTable)``;
+
+export const TableHead = styled(MuiTableHead)``;
+
+export const TableBody = styled(MuiTableBody)``;
+
+export const TableRow = styled(MuiTableRow)``;
+
+const cssStickyColumn = css`
+  left: 0;
+  position: sticky;
+  z-index: 2;
+  background-color: #eee;
+`;
+
+const cssStickyRow = css`
+  top: 0;
+  position: sticky;
+  background-color: #eee;
+  z-index: 1;
+`;
+
+const cssStickyRowAndColumn = css`
+  top: 0;
+  left: 0;
+  position: sticky;
+  z-index: 3;
+  background-color: #eee;
+`;
+
+export const TableCell = styled(MuiTableCell, {
+  shouldForwardProp: isValidProp,
+})<{ stickyColumn?: boolean }>`
+  ${({ stickyColumn }) => (stickyColumn ? cssStickyColumn : null)}
+`;
+
+export const TableCellHead = styled(TableCell, {
+  shouldForwardProp: isValidProp,
+})<{ stickyRow?: boolean; stickyColumn?: boolean }>`
+  ${({ stickyRow }) => (stickyRow ? cssStickyRow : null)}
+  ${({ stickyRow, stickyColumn }) =>
+    stickyRow && stickyColumn ? cssStickyRowAndColumn : null}
+`;

--- a/packages/ui-components/src/components/BaseTable/BaseTable.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Table, TableHead, TableBody, TableRow } from "@mui/material";
 import { TableProps as MuiTableProps } from "@mui/material";
 
-export interface BaseTableColumn<R> {
+export interface ColumnDefinition<R> {
   name: string;
   rows: R[];
   sticky?: boolean;
@@ -12,14 +12,14 @@ export interface BaseTableColumn<R> {
     columnIndex: number;
   }>;
   renderHeader: React.FC<{
-    column: BaseTableColumn<R>;
+    column: ColumnDefinition<R>;
     columnIndex: number;
   }>;
 }
 
 export interface BaseTableProps<R> extends MuiTableProps {
   rows: R[];
-  columns: BaseTableColumn<R>[];
+  columns: ColumnDefinition<R>[];
 }
 
 export const BaseTable = <R,>({ rows, columns }: BaseTableProps<R>) => {

--- a/packages/ui-components/src/components/BaseTable/BaseTable.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { TableProps as MuiTableProps } from "@mui/material";
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableCellHead,
+} from "./BaseTable.style";
+
+export interface BaseTableColumn<R> {
+  name: string;
+  rows: R[];
+  sticky?: boolean;
+  renderCell: React.FC<{
+    row: R;
+    rowIndex: number;
+    columnIndex: number;
+  }>;
+  renderHeader: React.FC<{
+    column: BaseTableColumn<R>;
+    columnIndex: number;
+  }>;
+}
+
+export interface BaseTableProps<R> extends MuiTableProps {
+  rows: R[];
+  columns: BaseTableColumn<R>[];
+}
+
+export const BaseTable = <R,>({ rows, columns }: BaseTableProps<R>) => {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          {columns.map((column, columnIndex) => (
+            <TableCellHead
+              key={`table-column-${columnIndex}`}
+              stickyRow={true}
+              stickyColumn={column.sticky}
+            >
+              {column.renderHeader({ column, columnIndex })}
+            </TableCellHead>
+          ))}
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {rows.map((row, rowIndex) => (
+          <TableRow key={`table-row-${rowIndex}`}>
+            {columns.map((column, columnIndex) => (
+              <TableCell
+                key={`table-cell-${rowIndex}-${columnIndex}`}
+                stickyColumn={column.sticky}
+              >
+                {column.renderCell({ row, rowIndex, columnIndex })}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};

--- a/packages/ui-components/src/components/BaseTable/BaseTable.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.tsx
@@ -1,13 +1,6 @@
 import React from "react";
+import { Table, TableHead, TableBody, TableRow } from "@mui/material";
 import { TableProps as MuiTableProps } from "@mui/material";
-import {
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableCell,
-  TableCellHead,
-} from "./BaseTable.style";
 
 export interface BaseTableColumn<R> {
   name: string;
@@ -35,13 +28,7 @@ export const BaseTable = <R,>({ rows, columns }: BaseTableProps<R>) => {
       <TableHead>
         <TableRow>
           {columns.map((column, columnIndex) => (
-            <TableCellHead
-              key={`table-column-${columnIndex}`}
-              stickyRow={true}
-              stickyColumn={column.sticky}
-            >
-              {column.renderHeader({ column, columnIndex })}
-            </TableCellHead>
+            <>{column.renderHeader({ column, columnIndex })}</>
           ))}
         </TableRow>
       </TableHead>
@@ -49,12 +36,7 @@ export const BaseTable = <R,>({ rows, columns }: BaseTableProps<R>) => {
         {rows.map((row, rowIndex) => (
           <TableRow key={`table-row-${rowIndex}`}>
             {columns.map((column, columnIndex) => (
-              <TableCell
-                key={`table-cell-${rowIndex}-${columnIndex}`}
-                stickyColumn={column.sticky}
-              >
-                {column.renderCell({ row, rowIndex, columnIndex })}
-              </TableCell>
+              <>{column.renderCell({ row, rowIndex, columnIndex })}</>
             ))}
           </TableRow>
         ))}

--- a/packages/ui-components/src/components/BaseTable/BaseTable.tsx
+++ b/packages/ui-components/src/components/BaseTable/BaseTable.tsx
@@ -3,6 +3,7 @@ import { Table, TableHead, TableBody, TableRow } from "@mui/material";
 import { TableProps as MuiTableProps } from "@mui/material";
 
 export interface ColumnDefinition<R> {
+  id: string;
   name: string;
   rows: R[];
   sticky?: boolean;

--- a/packages/ui-components/src/components/BaseTable/index.ts
+++ b/packages/ui-components/src/components/BaseTable/index.ts
@@ -1,0 +1,1 @@
+export * from "./BaseTable";

--- a/packages/ui-components/src/components/BaseTable/index.ts
+++ b/packages/ui-components/src/components/BaseTable/index.ts
@@ -1,1 +1,2 @@
 export * from "./BaseTable";
+export * from "./BaseTable.style";

--- a/packages/ui-components/src/components/MetricCompareTable/ColumnHeader.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/ColumnHeader.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Stack, Typography } from "@mui/material";
+import { ColumnHeaderCell } from "./MetricCompareTable.style";
+
+export interface ColumnHeaderProps
+  extends React.ComponentProps<typeof ColumnHeaderCell> {
+  columnTitle?: string;
+  supportingText?: string;
+}
+
+export const ColumnHeader: React.FC<ColumnHeaderProps> = ({
+  columnTitle,
+  supportingText,
+  ...otherHeaderProps
+}) => {
+  return (
+    <ColumnHeaderCell stickyRow align="right" {...otherHeaderProps}>
+      <Stack direction="column">
+        {columnTitle && (
+          <Typography variant="labelSmall">{columnTitle}</Typography>
+        )}
+        {supportingText && (
+          <Typography variant="paragraphSmall">{supportingText}</Typography>
+        )}
+      </Stack>
+    </ColumnHeaderCell>
+  );
+};

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -12,10 +12,10 @@ export default {
 const Template: ComponentStory<typeof MetricCompareTable> = (args) => (
   <div
     style={{
-      width: 400,
+      width: 600,
       height: 600,
       overflow: "auto",
-      border: "solid 1px solid 1px #0969da",
+      border: "solid 1px #0969da",
     }}
   >
     <MetricCompareTable {...args} />

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -25,5 +25,12 @@ const Template: ComponentStory<typeof MetricCompareTable> = (args) => (
 export const Example = Template.bind({});
 Example.args = {
   regions: states.all,
-  metrics: [MetricId.MOCK_CASES, MetricId.PI],
+  metrics: [
+    MetricId.MOCK_CASES,
+    MetricId.PI,
+    MetricId.MOCK_CASES,
+    MetricId.MOCK_CASES,
+    MetricId.MOCK_CASES,
+    MetricId.MOCK_CASES,
+  ],
 };

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { states } from "@actnowcoalition/regions";
+import { MetricId } from "../../stories/mockMetricCatalog";
+import { MetricCompareTable } from ".";
+
+export default {
+  title: "Metrics/MetricCompareTable",
+  component: MetricCompareTable,
+} as ComponentMeta<typeof MetricCompareTable>;
+
+const Template: ComponentStory<typeof MetricCompareTable> = (args) => (
+  <div
+    style={{
+      width: 400,
+      height: 600,
+      overflow: "auto",
+      border: "solid 1px solid 1px #0969da",
+    }}
+  >
+    <MetricCompareTable {...args} />
+  </div>
+);
+
+export const Example = Template.bind({});
+Example.args = {
+  regions: states.all,
+  metrics: [MetricId.MOCK_CASES, MetricId.PI],
+};

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
@@ -1,3 +1,14 @@
 import { styled } from "../../styles";
+import { TableCellHead, TableCell as BaseTableCell } from "../BaseTable";
 
-export const Container = styled("div")``;
+export const ColumnHeaderCell = styled(TableCellHead)`
+  font-weight: normal;
+  vertical-align: bottom;
+  background-color: ${({ theme }) => theme.palette.background.default};
+`;
+
+export const TableCell = styled(BaseTableCell)`
+  background-color: ${({ theme }) => theme.palette.background.default};
+  vertical-align: text-top;
+  padding: ${({ theme }) => theme.spacing(1.5)};
+`;

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
@@ -1,0 +1,3 @@
+import { styled } from "../../styles";
+
+export const Container = styled("div")``;

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { Region } from "@actnowcoalition/regions";
+import { Metric, MetricCatalog } from "@actnowcoalition/metrics";
+import { useMetricCatalog } from "../MetricCatalogContext";
+import {
+  BaseTable,
+  ColumnDefinition,
+  TableCell,
+  TableCellHead,
+} from "../BaseTable";
+import { MetricValue } from "../MetricValue";
+
+export interface MetricCompareTableProps {
+  regions: Region[];
+  metrics: (Metric | string)[];
+}
+
+export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
+  regions,
+  metrics: metricOrIds,
+}) => {
+  const metricCatalog = useMetricCatalog();
+
+  const metriColumns = metricOrIds.map((metricOrId) => {
+    const metric = metricCatalog.getMetric(metricOrId);
+    return getMetricColumn(metric, rows, metricCatalog);
+  });
+
+  const rows: Region[] = regions;
+  const columns: ColumnDefinition<Region>[] = [
+    {
+      name: "Region",
+      rows,
+      renderHeader: ({ column }) => (
+        <TableCellHead stickyRow stickyColumn>
+          {column.name}s
+        </TableCellHead>
+      ),
+      renderCell: ({ row }) => (
+        <TableCell stickyColumn>{row.fullName}</TableCell>
+      ),
+      sticky: true,
+    },
+    ...metriColumns,
+    ...metriColumns,
+  ];
+
+  return <BaseTable rows={regions} columns={columns} />;
+};
+
+function getMetricColumn(
+  metric: Metric,
+  rows: Region[],
+  metricCatalog: MetricCatalog
+): ColumnDefinition<Region> {
+  return {
+    name: metric.name,
+    rows,
+    renderHeader: ({ column }) => (
+      <TableCellHead stickyRow>{column.name}</TableCellHead>
+    ),
+    renderCell: ({ row }) => {
+      const { data, error } = metricCatalog.useData(row, metric);
+
+      if (error || !data) {
+        return <TableCell />;
+      }
+      return (
+        <TableCell align="right">
+          <MetricValue variant="dataTabular" region={row} metric={metric} />
+        </TableCell>
+      );
+    },
+  };
+}

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -67,7 +67,12 @@ function getMetricColumn(
       }
       return (
         <TableCell align="right">
-          <MetricValue variant="dataTabular" region={row} metric={metric} />
+          <MetricValue
+            variant="dataTabular"
+            region={row}
+            metric={metric}
+            justifyContent="space-between"
+          />
         </TableCell>
       );
     },

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -1,7 +1,9 @@
 import React from "react";
+import { Typography, Stack, IconButton } from "@mui/material";
 import { Region } from "@actnowcoalition/regions";
 import { Metric, MetricCatalog } from "@actnowcoalition/metrics";
 import { useMetricCatalog } from "../MetricCatalogContext";
+import { formatInteger } from "@actnowcoalition/number-format";
 import {
   BaseTable,
   ColumnDefinition,
@@ -9,6 +11,8 @@ import {
   TableCellHead,
 } from "../BaseTable";
 import { MetricValue } from "../MetricValue";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 
 export interface MetricCompareTableProps {
   regions: Region[];
@@ -29,15 +33,43 @@ export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
   const rows: Region[] = regions;
   const columns: ColumnDefinition<Region>[] = [
     {
-      name: "Region",
+      name: "Locations",
       rows,
       renderHeader: ({ column }) => (
-        <TableCellHead stickyRow stickyColumn>
-          {column.name}s
+        <TableCellHead
+          stickyRow
+          stickyColumn
+          style={{
+            fontWeight: "normal",
+            verticalAlign: "bottom",
+            backgroundColor: "#fff",
+          }}
+          sx={{ p: 0.5 }}
+        >
+          <Stack direction="column" justifyItems="flex-end">
+            <Typography variant="labelSmall" sx={{ ml: 0.5 }}>
+              {column.name}
+            </Typography>
+            <Typography variant="paragraphSmall" sx={{ ml: 0.5 }}>
+              Population
+            </Typography>
+            <SortControls />
+          </Stack>
         </TableCellHead>
       ),
       renderCell: ({ row }) => (
-        <TableCell stickyColumn>{row.fullName}</TableCell>
+        <TableCell
+          stickyColumn
+          style={{ backgroundColor: "#fff" }}
+          sx={{ p: 0.5 }}
+        >
+          <Stack>
+            <Typography variant="labelSmall">{row.fullName}</Typography>
+            <Typography variant="dataTabular">
+              {formatInteger(row.population)}
+            </Typography>
+          </Stack>
+        </TableCell>
       ),
       sticky: true,
     },
@@ -45,7 +77,14 @@ export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
     ...metriColumns,
   ];
 
-  return <BaseTable rows={regions} columns={columns} />;
+  return (
+    <BaseTable
+      rows={regions}
+      columns={columns}
+      size="small"
+      cellPadding="none"
+    />
+  );
 };
 
 function getMetricColumn(
@@ -57,7 +96,20 @@ function getMetricColumn(
     name: metric.name,
     rows,
     renderHeader: ({ column }) => (
-      <TableCellHead stickyRow>{column.name}</TableCellHead>
+      <TableCellHead
+        stickyRow
+        align="right"
+        style={{
+          minWidth: 110,
+          justifyContent: "bottom",
+          backgroundColor: "#fff",
+        }}
+        sx={{ p: 0.5 }}
+      >
+        <Stack direction="column">
+          <Typography variant="labelSmall">{column.name}</Typography>
+        </Stack>
+      </TableCellHead>
     ),
     renderCell: ({ row }) => {
       const { data, error } = metricCatalog.useData(row, metric);
@@ -66,7 +118,7 @@ function getMetricColumn(
         return <TableCell />;
       }
       return (
-        <TableCell align="right">
+        <TableCell align="right" sx={{ p: 0.5 }}>
           <MetricValue
             variant="dataTabular"
             region={row}
@@ -78,3 +130,16 @@ function getMetricColumn(
     },
   };
 }
+
+const SortControls: React.FC = () => {
+  return (
+    <Stack direction="row" spacing={0}>
+      <IconButton size="small">
+        <KeyboardArrowDownIcon fontSize="small" />
+      </IconButton>
+      <IconButton size="small">
+        <KeyboardArrowUpIcon fontSize="small" />
+      </IconButton>
+    </Stack>
+  );
+};

--- a/packages/ui-components/src/components/MetricCompareTable/index.ts
+++ b/packages/ui-components/src/components/MetricCompareTable/index.ts
@@ -1,0 +1,1 @@
+export * from "./MetricCompareTable";

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Metric, MetricCatalog } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+import { ColumnDefinition } from "../BaseTable";
+import { ColumnHeader } from "./ColumnHeader";
+import { TableCell } from "./MetricCompareTable.style";
+import { MetricValue } from "../MetricValue";
+
+export function getMetricColumn<T>(
+  metric: Metric,
+  metricIndex: number,
+  rows: { region: Region; otherProps: T }[],
+  metricCatalog: MetricCatalog
+): ColumnDefinition<{ region: Region; otherProps: T }> {
+  return {
+    id: `${metric.id}-${metricIndex}`,
+    name: metric.name,
+    rows,
+    renderHeader: ({ column }) => (
+      <ColumnHeader
+        columnTitle={column.name}
+        stickyRow
+        align="right"
+        style={{ minWidth: 110 }}
+      />
+    ),
+    renderCell: ({ row }) => {
+      const { data, error } = metricCatalog.useData(row.region, metric);
+
+      if (error || !data) {
+        return <TableCell />;
+      }
+      return (
+        <TableCell align="right">
+          <MetricValue
+            variant="dataTabular"
+            region={row.region}
+            metric={metric}
+            justifyContent="end"
+          />
+        </TableCell>
+      );
+    },
+  };
+}

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -91,3 +91,5 @@ export * from "./components/MetricOverview";
 export * from "./components/MetricValue";
 export * from "./components/ProgressBar";
 export * from "./components/RegionSearch";
+
+export * from "./components/MetricCompareTable";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -75,6 +75,7 @@ declare module "@mui/material/styles" {
 /** UI Components and props */
 export * from "./components/Axis";
 export * from "./components/BarChart";
+export * from "./components/BaseTable";
 export * from "./components/Grid";
 export * from "./components/InfoTooltip";
 export * from "./components/LabelIcon";

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -32,6 +32,10 @@ const testMetricDefs: MetricDefinition[] = [
     },
     thresholds: [10, 100],
     levelSetId: "cases_mock",
+    formatOptions: {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    },
   },
   {
     id: MetricId.PASS_FAIL,


### PR DESCRIPTION
The table in https://www.multistate.us/research/election-laws has pretty good column and row pinning via css, I'm trying to mimic the behaviour and use it for the `CompareTable`.

The behaviours that I want to copy from that table are:
- When scrolling vertically, the table header stick to the top (it won't scroll away), so the column names are always visible.
- When scrolling horizontally, the location name sticks to the left, and the other columns scroll. But more impressively, the table headers scroll in sync. This allows location names and metric names to remain visible when the user scrolls to see other locations/metrics. 

Once we improve this base component we can use it to implement a metric-aware `CompareTable` with sorting and everything.

[super-table-double-scroll.webm](https://user-images.githubusercontent.com/114084/188033890-f5cbaa19-1ff7-4e2f-903a-2f4a53ec5a5d.webm)
