### PR TITLE
Demo: `USCountiesMap` component

### DIFF
--- a/packages/ui-components/src/components/Maps/USNationalMap/USCountiesMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USCountiesMap.stories.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import min from "lodash/min";
+import max from "lodash/max";
+import { Story, ComponentMeta } from "@storybook/react";
+import { USNationalMap } from "./USNationalMap";
+import { scaleLinear } from "@visx/scale";
+import { USCountiesMap, USCountiesMapProps } from "./USCountiesMap";
+import {
+  defaultHeight,
+  defaultScale,
+  defaultWidth,
+} from "../../../common/geo-shapes";
+import { geoAlbersUsa } from "d3-geo";
+import { counties } from "@actnowcoalition/regions";
+
+export default {
+  title: "Maps/USCountiesMap",
+  component: USNationalMap,
+} as ComponentMeta<typeof USNationalMap>;
+
+const Template: Story<USCountiesMapProps> = (args) => (
+  <svg width={args.width} height={args.height}>
+    <USCountiesMap {...args} />
+  </svg>
+);
+
+const width = 600;
+const height = defaultHeight * (width / defaultWidth);
+const scale = (defaultScale * width) / defaultWidth;
+
+const canvasProjection = geoAlbersUsa()
+  .scale(2 * scale)
+  .translate([width, height]);
+
+const countyRegionIds = counties.all.map((c) => Number(c.regionId));
+const minValue = min(countyRegionIds) || 0;
+const maxValue = max(countyRegionIds) || 100;
+
+const colorScale = scaleLinear({
+  domain: [minValue, maxValue],
+  range: ["#dd33fa", "#4615b2"],
+});
+
+export const Example = Template.bind({});
+Example.args = {
+  width: 600,
+  height: 400,
+  getFillColor: (countyId: string) => colorScale(Number(countyId)),
+  geoProjection: canvasProjection,
+  getGeoId: (geo) => `${geo.id}`,
+};

--- a/packages/ui-components/src/components/Maps/USNationalMap/USCountiesMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USCountiesMap.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { ExtendedFeature, GeoProjection, geoPath as d3GeoPath } from "d3-geo";
 import { StyledCanvas } from "../Maps.style";
-import { stateBorders } from "../../../common/geo-shapes";
-import { countiesGeographies } from "../../../common/geo-shapes";
+import { countiesGeographies, stateBorders } from "../../../common/geo-shapes";
 
 const borderColor = "white";
 

--- a/packages/ui-components/src/components/Maps/USNationalMap/USCountiesMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USCountiesMap.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useRef } from "react";
+import { ExtendedFeature, GeoProjection, geoPath as d3GeoPath } from "d3-geo";
+import { StyledCanvas } from "../Maps.style";
+import { stateBorders } from "../../../common/geo-shapes";
+import { countiesGeographies } from "../../../common/geo-shapes";
+
+const borderColor = "white";
+
+export interface USCountiesMapProps {
+  width: number;
+  height: number;
+  getFillColor: (regionId: string) => string;
+  geoProjection: GeoProjection;
+  getGeoId: (geo: ExtendedFeature) => string;
+}
+
+export const USCountiesMap: React.FC<USCountiesMapProps> = ({
+  width,
+  height,
+  getFillColor,
+  geoProjection,
+  getGeoId,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas) {
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        const path = d3GeoPath(geoProjection, ctx);
+        // Feature shapes and borders
+        countiesGeographies.features.forEach((geo) => {
+          const geoId = getGeoId(geo);
+          ctx.strokeStyle = borderColor;
+          ctx.lineWidth = 1;
+          ctx.fillStyle = getFillColor(geoId);
+          ctx.beginPath();
+          path(geo);
+          ctx.fill();
+          ctx.stroke();
+        });
+        // State borders
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = borderColor;
+        ctx.beginPath();
+        path(stateBorders);
+        ctx.stroke();
+      }
+    }
+  });
+
+  return (
+    <foreignObject width={width} height={height}>
+      <StyledCanvas
+        width={2 * width}
+        height={2 * height}
+        ref={canvasRef}
+        style={{ width, height }}
+      />
+    </foreignObject>
+  );
+};


### PR DESCRIPTION
In this implementation, the counties map is still rendered with canvas, but using a `foreignObject` wrapper so it can be included inside an SVG element.

The `getFillColor` function now receives a `regionId` string instead of a `Region`, which will allow us to remove the local dependencies on the counties `RegionDB` instance.