### PR TITLE
CsvDataProvider: allow non-timeseries data to be returned when `includeTimseries=true`

### DIFF
--- a/packages/metrics/src/data_providers/CachingMetricDataProviderBase.ts
+++ b/packages/metrics/src/data_providers/CachingMetricDataProviderBase.ts
@@ -28,7 +28,7 @@ export abstract class CachingMetricDataProviderBase
    *
    * @param regions The set of regions to populate the cache with.
    * @param metrics The set of metrics to populate the cache with.
-   * @param includeTimeseries Whether to include timeseries data.
+   * @param includeTimeseries Whether to include timeseries data if it exists.
    */
   abstract populateCache(
     regions: Region[],

--- a/packages/metrics/src/data_providers/CsvDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.test.ts
@@ -56,6 +56,15 @@ describe("CsvDataProvider", () => {
     expect(metricDataTs.timeseries.lastValue).toBe(150);
   });
 
+  test("fetchData() returns non-timeseries data if timeseries data is not available.", async () => {
+    const metricData = await testFetchingCsvData(
+      mockCsv,
+      /*includeTimeseries=*/ true
+    );
+    expect(metricData.currentValue).toBe(150);
+    expect(metricData.hasTimeseries()).toBe(false);
+  });
+
   test("populateCache() fails if csv does not have at least one row.", async () => {
     const provider = new CsvDataProvider("csv-provider", {
       regionColumn: "region",

--- a/packages/metrics/src/data_providers/CsvDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.test.ts
@@ -56,18 +56,6 @@ describe("CsvDataProvider", () => {
     expect(metricDataTs.timeseries.lastValue).toBe(150);
   });
 
-  test("fetchData() fails if timeseries is expected, but the CSV does not have timeseries data.", async () => {
-    const provider = new CsvDataProvider("csv-provider", {
-      regionColumn: "region",
-      csvText: mockCsv,
-    });
-    expect(async () => {
-      await provider.fetchData([newYork], [testMetric], true);
-    }).rejects.toThrow(
-      "includeTimeseries set to true but cached data has no timeseries."
-    );
-  });
-
   test("populateCache() fails if csv does not have at least one row.", async () => {
     const provider = new CsvDataProvider("csv-provider", {
       regionColumn: "region",

--- a/packages/metrics/src/data_providers/CsvDataProvider.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.ts
@@ -102,10 +102,6 @@ export class CsvDataProvider extends CachingMetricDataProviderBase {
       );
     }
     if (includeTimeseries) {
-      assert(
-        metricData.hasTimeseries(),
-        "includeTimeseries set to true but cached data has no timeseries."
-      );
       return metricData;
     } else {
       return metricData.dropTimeseries();


### PR DESCRIPTION
`metricCatalog.useData()` sets `includeTimeseries` to `true` by default, which means that currently:

```typescript
import { MetricCatalog } from "@actnowcoalition/metrics";

const metricCatalog = new MetricCatalog(...)
// Where MetricId.NO_TS_METRIC is a metric that uses the CsvDataProvider class with no timeseries
const {data, error} = metricCatalog.useData(region, MetricId.NO_TS_METRIC)
```

will throw an error. 

Per discussion in https://github.com/covid-projections/act-now-packages/pull/108#discussion_r959013572, I think the desired behavior is to have `includeTimseries=true` return timeseries data if it exists, else it should just return the non-timeseries data. 