### PR TITLE
Configure typescript and jest to find other packages.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  moduleNameMapper: {
+    "^@actnowcoalition/(.*)$": "<rootDir>/packages/$1/src",
+  },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,13 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
     "incremental": true,
     "downlevelIteration": true,
     "sourceMap": true,
-    "jsx": "react"
+    "jsx": "react",
+    "paths": {
+      "@actnowcoalition/*": ["./packages/*/src"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx", "**/*.json"],
   "exclude": ["node_modules"],


### PR DESCRIPTION
With this change you should never need to run `yarn build:all` locally and VS Code / jest will always use the latest source code of dependent packages (regardless of whether you've done a recent build).

In particular:
1. You should no longer need to build before VS Code will recognize our `@actnowcoalition/*` packages as valid or to see your latest changes.
2. Go to definition / Find all references should now work in VS Code, even across packages.
3. Jest tests should pass even if you haven't done a build and will always pick up the latest code of all packages.

You can test via:
```sh
# Delete all files not checked into git.
git clean -d -f -x .
yarn
yarn test # should succeed
code . # VS Code should be fully functional even though we haven't done a build.
```

Note that there are a lot of guides on setting up TypeScript monorepos, e.g. [this](https://dev.to/mxro/the-ultimate-guide-to-typescript-monorepos-5ap7) and they almost all recommend setting up project references between your packages which basically lets you have different tsconfig files for each package that then refer to each other.  I got this to work, but it was pretty invasive / complex and required duplicating the references across a lot of tsconfig files (they're not inherited), and I am not sure what the advantages are.  So for now I'm going forward with this change which is more minimal but still accomplishes what I wanted.

Note: Since this doesn't affect any actual released code, I'm intentionally not adding a changeset.