### PR TITLE
Style Chip component

### DIFF
--- a/.changeset/tasty-boats-flow.md
+++ b/.changeset/tasty-boats-flow.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Style the Chip component and minor fixes on theme/components'

--- a/packages/ui-components/src/stories/Chip.stories.tsx
+++ b/packages/ui-components/src/stories/Chip.stories.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Chip } from "@mui/material";
+
+export default {
+  title: "Design System/Chip",
+};
+
+export const DefaultExample = () => <Chip label="New York" />;
+
+export const Deletable = () => (
+  <Chip
+    label="New York"
+    variant="outlined"
+    onDelete={() => console.log("Delete")}
+  />
+);
+
+export const ClickableAndDeletable = () => (
+  <Chip
+    label="New York"
+    variant="outlined"
+    onDelete={() => console.log("Delete")}
+    onClick={() => console.log("Click")}
+  />
+);

--- a/packages/ui-components/src/stories/Colors.stories.tsx
+++ b/packages/ui-components/src/stories/Colors.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import isObject from "lodash/isObject";
-import { Typography, Palette, Grid, Box } from "@mui/material";
+import { Typography, Palette, Grid, Box, Stack } from "@mui/material";
 import theme from "../styles/theme";
 
 export default {
@@ -55,7 +55,10 @@ const ColorGroup: React.FC<{
           <ColorBox color={item.color} />
         </Grid>
         <Grid item sm={11} xs={12}>
-          <Typography variant="labelSmall">{item.name}</Typography>
+          <Stack direction="column" spacing={0.5}>
+            <Typography variant="labelSmall">{item.name}</Typography>
+            <Typography variant="dataTabular">{item.color}</Typography>
+          </Stack>
         </Grid>
       </Grid>
     ))}

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -81,6 +81,25 @@ const components: ThemeOptions["components"] = {
       },
     },
   },
+  MuiChip: {
+    styleOverrides: {
+      root: {
+        border: `solid 1px ${palette.border.default}`,
+      },
+      label: {
+        fontFamily: typography.labelSmall.fontFamily,
+        fontSize: typography.labelSmall.fontSize,
+        fontWeight: typography.labelSmall.fontWeight,
+        lineHeight: typography.labelSmall.lineHeight,
+        color: palette.secondary.dark,
+      },
+      deleteIcon: {
+        ":hover": {
+          color: palette.secondary.dark,
+        },
+      },
+    },
+  },
 };
 
 export default components;

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -1,32 +1,30 @@
 /** MUI theme components */
 import { ThemeOptions, createTheme } from "@mui/material";
-import typography, { typographyConstants } from "./typography";
-import palette from "./palette";
 
 const referenceTheme = createTheme();
 
 const components: ThemeOptions["components"] = {
   MuiButton: {
     styleOverrides: {
-      root: {
+      root: ({ theme }) => ({
         textTransform: "none",
-        fontFamily: typography.labelLarge.fontFamily,
-        fontSize: typography.labelLarge.fontSize,
-        fontWeight: typography.labelLarge.fontWeight,
-        lineHeight: typography.labelLarge.lineHeight,
-      },
-      outlinedPrimary: {
-        borderColor: palette.border.default,
-      },
+        fontFamily: theme.typography.labelLarge.fontFamily,
+        fontSize: theme.typography.labelLarge.fontSize,
+        fontWeight: theme.typography.labelLarge.fontWeight,
+        lineHeight: theme.typography.labelLarge.lineHeight,
+      }),
+      outlinedPrimary: ({ theme }) => ({
+        borderColor: theme.palette.border.default,
+      }),
     },
   },
   MuiTooltip: {
     styleOverrides: {
-      tooltip: {
+      tooltip: ({ theme }) => ({
         backgroundColor: "black",
         color: "white",
-        fontSize: typographyConstants.fontSizeBase,
-        lineHeight: typographyConstants.lineHeightBase,
+        fontSize: theme.typography.paragraphLarge.fontSize,
+        lineHeight: theme.typography.paragraphLarge.lineHeight,
         padding: "16px",
         "& a": {
           color: "white",
@@ -34,7 +32,7 @@ const components: ThemeOptions["components"] = {
         [referenceTheme.breakpoints.down("sm")]: {
           padding: "20px 24px",
         },
-      },
+      }),
       arrow: {
         color: "black",
       },
@@ -42,30 +40,30 @@ const components: ThemeOptions["components"] = {
   },
   MuiToggleButtonGroup: {
     styleOverrides: {
-      root: {
-        ...typography.paragraphSmall,
-        border: `solid 1px ${palette.border.default}`,
-      },
-      groupedHorizontal: {
+      root: ({ theme }) => ({
+        ...theme.typography.paragraphSmall,
+        border: `solid 1px ${theme.palette.border.default}`,
+      }),
+      groupedHorizontal: ({ theme }) => ({
         border: "none",
-        color: typography.paragraphSmall.color,
+        color: theme.typography.paragraphSmall.color,
         textTransform: "none",
         borderBottom: `solid 2px transparent`,
         ":not(:first-of-type)": {
           borderLeft: "none",
         },
         "&.Mui-selected": {
-          ...typography.labelSmall,
-          borderBottom: `solid 2px ${palette.secondary.dark}`,
+          ...theme.typography.labelSmall,
+          borderBottom: `solid 2px ${theme.palette.secondary.dark}`,
           backgroundColor: "transparent",
         },
-      },
-      groupedVertical: {
+      }),
+      groupedVertical: ({ theme }) => ({
         borderLeft: "none",
         borderRight: "none",
         borderTop: "none",
         borderBottom: "none",
-        color: typography.paragraphSmall.color,
+        color: theme.typography.paragraphSmall.color,
         textTransform: "none",
         ":first-of-type": {
           borderTop: "none",
@@ -74,30 +72,28 @@ const components: ThemeOptions["components"] = {
           borderBottom: "none",
         },
         "&.Mui-selected": {
-          ...typography.labelSmall,
-          borderRight: `solid 2px ${palette.secondary.dark}`,
+          ...theme.typography.labelSmall,
+          borderRight: `solid 2px ${theme.palette.secondary.dark}`,
           backgroundColor: "transparent",
         },
-      },
+      }),
     },
   },
   MuiChip: {
     styleOverrides: {
-      root: {
-        border: `solid 1px ${palette.border.default}`,
-      },
-      label: {
-        fontFamily: typography.labelSmall.fontFamily,
-        fontSize: typography.labelSmall.fontSize,
-        fontWeight: typography.labelSmall.fontWeight,
-        lineHeight: typography.labelSmall.lineHeight,
-        color: palette.secondary.dark,
-      },
-      deleteIcon: {
+      root: ({ theme }) => ({
+        borderColor: theme.palette.border.default,
+      }),
+      label: ({ theme }) => ({
+        ...theme.typography.labelSmall,
+        color: theme.palette.secondary.dark,
+      }),
+      deleteIcon: ({ theme }) => ({
+        color: theme.palette.text.disabled,
         ":hover": {
-          color: palette.secondary.dark,
+          color: theme.palette.secondary.dark,
         },
-      },
+      }),
     },
   },
 };


### PR DESCRIPTION
Close #212 - Style the MUI Chip component

- [ActNow Design System - Chip (Tag)](https://www.figma.com/file/YN7x6bJmSfRHaovP5ABKu2/ActNow-Design-System?node-id=72%3A2447)
- [Storybook → Chip → Clickable & Deletable](https://act-now-packages--pr218-pablo-chip-component-vi2ogvue.web.app/storybook/index.html?path=/story/design-system-chip--clickable-and-deletable)

<img width="128" alt="image" src="https://user-images.githubusercontent.com/114084/191824187-227cf227-3372-444a-9fa5-84bfd830f95c.png">

I discovered a way to use all the theme variables when styling a component. Instead of importing the bare `typography` and `palette` objects, we can pass a callback to the styles of each component. 

Before this change, only the `palette` variables that we customized were available, not the ones inherited from MUI (for example, `theme.palette.grey[100]` or `theme.palette.text.disabled` were not available). Using the callback syntax makes all the colors available (similar for the typography).

I also added the hex codes to the stories for Color, so we can more easily match the mocks when they reference colors with a different name.

Note that we only have designs for the outlined version, so I only styled that one.