### PR TITLE
Pass `StackProps` to `MetricValue` component

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/ui-components",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "UI components for Act Now",
   "repository": {
     "type": "git",

--- a/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
@@ -23,3 +23,30 @@ DefaultVariant.args = {
 
 export const DataTabular = Template.bind({});
 DataTabular.args = { ...DefaultVariant.args, variant: "dataTabular" };
+
+export const AlignedRight = () => (
+  <div
+    style={{
+      width: 300,
+      border: "dashed 1px #eee",
+      display: "flex",
+      justifyContent: "flex-end",
+    }}
+  >
+    <MetricValue
+      region={washingtonState}
+      metric={MetricId.MOCK_CASES}
+      style={{ width: "fit-content" }}
+    />
+  </div>
+);
+
+export const SpaceBetween = () => (
+  <div style={{ width: 300, border: "dashed 1px #eee" }}>
+    <MetricValue
+      region={washingtonState}
+      metric={MetricId.MOCK_CASES}
+      justifyContent="space-between"
+    />
+  </div>
+);

--- a/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
@@ -42,11 +42,10 @@ export const AlignedRight = () => (
 );
 
 export const SpaceBetween = () => (
-  <div style={{ width: 300, border: "dashed 1px #eee" }}>
-    <MetricValue
-      region={washingtonState}
-      metric={MetricId.MOCK_CASES}
-      justifyContent="space-between"
-    />
-  </div>
+  <MetricValue
+    region={washingtonState}
+    metric={MetricId.MOCK_CASES}
+    justifyContent="space-between"
+    style={{ width: 300, border: "dashed 1px #eee" }}
+  />
 );

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { Stack, Typography, TypographyProps } from "@mui/material";
+import { Stack, StackProps, Typography, TypographyProps } from "@mui/material";
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricDot } from "../MetricDot";
 
-export interface MetricValueProps {
+export interface MetricValueProps extends StackProps {
   /** Region for which we want to show the metric value */
   region: Region;
   /** Metric for which we want to show the metric value  */
@@ -21,6 +21,7 @@ export const MetricValue: React.FC<MetricValueProps> = ({
   region,
   metric: metricOrId,
   variant = "dataEmphasizedLarge",
+  ...stackProps
 }) => {
   const metricCatalog = useMetricCatalog();
   const metric = metricCatalog.getMetric(metricOrId);
@@ -32,7 +33,7 @@ export const MetricValue: React.FC<MetricValueProps> = ({
   }
 
   return (
-    <Stack direction="row" spacing={1} alignItems="center">
+    <Stack direction="row" spacing={1} alignItems="center" {...stackProps}>
       <MetricDot region={region} metric={metric} />
       <Typography variant={variant}>
         {metric.formatValue(data.currentValue, "---")}


### PR DESCRIPTION
By default, the `MetricValue` component will extend to fill the entire width of its container. This PR extends the types of the `MetricValue` props and passes them to the underlying stack component to allow manipulating the alignment of the dot relative to the label

Passing the right props allow to change the component width to `fit-content` and align the component to the right (we might need that if we are showing multiple metric values vertically)

<img width="313" alt="image" src="https://user-images.githubusercontent.com/114084/188246835-c5464979-8f3c-4bce-8cd7-df537e99dea3.png">

On a table, we might want to align the number to the right and the dot to the left

<img width="308" alt="image" src="https://user-images.githubusercontent.com/114084/188246842-e8e4bb3f-d4f3-43b6-abfc-2d0a598059b0.png">

I added a few examples in Storybook to confirm that it works well.