### PR TITLE
Reverse order of levels in `LegendThresholdVertical` to match mocks

### DIFF
--- a/.changeset/many-mayflies-jam.md
+++ b/.changeset/many-mayflies-jam.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Reverse order of levels in LegendThresholdVertical

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -34,9 +34,11 @@ export const LegendThresholdVertical = <T,>({
 }: LegendThresholdVerticalProps<T>) => {
   const numberOfItems = items.length;
   const legendColorHeight = height / numberOfItems;
+  // Reverse the order of the items so that the lowest levels are rendered at the bottom.
+  const orderedItems = items.slice().reverse();
   return (
     <LegendThresholdVerticalWrapper>
-      {items.map((item, itemIndex) => (
+      {orderedItems.map((item, itemIndex) => (
         <LegendContainer key={itemIndex} style={{ height: legendColorHeight }}>
           <LegendColor
             style={{


### PR DESCRIPTION
[See mocks](https://www.figma.com/file/YN7x6bJmSfRHaovP5ABKu2/ActNow-Design-System?node-id=13%3A948)

**Before:**
<img width="138" alt="image" src="https://user-images.githubusercontent.com/55333380/190473557-1e763730-507f-41b8-823b-5463de26b745.png">
**After:**
<img width="138" alt="image" src="https://user-images.githubusercontent.com/55333380/190473799-03603cb5-3b55-4193-acc0-f1d8ec390bca.png">
