### PR TITLE
Fix compare table sorting.

### DIFF
--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -17,12 +17,13 @@ export default {
 } as ComponentMeta<typeof CompareTable>;
 
 interface RowItem {
+  rowId: string;
   region: Region;
 }
 
 const rows: RowItem[] = states.all
   .sort((a, b) => (a.population > b.population ? -1 : 1))
-  .map((region) => ({ region }));
+  .map((region) => ({ region, rowId: region.regionId }));
 
 const StatefulCompareTable: React.FC<{
   rows: RowItem[];

--- a/packages/ui-components/src/components/CompareTable/CompareTable.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.tsx
@@ -8,7 +8,12 @@ import {
   CompareTableProps,
 } from ".";
 
-export const CompareTable = <R,>({
+interface CompareTableRowBase {
+  /** A unique ID that identifies this row. */
+  rowId: string;
+}
+
+export const CompareTable = <R extends CompareTableRowBase>({
   rows,
   columns,
   sortColumnId,
@@ -34,9 +39,9 @@ export const CompareTable = <R,>({
       </TableHead>
       <TableBody>
         {sortedRows.map((row, rowIndex) => (
-          <TableRow key={`table-row-${rowIndex}`}>
+          <TableRow key={`table-row-${row.rowId}`}>
             {columns.map((column, columnIndex) => (
-              <Fragment key={`cell-${rowIndex}-${columnIndex}`}>
+              <Fragment key={`cell-${row.rowId}-${columnIndex}`}>
                 {column.renderCell({ row, rowIndex, columnIndex })}
               </Fragment>
             ))}

--- a/packages/ui-components/src/components/CompareTable/CompareTable.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.tsx
@@ -8,7 +8,7 @@ import {
   CompareTableProps,
 } from ".";
 
-interface CompareTableRowBase {
+export interface CompareTableRowBase {
   /** A unique ID that identifies this row. */
   rowId: string;
 }

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -17,6 +17,7 @@ export interface MetricCompareTableProps {
 }
 
 interface Row {
+  rowId: string;
   region: Region;
   multiMetricsDataStore: MultiMetricDataStore;
 }
@@ -47,9 +48,10 @@ export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
     return null;
   }
 
-  const rows: Row[] = data.all.map((multiMetricsDataStore) => ({
-    region: multiMetricsDataStore.region,
-    multiMetricsDataStore,
+  const rows: Row[] = data.all.map((multiMetricDataStore) => ({
+    rowId: multiMetricDataStore.region.regionId,
+    region: multiMetricDataStore.region,
+    multiMetricsDataStore: multiMetricDataStore,
   }));
 
   const columns: ColumnDefinition<Row>[] = [


### PR DESCRIPTION
Per https://reactjs.org/docs/lists-and-keys.html:

> We don’t recommend using indexes for keys if the order of items may change. This can negatively impact performance and **may cause issues with component state**. Check out Robin Pokorny’s article for an [in-depth explanation on the negative impacts of using an index as a key](https://robinpokorny.com/blog/index-as-a-key-is-an-anti-pattern/). If you choose not to assign an explicit key to list items then React will default to using indexes as keys.

I think what was happening is that after re-sorting the table, React didn't know that the order of elements had changed and so the internal `useEffect()` calls within each row were returning data for wrong rows.

Note I left it using the `columnIndex` in the keys, since we don't support re-ordering / removing columns, but we may want to revisit.  

Feel free to rework this in any way you like.  Another option might be to use the *initial* index of each row (before sorting) as the row's key.  That would _probably?_ be safe and means the consumer of the table doesn't have to provide explicit IDs.