### PR TITLE
regions: Update RegionDB to take an optional relativeUrl function

### DIFF
--- a/.changeset/old-lizards-turn.md
+++ b/.changeset/old-lizards-turn.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/regions": minor
+---
+
+RegionDB receives options to customize the relativeUrl region

--- a/packages/regions/src/Region.ts
+++ b/packages/regions/src/Region.ts
@@ -22,7 +22,7 @@ export class Region {
     public readonly slug: string,
     public readonly relativeUrl: string,
     public readonly parent: Region | null,
-    // TODO: transfrom population and potentially other attributes to Metric.
+    // TODO: transform population and potentially other attributes to Metric.
     // This will allow us to leverage on more advanced Metric functionality,
     // such as display sources, number formatting options, etc.
     public readonly population: number
@@ -38,7 +38,7 @@ export class Region {
 
   /**
    * Generates a slug from the input string by replacing accented
-   * characters with their basic Latin equivalents, replacing whitespaces
+   * characters with their basic Latin equivalents, replacing white spaces
    * with underscores and splitting words when capitalization changes.
    *
    * @example

--- a/packages/regions/src/RegionDB.test.ts
+++ b/packages/regions/src/RegionDB.test.ts
@@ -1,0 +1,16 @@
+import { RegionDB } from "./RegionDB";
+import { states, Region } from "./";
+
+describe("RegionDB", () => {
+  test("The relativeUrl option is applied", () => {
+    const regions = new RegionDB(states.all);
+    expect(regions.findByRegionIdStrict("53")?.relativeUrl).toBe("");
+
+    const customizedRegions = new RegionDB(states.all, {
+      relativeUrl: (region: Region) => `/states/${region.slug}`,
+    });
+    expect(customizedRegions.findByRegionIdStrict("53").relativeUrl).toBe(
+      "/states/washington-wa"
+    );
+  });
+});

--- a/packages/regions/src/RegionDB.ts
+++ b/packages/regions/src/RegionDB.ts
@@ -2,11 +2,30 @@ import keyBy from "lodash/keyBy";
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "./Region";
 
+export interface RegionDBOptions {
+  /** Customize the relativeUrl property of each region in this RegionDB */
+  relativeUrl: (region: Region) => string;
+}
+
+const defaultOptions: RegionDBOptions = {
+  relativeUrl: () => "",
+};
+
 export class RegionDB {
   private regionsById: { [regionId: string]: Region };
 
-  constructor(private regions: Region[]) {
-    this.regionsById = keyBy(regions, (region: Region) => region.regionId);
+  constructor(private regions: Region[], private options?: RegionDBOptions) {
+    const { relativeUrl } = { ...defaultOptions, ...options };
+
+    // Reconstruct the region array using the provided options
+    this.regions = regions.map((region) =>
+      Region.fromJSON({
+        ...region.toJSON(),
+        relativeUrl: relativeUrl(region),
+      })
+    );
+
+    this.regionsById = keyBy(this.regions, (region: Region) => region.regionId);
   }
 
   findByRegionId(regionId: string): Region | null {


### PR DESCRIPTION
Part of #220 - Updating the map components to take app regions. This will require updating a few different parts, so this PR is just to make the `relativeUrl` customizable when initializing the `RegionDB`.

**Example:**

```tsx
// src/utils/regions.ts

const regions = new RegionsDB([...states.all], {
  relativeUrl: (region:Region) => `/us/states/${region.slug}`
});

// ...

const washington = regions.findByRegionIdStrict('53');
washington.relativeUrl  // "/us/states/washington-wa"
```

