### PR TITLE
Add relativeUrl as a Region attribute

### DIFF
--- a/packages/regions/README.md
+++ b/packages/regions/README.md
@@ -13,6 +13,7 @@ const washingtonState = new Region(
   "Washington", // shorName
   "WA", // abbreviation
   "washington-wa", // urlFragment
+  "/us/washington-wa", // relativeUrl
   null, // parent
   7614893 // population
 );

--- a/packages/regions/package.json
+++ b/packages/regions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actnowcoalition/regions",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A package containing classes and datasets to represent geographic areas and administrative divisions with a uniform interface.",
   "repository": {
     "type": "git",

--- a/packages/regions/src/Region.test.ts
+++ b/packages/regions/src/Region.test.ts
@@ -14,6 +14,7 @@ describe("Region serialization", () => {
     shortName: "Florida",
     abbreviation: "FL",
     slug: "florida-fl",
+    relativeUrl: "/us/florida-fl",
     parent: null,
     population: 21_477_737,
   };
@@ -24,6 +25,7 @@ describe("Region serialization", () => {
     shortName: "Miami-Dade County, FL",
     abbreviation: "Miami-Dade Co.",
     slug: "miami-dade-county",
+    relativeUrl: null,
     parent: parentJSON,
     population: 2_716_940,
   };
@@ -33,6 +35,7 @@ describe("Region serialization", () => {
     "Miami-Dade County, FL",
     "Miami-Dade Co.",
     "miami-dade-county",
+    null,
     Region.fromJSON(parentJSON),
     2_716_940
   );

--- a/packages/regions/src/Region.test.ts
+++ b/packages/regions/src/Region.test.ts
@@ -25,7 +25,7 @@ describe("Region serialization", () => {
     shortName: "Miami-Dade County, FL",
     abbreviation: "Miami-Dade Co.",
     slug: "miami-dade-county",
-    relativeUrl: null,
+    relativeUrl: "/us/miami-dade-county",
     parent: parentJSON,
     population: 2_716_940,
   };
@@ -35,7 +35,7 @@ describe("Region serialization", () => {
     "Miami-Dade County, FL",
     "Miami-Dade Co.",
     "miami-dade-county",
-    null,
+    "/us/miami-dade-county",
     Region.fromJSON(parentJSON),
     2_716_940
   );

--- a/packages/regions/src/Region.ts
+++ b/packages/regions/src/Region.ts
@@ -8,6 +8,7 @@ export interface RegionJSON {
   shortName: string;
   abbreviation: string;
   slug: string;
+  relativeUrl: string | null;
   parent: RegionJSON | null;
   population: number;
 }
@@ -19,6 +20,7 @@ export class Region {
     public readonly shortName: string,
     public readonly abbreviation: string,
     public readonly slug: string,
+    public readonly relativeUrl: string | null,
     public readonly parent: Region | null,
     // TODO: transfrom population and potentially other attributes to Metric.
     // This will allow us to leverage on more advanced Metric functionality,
@@ -28,12 +30,6 @@ export class Region {
 
   contains(subregion: Region): boolean {
     return subregion.parent?.regionId === this.regionId;
-  }
-
-  get relativeUrl(): string {
-    return this.parent
-      ? Region.urlJoin(this.parent.relativeUrl, this.slug)
-      : Region.urlJoin("/", this.slug);
   }
 
   toString() {
@@ -73,6 +69,7 @@ export class Region {
       regionJSON.shortName,
       regionJSON.abbreviation,
       regionJSON.slug,
+      regionJSON.relativeUrl,
       regionJSON.parent ? Region.fromJSON(regionJSON.parent) : null,
       regionJSON.population
     );
@@ -85,6 +82,7 @@ export class Region {
       shortName: this.shortName,
       abbreviation: this.abbreviation,
       slug: this.slug,
+      relativeUrl: this.relativeUrl,
       parent: this.parent ? this.parent.toJSON() : null,
       population: this.population,
     };

--- a/packages/regions/src/Region.ts
+++ b/packages/regions/src/Region.ts
@@ -8,7 +8,7 @@ export interface RegionJSON {
   shortName: string;
   abbreviation: string;
   slug: string;
-  relativeUrl: string | null;
+  relativeUrl: string;
   parent: RegionJSON | null;
   population: number;
 }
@@ -20,7 +20,7 @@ export class Region {
     public readonly shortName: string,
     public readonly abbreviation: string,
     public readonly slug: string,
-    public readonly relativeUrl: string | null,
+    public readonly relativeUrl: string,
     public readonly parent: Region | null,
     // TODO: transfrom population and potentially other attributes to Metric.
     // This will allow us to leverage on more advanced Metric functionality,

--- a/packages/regions/src/datasets/nations/nations_db.test.ts
+++ b/packages/regions/src/datasets/nations/nations_db.test.ts
@@ -8,7 +8,7 @@ describe("nations_db", () => {
     abbreviation: "IRL",
     parent: null,
     slug: "ireland",
-    relativeUrl: null,
+    relativeUrl: "",
     population: 4964440,
   };
 

--- a/packages/regions/src/datasets/nations/nations_db.test.ts
+++ b/packages/regions/src/datasets/nations/nations_db.test.ts
@@ -8,6 +8,7 @@ describe("nations_db", () => {
     abbreviation: "IRL",
     parent: null,
     slug: "ireland",
+    relativeUrl: null,
     population: 4964440,
   };
 

--- a/packages/regions/src/datasets/nations/nations_db.ts
+++ b/packages/regions/src/datasets/nations/nations_db.ts
@@ -9,6 +9,7 @@ const nations = nationsJSON.map((country) => {
     /*shortName=*/ country.name,
     /*abbreviation=*/ country.iso3_code,
     /*slug=*/ Region.toSlug(country.name),
+    /*relativeUrl=*/ null,
     /*parent=*/ null,
     /*population=*/ country.population
   );

--- a/packages/regions/src/datasets/nations/nations_db.ts
+++ b/packages/regions/src/datasets/nations/nations_db.ts
@@ -9,7 +9,7 @@ const nations = nationsJSON.map((country) => {
     /*shortName=*/ country.name,
     /*abbreviation=*/ country.iso3_code,
     /*slug=*/ Region.toSlug(country.name),
-    /*relativeUrl=*/ null,
+    /*relativeUrl=*/ "",
     /*parent=*/ null,
     /*population=*/ country.population
   );

--- a/packages/regions/src/datasets/us/counties_db.ts
+++ b/packages/regions/src/datasets/us/counties_db.ts
@@ -12,7 +12,8 @@ const counties = countiesJSON.map((county) => {
     `${county.name}, ${state.abbreviation}`,
     countyAbbreviation,
     Region.toSlug(county.name),
-    state,
+    null, // relativeUrl
+    state, // parent
     county.population
   );
 });

--- a/packages/regions/src/datasets/us/counties_db.ts
+++ b/packages/regions/src/datasets/us/counties_db.ts
@@ -12,7 +12,7 @@ const counties = countiesJSON.map((county) => {
     `${county.name}, ${state.abbreviation}`,
     countyAbbreviation,
     Region.toSlug(county.name),
-    null, // relativeUrl
+    "", // relativeUrl
     state, // parent
     county.population
   );

--- a/packages/regions/src/datasets/us/metros_db.ts
+++ b/packages/regions/src/datasets/us/metros_db.ts
@@ -14,7 +14,7 @@ const metros = metrosJson.map((metro) => {
     `${metro.name} metro`,
     `${metro.name} metro`,
     metroUrlFragment,
-    null, // relativeUrl
+    "", // relativeUrl
     null, // parent
     metro.population
   );

--- a/packages/regions/src/datasets/us/metros_db.ts
+++ b/packages/regions/src/datasets/us/metros_db.ts
@@ -14,7 +14,8 @@ const metros = metrosJson.map((metro) => {
     `${metro.name} metro`,
     `${metro.name} metro`,
     metroUrlFragment,
-    null,
+    null, // relativeUrl
+    null, // parent
     metro.population
   );
 });

--- a/packages/regions/src/datasets/us/states_db.ts
+++ b/packages/regions/src/datasets/us/states_db.ts
@@ -12,7 +12,8 @@ const states = statesJSON
       state.name,
       state.stateCode,
       `${slugName}-${slugStateCode}`,
-      null,
+      null, // relativeUrl
+      null, // parent
       state.population
     );
   })

--- a/packages/regions/src/datasets/us/states_db.ts
+++ b/packages/regions/src/datasets/us/states_db.ts
@@ -12,7 +12,7 @@ const states = statesJSON
       state.name,
       state.stateCode,
       `${slugName}-${slugStateCode}`,
-      null, // relativeUrl
+      "", // relativeUrl
       null, // parent
       state.population
     );


### PR DESCRIPTION
Close #141 

Instead of removing the `relativeUrl` getter method from `Region`, I'm adding it as an instance property so we can overwrite it when creating regions for a specific project. The idea is to create new instances of each region using the custom per-project `relativeUrl` and using the modified instances to initialize `RegionDB`

```ts
// src/utils/regions.ts

import { states, Region, RegionDB } from "@actnowcoalition/regions";

const updatedStates = states.all.map(state => {
  return Region.fromJSON({
    ...state.toJSON(), 
    // Custom relativeUrl based on the project URL structure
    relativeUrl: `/us/${state.slug}` 
  });
});

export const regions = new RegionDB(updatedStates);
```