### PR TITLE
Make maps responsive

### DIFF
--- a/.changeset/wicked-bananas-agree.md
+++ b/.changeset/wicked-bananas-agree.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Make maps responsive, fix map bug caused by absolute positioning

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -42,10 +42,10 @@
     "@testing-library/react-hooks": "^8.0.1",
     "@visx/mock-data": "^2.1.2",
     "babel-loader": "^8.2.5",
-    "react-test-renderer": "^18.2.0",
-    "typescript": "^4.6.4",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
+    "typescript": "^4.6.4"
   },
   "dependencies": {
     "@actnowcoalition/assert": "^0.1.0",
@@ -64,6 +64,7 @@
     "@visx/curve": "^2.1.0",
     "@visx/grid": "^2.12.2",
     "@visx/group": "^2.10.0",
+    "@visx/responsive": "^2.10.0",
     "@visx/scale": "^2.2.2",
     "@visx/shape": "^2.12.2",
     "d3-geo": "^2.0.2",

--- a/packages/ui-components/src/components/Maps/Maps.style.ts
+++ b/packages/ui-components/src/components/Maps/Maps.style.ts
@@ -5,11 +5,15 @@ export const StyledCanvas = styled("canvas")`
   pointer-events: none;
 `;
 
-export const MapContainer = styled("div")`
+export const MapContainer = styled("div", {
+  shouldForwardProp: isValidProp,
+})<{
+  height?: number;
+}>`
   position: relative;
   display: flex;
   justify-content: center;
-  height: 100%;
+  height: ${({ height }) => (height ? `${height}px` : "100%")};
 `;
 
 export const PositionAbsolute = styled("div")`

--- a/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
 import { MetricUSNationalMap } from "./MetricUSNationalMap";
 import { states } from "@actnowcoalition/regions";
-import { defaultWidth } from "../../../common/geo-shapes";
 import { MetricId } from "../../../stories/mockMetricCatalog";
 import { MetricUSNationalMapProps } from "./interfaces";
 
@@ -23,7 +22,6 @@ const renderSimpleTooltip = (regionId: string) => {
 export const MetricAwareStates = Template.bind({});
 MetricAwareStates.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
-  width: defaultWidth,
   metric: MetricId.MOCK_CASES,
 };
 
@@ -31,7 +29,6 @@ MetricAwareStates.args = {
 export const MetricAwareCounties = Template.bind({});
 MetricAwareCounties.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
-  width: defaultWidth,
   metric: MetricId.MOCK_CASES,
   showCounties: true,
 };

--- a/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.stories.tsx
@@ -5,7 +5,6 @@ import { USNationalMapProps } from "./interfaces";
 import { states, Region } from "@actnowcoalition/regions";
 import { interpolatePiYG } from "d3-scale-chromatic";
 import { scaleOrdinal, scaleLinear } from "@visx/scale";
-import { defaultWidth } from "../../../common/geo-shapes";
 
 export default {
   title: "Maps/US National",
@@ -24,7 +23,6 @@ const renderSimpleTooltip = (regionId: string) => {
 export const States = Template.bind({});
 States.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
-  width: defaultWidth,
 };
 
 /** Counties with no fill color */
@@ -32,7 +30,6 @@ export const StatesWithCounties = Template.bind({});
 StatesWithCounties.args = {
   showCounties: true,
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
-  width: defaultWidth,
 };
 
 const alphabetArr = "abcdefghijklmnopqrstuvwxyz".split("");
@@ -69,7 +66,6 @@ export const StatesColoredByFirstLetter = Template.bind({});
 StatesColoredByFirstLetter.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
   getFillColor: (region: Region) => getFillColorByFirstLetter(region),
-  width: defaultWidth,
 };
 
 /** Counties colored by first letter of fullName */
@@ -78,5 +74,4 @@ CountiesColoredByFirstLetter.args = {
   showCounties: true,
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
   getFillColor: (region: Region) => getFillColorByFirstLetter(region),
-  width: defaultWidth,
 };

--- a/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.tsx
@@ -32,7 +32,9 @@ const USNationalMapInner: React.FC<USNationalMapProps> = ({
   const geoPath = d3GeoPath().projection(projection);
 
   return (
-    <MapContainer>
+    // We need to be explicit in declaring the height of the national map's container
+    // because of the component pieces' absolute positioning.
+    <MapContainer height={height}>
       {showCounties && (
         <PositionAbsolute>
           <CountiesMap

--- a/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.tsx
@@ -10,8 +10,9 @@ import { geoPath as d3GeoPath, geoAlbersUsa } from "d3-geo";
 import StatesMap from "./StatesMap";
 import CountiesMap from "./CountiesMap";
 import { USNationalMapProps } from "./interfaces";
+import { ParentSize } from "@visx/responsive";
 
-export const USNationalMap: React.FC<USNationalMapProps> = ({
+const USNationalMapInner: React.FC<USNationalMapProps> = ({
   width = defaultWidth,
   renderTooltip,
   getFillColor = () => "lightGray",
@@ -56,3 +57,9 @@ export const USNationalMap: React.FC<USNationalMapProps> = ({
     </MapContainer>
   );
 };
+
+export const USNationalMap: React.FC<USNationalMapProps> = (props) => (
+  <ParentSize>
+    {({ width }) => <USNationalMapInner width={width} {...props} />}
+  </ParentSize>
+);

--- a/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
@@ -31,8 +31,6 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
 }) => {
   const height = defaultHeight * (width / defaultWidth);
 
-  console.log("width", width);
-
   const stateGeo = statesGeographies.features.find(
     (geo) => geo.id === stateRegionId
   );

--- a/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
@@ -16,10 +16,11 @@ import {
   RegionOverlay,
 } from "../Maps.style";
 import { USStateMapProps } from "./interfaces";
+import { ParentSize } from "@visx/responsive";
 
 const countiesAndStates = new RegionDB([...states.all, ...counties.all]);
 
-export const USStateMap: React.FC<USStateMapProps> = ({
+const USStateMapInner: React.FC<USStateMapProps> = ({
   stateRegionId,
   renderTooltip,
   getFillColor = () => "lightGray",
@@ -29,6 +30,8 @@ export const USStateMap: React.FC<USStateMapProps> = ({
   showBorderingStates = true,
 }) => {
   const height = defaultHeight * (width / defaultWidth);
+
+  console.log("width", width);
 
   const stateGeo = statesGeographies.features.find(
     (geo) => geo.id === stateRegionId
@@ -113,3 +116,9 @@ export const USStateMap: React.FC<USStateMapProps> = ({
     </MapContainer>
   );
 };
+
+export const USStateMap: React.FC<USStateMapProps> = (props) => (
+  <ParentSize>
+    {({ width }) => <USStateMapInner width={width} {...props} />}
+  </ParentSize>
+);

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -1441,6 +1441,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
+  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
+
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"
@@ -3055,6 +3060,17 @@
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@visx/point/-/point-2.6.0.tgz#c4316ca409b5b829c5455f07118d8c14a92cc633"
   integrity sha512-amBi7yMz4S2VSchlPdliznN41TuES64506ySI22DeKQ+mc1s1+BudlpnY90sM1EIw4xnqbKmrghTTGfy6SVqvQ==
+
+"@visx/responsive@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@visx/responsive/-/responsive-2.10.0.tgz#3e5c5853c7b2b33481e99a64678063cef717de0b"
+  integrity sha512-NssDPpuUYp7hqVISuYkKZ5zk6ob0++RdTIaUjRcUdyFEbvzb9+zIb8QToOkvI90L2EC/MY4Jx0NpDbEe79GpAw==
+  dependencies:
+    "@juggle/resize-observer" "^3.3.1"
+    "@types/lodash" "^4.14.172"
+    "@types/react" "*"
+    lodash "^4.17.21"
+    prop-types "^15.6.1"
 
 "@visx/scale@2.2.2", "@visx/scale@^2.2.2":
   version "2.2.2"
@@ -8829,7 +8845,7 @@ prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==


### PR DESCRIPTION
- Uses `ParentSize` to make maps responsive
- Fixes [bug caused by national map's use of absolute positioning](https://github.com/covid-projections/act-now-packages/issues/146) by manually passing height to national map's `MapContainer`

fixes #201 
fixes #146 