### PR TITLE
Fix legend threshold labels

### DIFF
--- a/.changeset/calm-cobras-cry.md
+++ b/.changeset/calm-cobras-cry.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix a a bug that prevented the labels to show on LegendThreshold (horizontal)

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -52,28 +52,32 @@ export const LegendThresholdHorizontal = <T,>({
         rx={borderRadius}
         ry={borderRadius}
       >
-        {items.map((item, itemIndex) => {
-          const x = scaleRect(itemIndex) ?? 0;
-          return (
-            <Group key={`item-${itemIndex}`}>
-              <rect
-                x={x}
-                height={barHeight}
-                width={rectWidth}
-                fill={getItemColor(item, itemIndex)}
-              />
-              {showLabels && itemIndex !== items.length - 1 && (
-                <Group top={barHeight} left={x + rectWidth}>
-                  <TickMark y1={0} y2={labelTickHeight} />
-                  <TickLabel y={labelTickHeight + tickLabelPadding}>
-                    {getItemLabel && getItemLabel(item, itemIndex)}
-                  </TickLabel>
-                </Group>
-              )}
-            </Group>
-          );
-        })}
+        {items.map((item, itemIndex) => (
+          <rect
+            key={`item-${itemIndex}`}
+            x={scaleRect(itemIndex) ?? 0}
+            height={barHeight}
+            width={rectWidth}
+            fill={getItemColor(item, itemIndex)}
+          />
+        ))}
       </RectClipGroup>
+      {items.map(
+        (item, itemIndex) =>
+          showLabels &&
+          itemIndex !== items.length - 1 && (
+            <Group
+              key={`item-${itemIndex}`}
+              top={barHeight}
+              left={(scaleRect(itemIndex) ?? 0) + rectWidth}
+            >
+              <TickMark y1={0} y2={labelTickHeight} />
+              <TickLabel y={labelTickHeight + tickLabelPadding}>
+                {getItemLabel && getItemLabel(item, itemIndex)}
+              </TickLabel>
+            </Group>
+          )
+      )}
     </svg>
   );
 };


### PR DESCRIPTION
Close #207  - The issue was actually that by default the labels are shown, but they were not visible because of a bug I introduced when I refactored the component to use `RectClipGroup`. The fix is to move the labels (and tick marks) outside `RectClipGroup`

**Before - No labels** 😢

<img width="324" src="https://user-images.githubusercontent.com/114084/191629601-39555cc5-7046-4976-a4ed-0fafdad50aba.png" >

**After**

<img width="324" alt="image" src="https://user-images.githubusercontent.com/114084/191629542-9367e09a-8750-416f-933d-7ac45cf1c340.png">
