### PR TITLE
Implement `RectClipGroup` component

### DIFF
--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -52,29 +52,27 @@ export const LegendThresholdHorizontal = <T,>({
         rx={borderRadius}
         ry={borderRadius}
       >
-        <Group>
-          {items.map((item, itemIndex) => {
-            const x = scaleRect(itemIndex) ?? 0;
-            return (
-              <Group key={`item-${itemIndex}`}>
-                <rect
-                  x={x}
-                  height={barHeight}
-                  width={rectWidth}
-                  fill={getItemColor(item, itemIndex)}
-                />
-                {showLabels && itemIndex !== items.length - 1 && (
-                  <Group top={barHeight} left={x + rectWidth}>
-                    <TickMark y1={0} y2={labelTickHeight} />
-                    <TickLabel y={labelTickHeight + tickLabelPadding}>
-                      {getItemLabel && getItemLabel(item, itemIndex)}
-                    </TickLabel>
-                  </Group>
-                )}
-              </Group>
-            );
-          })}
-        </Group>
+        {items.map((item, itemIndex) => {
+          const x = scaleRect(itemIndex) ?? 0;
+          return (
+            <Group key={`item-${itemIndex}`}>
+              <rect
+                x={x}
+                height={barHeight}
+                width={rectWidth}
+                fill={getItemColor(item, itemIndex)}
+              />
+              {showLabels && itemIndex !== items.length - 1 && (
+                <Group top={barHeight} left={x + rectWidth}>
+                  <TickMark y1={0} y2={labelTickHeight} />
+                  <TickLabel y={labelTickHeight + tickLabelPadding}>
+                    {getItemLabel && getItemLabel(item, itemIndex)}
+                  </TickLabel>
+                </Group>
+              )}
+            </Group>
+          );
+        })}
       </RectClipGroup>
     </svg>
   );

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
-import uniqueId from "lodash/uniqueId";
 import { TickLabel, TickMark } from "./LegendThreshold.style";
 import { CommonLegendThresholdProps } from "./interfaces";
+import { RectClipGroup } from "../RectClipGroup";
 
 export interface LegendThresholdHorizontalProps<T>
   extends CommonLegendThresholdProps<T> {
@@ -41,49 +41,41 @@ export const LegendThresholdHorizontal = <T,>({
   const scaleRect = scaleBand({ domain: indexList, range: [0, width] });
   const rectWidth = scaleRect.bandwidth();
 
-  const clipPathId = uniqueId(`bars-clip-path-`);
-
   const labelTickHeight = 4;
   const tickLabelPadding = 2;
 
   return (
     <svg width={width} height={height} {...otherSvgProps}>
-      <defs>
-        <clipPath id={clipPathId}>
-          <rect
-            x={0}
-            y={0}
-            width={width}
-            height={showLabels ? barHeight : height}
-            rx={borderRadius}
-            ry={borderRadius}
-          />
-        </clipPath>
-      </defs>
-      <Group>
-        {items.map((item, itemIndex) => {
-          const x = scaleRect(itemIndex) ?? 0;
-          return (
-            <Group key={`item-${itemIndex}`}>
-              <rect
-                x={x}
-                height={barHeight}
-                width={rectWidth}
-                fill={getItemColor(item, itemIndex)}
-                clipPath={`url(#${clipPathId})`}
-              />
-              {showLabels && itemIndex !== items.length - 1 && (
-                <Group top={barHeight} left={x + rectWidth}>
-                  <TickMark y1={0} y2={labelTickHeight} />
-                  <TickLabel y={labelTickHeight + tickLabelPadding}>
-                    {getItemLabel && getItemLabel(item, itemIndex)}
-                  </TickLabel>
-                </Group>
-              )}
-            </Group>
-          );
-        })}
-      </Group>
+      <RectClipGroup
+        width={width}
+        height={showLabels ? barHeight : height}
+        rx={borderRadius}
+        ry={borderRadius}
+      >
+        <Group>
+          {items.map((item, itemIndex) => {
+            const x = scaleRect(itemIndex) ?? 0;
+            return (
+              <Group key={`item-${itemIndex}`}>
+                <rect
+                  x={x}
+                  height={barHeight}
+                  width={rectWidth}
+                  fill={getItemColor(item, itemIndex)}
+                />
+                {showLabels && itemIndex !== items.length - 1 && (
+                  <Group top={barHeight} left={x + rectWidth}>
+                    <TickMark y1={0} y2={labelTickHeight} />
+                    <TickLabel y={labelTickHeight + tickLabelPadding}>
+                      {getItemLabel && getItemLabel(item, itemIndex)}
+                    </TickLabel>
+                  </Group>
+                )}
+              </Group>
+            );
+          })}
+        </Group>
+      </RectClipGroup>
     </svg>
   );
 };

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
@@ -63,7 +63,6 @@ export const ProgressBar = ({
       {...otherSvgProps}
     >
       <RectClipGroup
-        y={0}
         width={width}
         height={height}
         rx={borderRadius}

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,7 +1,6 @@
-import { scaleLinear } from "@visx/scale";
-import { Group } from "@visx/group";
-import uniqueId from "lodash/uniqueId";
 import React from "react";
+import { scaleLinear } from "@visx/scale";
+import { RectClipGroup } from "../RectClipGroup";
 
 export interface ProgressBarProps {
   /** Border radius of the progress bar */
@@ -53,8 +52,6 @@ export const ProgressBar = ({
     range: [0, width],
   });
 
-  const clipPathId = uniqueId(`rounded-borders-clippath-`);
-
   return (
     <svg
       width={width}
@@ -65,21 +62,16 @@ export const ProgressBar = ({
       aria-valuenow={value}
       {...otherSvgProps}
     >
-      <defs>
-        <clipPath id={clipPathId}>
-          <rect
-            y={0}
-            width={width}
-            height={height}
-            rx={borderRadius}
-            ry={borderRadius}
-          />
-        </clipPath>
-      </defs>
-      <Group clipPath={`url(#${clipPathId})`}>
+      <RectClipGroup
+        y={0}
+        width={width}
+        height={height}
+        rx={borderRadius}
+        ry={borderRadius}
+      >
         <rect width={width} height={height} fill={backgroundColor} />
         <rect width={xScale(value)} height={height} fill={color} />
-      </Group>
+      </RectClipGroup>
     </svg>
   );
 };

--- a/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
+++ b/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ComponentMeta } from "@storybook/react";
 import { RectClipGroup } from ".";
 
 export default {
@@ -7,31 +7,15 @@ export default {
   component: RectClipGroup,
 } as ComponentMeta<typeof RectClipGroup>;
 
-const width = 300;
-const height = 300;
-
-const Template: ComponentStory<typeof RectClipGroup> = (args) => (
-  <svg width={width} height={height} style={{ border: "solid 1px #ddd" }}>
-    <RectClipGroup {...args} />
-    {/* The purple circle will show because it's outside the RectClipGroup */}
-    <circle cx={190} cy={90} r={30} fill="#651fff" />
-  </svg>
-);
-
-export const Example = Template.bind({});
-Example.args = {
-  width: 100,
-  height: 100,
-  x: 100,
-  y: 100,
-  rx: 20,
-  ry: 20,
-  // The parts of the circles that are outside the RectClipGroup are hidden
-  children: (
-    <>
+export const Example = () => (
+  <svg width={300} height={300} style={{ border: "solid 1px #ddd" }}>
+    <RectClipGroup width={100} height={100} x={100} y={100} rx={20} ry={20}>
+      {/* The parts of the circles that are outside the RectClipGroup are hidden */}
       <circle cx={150} cy={170} r={50} fill="#c6ff00" />
       <circle cx={200} cy={160} r={20} fill="#ff9100" />
       <circle cx={120} cy={120} r={40} fill="#00b0ff" />
-    </>
-  ),
-};
+    </RectClipGroup>
+    {/* The purple circle won't be clipped because it's outside the RectClipGroup */}
+    <circle cx={190} cy={90} r={30} fill="#651fff" />
+  </svg>
+);

--- a/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
+++ b/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { RectClipGroup } from ".";
+
+export default {
+  title: "Charts/RectClipGroup",
+  component: RectClipGroup,
+} as ComponentMeta<typeof RectClipGroup>;
+
+const width = 300;
+const height = 300;
+
+const Template: ComponentStory<typeof RectClipGroup> = (args) => (
+  <svg width={width} height={height} style={{ border: "solid 1px #ddd" }}>
+    <RectClipGroup {...args} />
+    {/* The purple circle will show because it's outside the RectClipGroup */}
+    <circle cx={190} cy={90} r={30} fill="#651fff" />
+  </svg>
+);
+
+export const Example = Template.bind({});
+Example.args = {
+  width: 100,
+  height: 100,
+  x: 100,
+  y: 100,
+  rx: 20,
+  ry: 20,
+  // The parts of the circles that are outside the RectClipGroup are hidden
+  children: (
+    <>
+      <circle cx={150} cy={170} r={50} fill="#c6ff00" />
+      <circle cx={200} cy={160} r={20} fill="#ff9100" />
+      <circle cx={120} cy={120} r={40} fill="#00b0ff" />
+    </>
+  ),
+};

--- a/packages/ui-components/src/components/RectClipGroup/RectClipGroup.tsx
+++ b/packages/ui-components/src/components/RectClipGroup/RectClipGroup.tsx
@@ -1,0 +1,36 @@
+import React, { SVGProps, useId } from "react";
+
+export interface RectClipGroupProps extends SVGProps<SVGRectElement> {
+  /** Elements that will be clipped by RectClipGroup */
+  children: React.ReactNode;
+}
+
+/**
+ * The RectClipGroup component hides the content of its children that is
+ * outside the area defined by its properties.
+ *
+ * @example
+ * ```tsx
+ * <svg width={400} height={200}>
+ *   <RectClipGroup x={100} width={100} height={100}>
+ *     <rect x={0} width={400} height={200} fill="red" />
+ *   </RectClipGroup>
+ * </svg>
+ * ```
+ */
+export const RectClipGroup: React.FC<RectClipGroupProps> = ({
+  children,
+  ...rectProps
+}) => {
+  const clipPathId = useId();
+  return (
+    <>
+      <defs>
+        <clipPath id={clipPathId}>
+          <rect {...rectProps} />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${clipPathId})`}>{children}</g>
+    </>
+  );
+};

--- a/packages/ui-components/src/components/RectClipGroup/index.ts
+++ b/packages/ui-components/src/components/RectClipGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "./RectClipGroup";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -95,3 +95,5 @@ export * from "./components/RegionSearch";
 export * from "./components/SortableTable";
 
 export * from "./components/MetricSparklines";
+
+export * from "./components/RectClipGroup";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -89,11 +89,9 @@ export * from "./components/MetricDot";
 export * from "./components/MetricLegendCategorical";
 export * from "./components/MetricLegendThreshold";
 export * from "./components/MetricOverview";
+export * from "./components/MetricSparklines";
 export * from "./components/MetricValue";
 export * from "./components/ProgressBar";
+export * from "./components/RectClipGroup";
 export * from "./components/RegionSearch";
 export * from "./components/SortableTable";
-
-export * from "./components/MetricSparklines";
-
-export * from "./components/RectClipGroup";


### PR DESCRIPTION
Implement the `RectClipGroup` component to make it easier to implement rounded borders and to hide elements that would be outside the charting area

<img width="309" alt="image" src="https://user-images.githubusercontent.com/114084/189782124-2393f551-dd46-4cb2-9288-4ad497794fd4.png">

I also updated the `LegendThresholdHorizontal` and `ProgressBar` components to use this new building block.