### PR TITLE
Implement tabs

### DIFF
--- a/.changeset/flat-rings-travel.md
+++ b/.changeset/flat-rings-travel.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Implement tabs

--- a/packages/ui-components/src/stories/Tabs.stories.tsx
+++ b/packages/ui-components/src/stories/Tabs.stories.tsx
@@ -12,34 +12,51 @@ const washingtonState = states.findByRegionIdStrict("53");
 
 const TabContent = () => {
   return (
-    <Stack>
-      <Typography variant="labelLarge" textAlign="left" mb={1}>
+    <Stack spacing={1}>
+      <Typography variant="labelLarge" textAlign="left">
         Metric Name
       </Typography>
       <MetricValue
         metric={MetricId.MOCK_CASES}
         region={washingtonState}
-        mb={1}
+        variant="dataEmphasizedSmall"
       />
-      <Typography variant="paragraphSmall" mb={1}>
-        Supporting text
-      </Typography>
+      <Typography variant="paragraphSmall">Supporting text</Typography>
     </Stack>
   );
 };
 
 export const SingleTab = () => <Tab label={<TabContent />} />;
 
-export const MultiTabs = () => {
+export const MultiTabsWithIndicator = () => {
   const [value, setValue] = useState(1);
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
   return (
     <Tabs value={value} onChange={handleChange}>
-      <Tab value={1} label={<TabContent />} />
-      <Tab value={2} label={<TabContent />} />
-      <Tab value={3} label={<TabContent />} />
+      <Tab value={1} label={<TabContent />} disableRipple />
+      <Tab value={2} label={<TabContent />} disableRipple />
+      <Tab value={3} label={<TabContent />} disableRipple />
+    </Tabs>
+  );
+};
+
+export const MultiTabsWithoutIndicator = () => {
+  const [value, setValue] = useState(1);
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+  return (
+    <Tabs
+      value={value}
+      onChange={handleChange}
+      TabIndicatorProps={{ sx: { backgroundColor: "transparent" } }}
+      style={{ borderBottom: "none" }}
+    >
+      <Tab value={1} label={<TabContent />} disableRipple />
+      <Tab value={2} label={<TabContent />} disableRipple />
+      <Tab value={3} label={<TabContent />} disableRipple />
     </Tabs>
   );
 };

--- a/packages/ui-components/src/stories/Tabs.stories.tsx
+++ b/packages/ui-components/src/stories/Tabs.stories.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+import { Stack, Tab, Typography, Tabs } from "@mui/material";
+import { MetricId } from "./mockMetricCatalog";
+import { states } from "@actnowcoalition/regions";
+import { MetricValue } from "../components/MetricValue";
+
+export default {
+  title: "Design System/Tabs",
+};
+
+const washingtonState = states.findByRegionIdStrict("53");
+
+const TabContent = () => {
+  return (
+    <Stack>
+      <Typography variant="labelLarge" textAlign="left" mb={1}>
+        Metric Name
+      </Typography>
+      <MetricValue
+        metric={MetricId.MOCK_CASES}
+        region={washingtonState}
+        mb={1}
+      />
+      <Typography variant="paragraphSmall" mb={1}>
+        Supporting text
+      </Typography>
+    </Stack>
+  );
+};
+
+export const SingleTab = () => <Tab label={<TabContent />} />;
+
+export const MultiTabs = () => {
+  const [value, setValue] = useState(1);
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+  return (
+    <Tabs value={value} onChange={handleChange}>
+      <Tab value={1} label={<TabContent />} />
+      <Tab value={2} label={<TabContent />} />
+      <Tab value={3} label={<TabContent />} />
+    </Tabs>
+  );
+};

--- a/packages/ui-components/src/stories/Tabs.stories.tsx
+++ b/packages/ui-components/src/stories/Tabs.stories.tsx
@@ -41,22 +41,3 @@ export const MultiTabsWithIndicator = () => {
     </Tabs>
   );
 };
-
-export const MultiTabsWithoutIndicator = () => {
-  const [value, setValue] = useState(1);
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
-    setValue(newValue);
-  };
-  return (
-    <Tabs
-      value={value}
-      onChange={handleChange}
-      TabIndicatorProps={{ sx: { backgroundColor: "transparent" } }}
-      style={{ borderBottom: "none" }}
-    >
-      <Tab value={1} label={<TabContent />} disableRipple />
-      <Tab value={2} label={<TabContent />} disableRipple />
-      <Tab value={3} label={<TabContent />} disableRipple />
-    </Tabs>
-  );
-};

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -4,6 +4,38 @@ import { ThemeOptions, createTheme } from "@mui/material";
 const referenceTheme = createTheme();
 
 const components: ThemeOptions["components"] = {
+  MuiTabs: {
+    styleOverrides: {
+      indicator: {
+        height: "3px",
+        backgroundColor: "black",
+      },
+      flexContainer: ({ theme }) => ({
+        borderBottom: `1px solid ${theme.palette.border.default}`,
+        width: "fit-content",
+      }),
+    },
+  },
+  MuiTab: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        textTransform: "none",
+        padding: "0px 0px 16px 0px",
+        margin: "0px 13px",
+        ":first-of-type": {
+          marginLeft: "0px",
+        },
+        ":last-of-type": {
+          marginRight: "0px",
+        },
+        ":not(&.Mui-selected)": {
+          span: {
+            color: theme.palette.text.secondary,
+          },
+        },
+      }),
+    },
+  },
   MuiButton: {
     styleOverrides: {
       root: ({ theme }) => ({

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -6,10 +6,10 @@ const referenceTheme = createTheme();
 const components: ThemeOptions["components"] = {
   MuiTabs: {
     styleOverrides: {
-      indicator: {
-        height: "3px",
-        backgroundColor: "black",
-      },
+      indicator: ({ theme }) => ({
+        height: theme.spacing(0.375),
+        backgroundColor: theme.palette.common.black,
+      }),
       flexContainer: ({ theme }) => ({
         borderBottom: `1px solid ${theme.palette.border.default}`,
         width: "fit-content",
@@ -20,8 +20,8 @@ const components: ThemeOptions["components"] = {
     styleOverrides: {
       root: ({ theme }) => ({
         textTransform: "none",
-        padding: "0px 0px 16px 0px",
-        margin: "0px 13px",
+        padding: `0px 0px ${theme.spacing(2)} 0px`,
+        margin: `0px ${theme.spacing(2)}`,
         ":first-of-type": {
           marginLeft: "0px",
         },

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -7,7 +7,7 @@ const components: ThemeOptions["components"] = {
   MuiTabs: {
     styleOverrides: {
       indicator: ({ theme }) => ({
-        height: theme.spacing(0.375),
+        height: "2px",
         backgroundColor: theme.palette.common.black,
       }),
       flexContainer: ({ theme }) => ({
@@ -20,13 +20,13 @@ const components: ThemeOptions["components"] = {
     styleOverrides: {
       root: ({ theme }) => ({
         textTransform: "none",
-        padding: `0px 0px ${theme.spacing(2)} 0px`,
-        margin: `0px ${theme.spacing(2)}`,
+        padding: `0 0 ${theme.spacing(2)} 0`,
+        margin: `0 ${theme.spacing(2)}`,
         ":first-of-type": {
-          marginLeft: "0px",
+          marginLeft: "0",
         },
         ":last-of-type": {
-          marginRight: "0px",
+          marginRight: "0",
         },
         ":not(&.Mui-selected)": {
           span: {


### PR DESCRIPTION
Closes https://github.com/covid-projections/act-now-packages/issues/96

Notes:
- For "tabs" that are not clickable, we decided to not implement them using MUI tabs. This PR only focuses on clickable tabs.
- The tab component is not supposed to be aware of its content. So we're leaving the dot inside the `MetricValue` component as its original color instead of greyed out when one selects a different tab.