### PR TITLE
Update the types of `RegionSearch`

### DIFF
--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { states, counties, metros } from "@actnowcoalition/regions";
+import { TextField, InputAdornment } from "@mui/material";
+import MapIcon from "@mui/icons-material/Map";
 import sortBy from "lodash/sortBy";
+import { states, counties, metros } from "@actnowcoalition/regions";
 import { RegionSearch } from ".";
 
 export default {
@@ -13,21 +15,41 @@ const Template: ComponentStory<typeof RegionSearch> = (args) => (
   <RegionSearch {...args} />
 );
 
-const allRegions = [...states.all, ...counties.all, ...metros.all];
-
-export const AllRegions = Template.bind({});
-AllRegions.args = {
-  searchOptions: allRegions,
-};
-
 export const StatesOnly = Template.bind({});
 StatesOnly.args = {
-  searchOptions: states.all,
-  inputLabel: "State",
+  options: states.all,
+  inputLabel: "States",
+};
+
+export const CustomRenderInput = Template.bind({});
+CustomRenderInput.args = {
+  options: states.all,
+  inputLabel: "States",
+  renderInput: (params) => (
+    <TextField
+      {...params}
+      sx={{ backgroundColor: "#E3F2FD" }}
+      label="Custom renderInput"
+      InputProps={{
+        ...params.InputProps,
+        endAdornment: (
+          <InputAdornment position="end">
+            <MapIcon />
+          </InputAdornment>
+        ),
+      }}
+    />
+  ),
 };
 
 export const CountiesOnly = Template.bind({});
 CountiesOnly.args = {
-  searchOptions: sortBy(counties.all, (county) => county.population * -1),
-  inputLabel: "County",
+  options: sortBy(counties.all, (county) => county.population * -1),
+  inputLabel: "Counties",
+};
+
+const allRegions = [...states.all, ...counties.all, ...metros.all];
+export const AllRegions = Template.bind({});
+AllRegions.args = {
+  options: allRegions,
 };

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -5,59 +5,60 @@ import { Autocomplete, AutocompleteProps, TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import { createFilterOptions } from "@mui/material/useAutocomplete";
 
-export interface RegionSearchProps {
-  searchOptions: Region[];
-  inputLabel?: string;
-}
-
 function stringifyOption(region: Region) {
   return region.fullName;
 }
 
 const onChange = (item: Region | null) => {
-  if (!item) {
-    return null;
-  } else {
+  if (item && item.relativeUrl) {
     window.location.href = item.relativeUrl;
   }
 };
 
-export const RegionSearch: React.FC<
-  RegionSearchProps &
-    AutocompleteProps<
-      Region,
-      /** Multiple */ false,
-      /** DisableClearable */ false,
-      /** FreeSolo */ false,
-      /** ChipComponent */ "div"
-    >
-> = ({
-  searchOptions,
+export type CustomAutocompleteProps = AutocompleteProps<
+  Region,
+  false, // multiple
+  false, // disableClearable
+  false, // freeSsolo
+  "div" // ChipComponent
+>;
+
+export interface RegionSearchProps extends CustomAutocompleteProps {
+  inputLabel?: string;
+}
+
+export const RegionSearch: React.FC<RegionSearchProps> = ({
+  options,
   inputLabel = "City, county, state, or district",
-  ...otherProps
+  renderInput: customRenderInput,
+  ...otherAutocompleteProps
 }) => {
+  const defaultRenderInput: RegionSearchProps["renderInput"] = (params) => (
+    <TextField
+      {...params}
+      label={inputLabel}
+      variant="outlined"
+      size="small"
+      InputProps={{ ...params.InputProps, endAdornment: <SearchIcon /> }}
+      inputProps={{ ...params.inputProps, "aria-label": "Search" }}
+    />
+  );
+
+  const renderInput = customRenderInput ?? defaultRenderInput;
+
   return (
     <Container>
       <Autocomplete
-        {...otherProps}
-        options={searchOptions}
+        options={options}
         onChange={(e, item: Region | null) => onChange(item)}
         clearIcon={<></>}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            label={inputLabel}
-            variant="outlined"
-            size="small"
-            InputProps={{ ...params.InputProps, endAdornment: <SearchIcon /> }}
-            inputProps={{ ...params.inputProps, "aria-label": "Search" }}
-          />
-        )}
+        renderInput={renderInput}
         getOptionLabel={stringifyOption}
         filterOptions={createFilterOptions({
           limit: 30,
           stringify: stringifyOption,
         })}
+        {...otherAutocompleteProps}
       />
     </Container>
   );

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -24,6 +24,7 @@ export type CustomAutocompleteProps = AutocompleteProps<
 >;
 
 export interface RegionSearchProps extends CustomAutocompleteProps {
+  /** Placeholder text to show in the inner text field  */
   inputLabel?: string;
 }
 
@@ -44,15 +45,13 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
     />
   );
 
-  const renderInput = customRenderInput ?? defaultRenderInput;
-
   return (
     <Container>
       <Autocomplete
         options={options}
         onChange={(e, item: Region | null) => onChange(item)}
         clearIcon={<></>}
-        renderInput={renderInput}
+        renderInput={customRenderInput ?? defaultRenderInput}
         getOptionLabel={stringifyOption}
         filterOptions={createFilterOptions({
           limit: 30,

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -23,9 +23,12 @@ export type CustomAutocompleteProps = AutocompleteProps<
   "div" // ChipComponent
 >;
 
-export interface RegionSearchProps extends CustomAutocompleteProps {
+export interface RegionSearchProps
+  extends Omit<CustomAutocompleteProps, "renderInput"> {
   /** Placeholder text to show in the inner text field  */
   inputLabel?: string;
+  /** Optional renderInput function. See https://mui.com/material-ui/api/autocomplete/ */
+  renderInput?: CustomAutocompleteProps["renderInput"];
 }
 
 export const RegionSearch: React.FC<RegionSearchProps> = ({
@@ -34,7 +37,9 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
   renderInput: customRenderInput,
   ...otherAutocompleteProps
 }) => {
-  const defaultRenderInput: RegionSearchProps["renderInput"] = (params) => (
+  const defaultRenderInput: CustomAutocompleteProps["renderInput"] = (
+    params
+  ) => (
     <TextField
       {...params}
       label={inputLabel}


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/144

Update the types of `RegionSearch` to more closely match the type of `Autocomplete`

- Rename `searchOptions` → `options` so we can simplify the types and rely on `AutocompleteProps` a bit more
- Make `renderInput` optional and ensures that its type is consistent with the type of `Autocomplete` (when using it with `Region[]` as `options`)
- Also added a few doc strings that were missing

## Testing

I tested with `yarn link` as usual, the https://github.com/covid-projections/hackathon-august-2022 works if we remove the `renderInput` and replacing `searchOptions` with `options`

