### PR TITLE
Update maps to receive regionDB instead of importing regions directly

### DIFF
--- a/.changeset/loud-snails-fry.md
+++ b/.changeset/loud-snails-fry.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": minor
+---
+
+Update the maps to not import regions directly

--- a/packages/ui-components/src/common/utils/maps.ts
+++ b/packages/ui-components/src/common/utils/maps.ts
@@ -1,4 +1,4 @@
-import { counties, Region } from "@actnowcoalition/regions";
+import { RegionDB, Region } from "@actnowcoalition/regions";
 
 /** Checks if a county or congressional district belongs to a given state */
 export function belongsToState(
@@ -11,8 +11,11 @@ export function belongsToState(
 }
 
 /** Returns an array of all counties of a given state */
-export function getCountiesOfState(stateRegionId: string): Region[] {
-  return counties.all.filter(
+export function getCountiesOfState(
+  regionDB: RegionDB,
+  stateRegionId: string
+): Region[] {
+  return regionDB.all.filter(
     (county) => county.parent?.regionId === stateRegionId
   );
 }

--- a/packages/ui-components/src/components/Maps/RenderMapProps.ts
+++ b/packages/ui-components/src/components/Maps/RenderMapProps.ts
@@ -1,7 +1,5 @@
-import { Region } from "@actnowcoalition/regions";
-
 export interface RenderMapProps {
   renderTooltip: (regionId: string) => React.ReactElement | string;
-  getFillColor?: (region: Region) => string;
+  getFillColor?: (regionId: string) => string;
   width?: number;
 }

--- a/packages/ui-components/src/components/Maps/USNationalMap/CanvasMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/CanvasMap.tsx
@@ -1,23 +1,14 @@
 import React, { useEffect, useRef } from "react";
 import { ExtendedFeature, GeoProjection, geoPath as d3GeoPath } from "d3-geo";
-import { StyledCanvas } from "../Maps.style";
 import { stateBorders } from "../../../common/geo-shapes";
-import {
-  Region,
-  states,
-  metros,
-  counties,
-  RegionDB,
-} from "@actnowcoalition/regions";
-
-const usRegions = new RegionDB([...states.all, ...counties.all, ...metros.all]);
+import { StyledCanvas } from "../Maps.style";
 
 const borderColor = "white";
 
 const CanvasMap: React.FC<{
   width: number;
   height: number;
-  getFillColor: (region: Region) => string;
+  getFillColor: (regionId: string) => string;
   geoProjection: GeoProjection;
   features: ExtendedFeature[];
   getGeoId: (geo: ExtendedFeature) => string;
@@ -33,10 +24,9 @@ const CanvasMap: React.FC<{
         // Feature shapes and borders
         features.forEach((geo) => {
           const geoId = getGeoId(geo);
-          const region = usRegions.findByRegionIdStrict(geoId);
           ctx.strokeStyle = borderColor;
           ctx.lineWidth = 1;
-          ctx.fillStyle = getFillColor(region);
+          ctx.fillStyle = getFillColor(geoId);
           ctx.beginPath();
           path(geo);
           ctx.fill();

--- a/packages/ui-components/src/components/Maps/USNationalMap/CountiesMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/CountiesMap.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import { ExtendedFeature, GeoProjection } from "d3-geo";
-import CanvasMap from "./CanvasMap";
 import { countiesGeographies } from "../../../common/geo-shapes";
-import { Region } from "@actnowcoalition/regions";
+import CanvasMap from "./CanvasMap";
 
 const CountiesMap: React.FC<{
   width: number;
   height: number;
-  getFillColor: (region: Region) => string;
+  getFillColor: (regionId: string) => string;
   geoProjection: GeoProjection;
   getGeoId: (geo: ExtendedFeature) => string;
 }> = (props) => (

--- a/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import { states, counties } from "@actnowcoalition/regions";
+import { states, counties, RegionDB } from "@actnowcoalition/regions";
 import { MetricId } from "../../../stories/mockMetricCatalog";
 import { MetricUSNationalMap } from "./MetricUSNationalMap";
 import { MetricUSNationalMapProps } from "./interfaces";
@@ -9,6 +9,8 @@ export default {
   title: "Maps/US National",
   component: MetricUSNationalMap,
 } as ComponentMeta<typeof MetricUSNationalMap>;
+
+const statesAndCounties = new RegionDB([...states.all, ...counties.all]);
 
 const Template: Story<MetricUSNationalMapProps> = (args) => (
   <MetricUSNationalMap {...args} />
@@ -32,5 +34,5 @@ MetricAwareCounties.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
   metric: MetricId.MOCK_CASES,
   showCounties: true,
-  regionDB: counties,
+  regionDB: statesAndCounties,
 };

--- a/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import { MetricUSNationalMap } from "./MetricUSNationalMap";
-import { states } from "@actnowcoalition/regions";
+import { states, counties } from "@actnowcoalition/regions";
 import { MetricId } from "../../../stories/mockMetricCatalog";
+import { MetricUSNationalMap } from "./MetricUSNationalMap";
 import { MetricUSNationalMapProps } from "./interfaces";
 
 export default {
@@ -23,6 +23,7 @@ export const MetricAwareStates = Template.bind({});
 MetricAwareStates.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
   metric: MetricId.MOCK_CASES,
+  regionDB: states,
 };
 
 /** Counties colored by mock metric data */
@@ -31,4 +32,5 @@ MetricAwareCounties.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
   metric: MetricId.MOCK_CASES,
   showCounties: true,
+  regionDB: counties,
 };

--- a/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.tsx
@@ -1,19 +1,15 @@
 import React from "react";
+import { useDataForRegionsAndMetrics } from "../../../common/hooks";
 import { USNationalMap } from "./USNationalMap";
 import { MetricUSNationalMapProps } from "./interfaces";
-import { states, counties, RegionDB } from "@actnowcoalition/regions";
-import { useDataForRegionsAndMetrics } from "../../../common/hooks";
-
-const statesAndCounties = new RegionDB([...states.all, ...counties.all]);
 
 export const MetricUSNationalMap: React.FC<MetricUSNationalMapProps> = ({
   metric,
+  regionDB,
   showCounties,
   ...otherProps
 }) => {
-  const mapRegions = showCounties ? statesAndCounties.all : states.all;
-
-  const { data } = useDataForRegionsAndMetrics(mapRegions, [metric], false);
+  const { data } = useDataForRegionsAndMetrics(regionDB.all, [metric], false);
 
   if (!data) {
     return null;
@@ -21,7 +17,10 @@ export const MetricUSNationalMap: React.FC<MetricUSNationalMapProps> = ({
 
   return (
     <USNationalMap
-      getFillColor={(region) => data.metricData(region, metric).getColor()}
+      getFillColor={(regionId: string) => {
+        const region = regionDB.findByRegionId(regionId);
+        return region ? data.metricData(region, metric).getColor() : "#eee";
+      }}
       showCounties={showCounties}
       {...otherProps}
     />

--- a/packages/ui-components/src/components/Maps/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/StatesMap.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { GeoPath } from "d3-geo";
 import Tooltip from "@mui/material/Tooltip";
-import { RegionOverlay, RegionShapeBase } from "../Maps.style";
 import { statesGeographies } from "../../../common/geo-shapes";
-import { Region, states } from "@actnowcoalition/regions";
+import { RegionOverlay, RegionShapeBase } from "../Maps.style";
 
 const StatesMap: React.FC<{
   width: number;
@@ -11,7 +10,7 @@ const StatesMap: React.FC<{
   geoPath: GeoPath;
   renderTooltip: (regionId: string) => React.ReactElement | string;
   showCounties: boolean;
-  getFillColor: (region: Region) => string;
+  getFillColor: (regionId: string) => string;
 }> = ({
   width,
   height,
@@ -20,23 +19,21 @@ const StatesMap: React.FC<{
   showCounties,
   getFillColor,
 }) => {
+  // TODO(Pablo): Add wrapping link once we update the RegionsDB API
   return (
     <svg width={width} height={height}>
       {statesGeographies.features.map((geo) => {
         const stateFips = `${geo.id}`;
-        const state = states.findByRegionIdStrict(stateFips);
         return (
           <Tooltip key={stateFips} title={renderTooltip(stateFips)}>
             <g>
-              <a href={state.relativeUrl}>
-                {!showCounties && (
-                  <RegionShapeBase
-                    d={geoPath(geo) ?? ""}
-                    fill={getFillColor(state)}
-                  />
-                )}
-                <RegionOverlay d={geoPath(geo) ?? ""} />
-              </a>
+              {!showCounties && (
+                <RegionShapeBase
+                  d={geoPath(geo) ?? ""}
+                  fill={getFillColor(stateFips)}
+                />
+              )}
+              <RegionOverlay d={geoPath(geo) ?? ""} />
             </g>
           </Tooltip>
         );

--- a/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.stories.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
+import { scaleOrdinal, scaleLinear } from "@visx/scale";
+import { interpolatePiYG } from "d3-scale-chromatic";
+import { states, counties, Region } from "@actnowcoalition/regions";
 import { USNationalMap } from "./USNationalMap";
 import { USNationalMapProps } from "./interfaces";
-import { states, Region } from "@actnowcoalition/regions";
-import { interpolatePiYG } from "d3-scale-chromatic";
-import { scaleOrdinal, scaleLinear } from "@visx/scale";
 
 export default {
   title: "Maps/US National",
@@ -65,7 +65,10 @@ const getFillColorByFirstLetter = (region: Region) => {
 export const StatesColoredByFirstLetter = Template.bind({});
 StatesColoredByFirstLetter.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
-  getFillColor: (region: Region) => getFillColorByFirstLetter(region),
+  getFillColor: (regionId: string) => {
+    const region = states.findByRegionIdStrict(regionId);
+    return getFillColorByFirstLetter(region);
+  },
 };
 
 /** Counties colored by first letter of fullName */
@@ -73,5 +76,8 @@ export const CountiesColoredByFirstLetter = Template.bind({});
 CountiesColoredByFirstLetter.args = {
   showCounties: true,
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
-  getFillColor: (region: Region) => getFillColorByFirstLetter(region),
+  getFillColor: (regionId: string) => {
+    const region = counties.findByRegionIdStrict(regionId);
+    return getFillColorByFirstLetter(region);
+  },
 };

--- a/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.tsx
@@ -1,16 +1,16 @@
 import React from "react";
-import { MapContainer, PositionAbsolute } from "../Maps.style";
+import { ParentSize } from "@visx/responsive";
+import { geoPath as d3GeoPath, geoAlbersUsa } from "d3-geo";
 import {
   defaultHeight,
   defaultScale,
   defaultWidth,
+  getCountyGeoId,
 } from "../../../common/geo-shapes";
-import { getCountyGeoId } from "../../../common/geo-shapes";
-import { geoPath as d3GeoPath, geoAlbersUsa } from "d3-geo";
+import { MapContainer, PositionAbsolute } from "../Maps.style";
 import StatesMap from "./StatesMap";
 import CountiesMap from "./CountiesMap";
 import { USNationalMapProps } from "./interfaces";
-import { ParentSize } from "@visx/responsive";
 
 const USNationalMapInner: React.FC<USNationalMapProps> = ({
   width = defaultWidth,

--- a/packages/ui-components/src/components/Maps/USNationalMap/interfaces.ts
+++ b/packages/ui-components/src/components/Maps/USNationalMap/interfaces.ts
@@ -1,5 +1,6 @@
-import { RenderMapProps } from "../RenderMapProps";
 import { Metric } from "@actnowcoalition/metrics";
+import { RegionDB } from "@actnowcoalition/regions";
+import { RenderMapProps } from "../RenderMapProps";
 
 export interface USNationalMapProps extends RenderMapProps {
   showCounties?: boolean;
@@ -7,4 +8,5 @@ export interface USNationalMapProps extends RenderMapProps {
 
 export interface MetricUSNationalMapProps extends USNationalMapProps {
   metric: Metric | string;
+  regionDB: RegionDB;
 }

--- a/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.stories.tsx
@@ -27,6 +27,7 @@ MetricAwareNewYork.args = {
   stateRegionId: "36",
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
   metric: MetricId.MOCK_CASES,
+  regionDB: statesAndCounties,
 };
 
 export const MetricAwareNewYorkWithHighlightedCounty = Template.bind({});
@@ -35,4 +36,5 @@ MetricAwareNewYorkWithHighlightedCounty.args = {
   currentRegion: herkimerCountyNewYorkRegion,
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
   metric: MetricId.MOCK_CASES,
+  regionDB: statesAndCounties,
 };

--- a/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { USStateMap } from "./USStateMap";
 import { MetricUSStateMapProps } from "./interfaces";
 import { useDataForRegionsAndMetrics } from "../../../common/hooks";
-import { states } from "@actnowcoalition/regions";
 import { getCountiesOfState } from "../../../common/utils/maps";
 
 export const MetricUSStateMap: React.FC<MetricUSStateMapProps> = ({
@@ -11,8 +10,8 @@ export const MetricUSStateMap: React.FC<MetricUSStateMapProps> = ({
   regionDB,
   ...otherProps
 }) => {
-  const state = states.findByRegionIdStrict(stateRegionId);
-  const countiesOfState = getCountiesOfState(stateRegionId);
+  const state = regionDB.findByRegionIdStrict(stateRegionId);
+  const countiesOfState = getCountiesOfState(regionDB, stateRegionId);
   const mapRegions = [...countiesOfState, state];
 
   const { data } = useDataForRegionsAndMetrics(mapRegions, [metric], false);

--- a/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.tsx
@@ -8,6 +8,7 @@ import { getCountiesOfState } from "../../../common/utils/maps";
 export const MetricUSStateMap: React.FC<MetricUSStateMapProps> = ({
   metric,
   stateRegionId,
+  regionDB,
   ...otherProps
 }) => {
   const state = states.findByRegionIdStrict(stateRegionId);
@@ -22,7 +23,10 @@ export const MetricUSStateMap: React.FC<MetricUSStateMapProps> = ({
 
   return (
     <USStateMap
-      getFillColor={(region) => data.metricData(region, metric).getColor()}
+      getFillColor={(regionId: string) => {
+        const region = regionDB.findByRegionId(regionId);
+        return region ? data.metricData(region, metric).getColor() : "#eee";
+      }}
       stateRegionId={stateRegionId}
       {...otherProps}
     />

--- a/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tooltip } from "@mui/material";
-import { counties, RegionDB, states } from "@actnowcoalition/regions";
+import { ParentSize } from "@visx/responsive";
 import { geoPath as d3GeoPath, geoAlbersUsa, geoMercator } from "d3-geo";
 import {
   statesGeographies,
@@ -16,9 +16,6 @@ import {
   RegionOverlay,
 } from "../Maps.style";
 import { USStateMapProps } from "./interfaces";
-import { ParentSize } from "@visx/responsive";
-
-const countiesAndStates = new RegionDB([...states.all, ...counties.all]);
 
 const USStateMapInner: React.FC<USStateMapProps> = ({
   stateRegionId,
@@ -63,19 +60,19 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
 
   const regionGeoToShow = showCounties ? regionsOfState : [stateGeo];
 
+  // TODO(Pablo): Restore the state link once we update the RegionDB API
   return (
     <MapContainer>
       <svg width={width} height={height}>
         {/* Style-able region shapes (ie. colorable by metric) */}
         {regionGeoToShow.map((geo) => {
-          const highlightShape = currentRegion?.regionId === `${geo.id}`;
+          const geoId = `${geo.id}`;
+          const highlightShape = currentRegion?.regionId === geoId;
           return (
             <HighlightableShape
-              key={geo.id}
+              key={geoId}
               d={geoPath(geo) ?? ""}
-              fill={getFillColor(
-                countiesAndStates.findByRegionIdStrict(`${geo.id}`)
-              )}
+              fill={getFillColor(geoId)}
               highlight={highlightShape}
             />
           );
@@ -85,13 +82,10 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
         {showBorderingStates &&
           otherStates.map((geo) => {
             const stateFips = `${geo.id}`;
-            const state = states.findByRegionIdStrict(stateFips);
             return (
-              <Tooltip title={renderTooltip(state.regionId)} key={geo.id}>
+              <Tooltip title={renderTooltip(stateFips)} key={stateFips}>
                 <g>
-                  <a href={state.relativeUrl}>
-                    <BorderingRegion d={geoPath(geo) ?? ""} />
-                  </a>
+                  <BorderingRegion d={geoPath(geo) ?? ""} />
                 </g>
               </Tooltip>
             );
@@ -99,13 +93,11 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
 
         {/* Clickable region overlay */}
         {regionGeoToShow.map((geo) => {
-          const region = countiesAndStates.findByRegionIdStrict(`${geo.id}`);
+          const geoId = `${geo.id}`;
           return (
-            <Tooltip title={renderTooltip(region.regionId)} key={geo.id}>
+            <Tooltip title={renderTooltip(geoId)} key={geoId}>
               <g>
-                <a href={region.relativeUrl}>
-                  <RegionOverlay d={geoPath(geo) ?? ""} />
-                </a>
+                <RegionOverlay d={geoPath(geo) ?? ""} />
               </g>
             </Tooltip>
           );

--- a/packages/ui-components/src/components/Maps/USStateMap/interfaces.ts
+++ b/packages/ui-components/src/components/Maps/USStateMap/interfaces.ts
@@ -1,6 +1,6 @@
 import { RenderMapProps } from "../RenderMapProps";
 import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 export interface USStateMapProps extends RenderMapProps {
   stateRegionId: string;
@@ -11,4 +11,5 @@ export interface USStateMapProps extends RenderMapProps {
 
 export interface MetricUSStateMapProps extends USStateMapProps {
   metric: Metric | string;
+  regionDB: RegionDB;
 }


### PR DESCRIPTION
Part of https://github.com/covid-projections/act-now-packages/issues/224 - Update the maps so they don't need to import regions directly. There are two main changes here:

- `getFillColor` now takes `regionId: string` instead of `Region`
- metric-aware maps receive `regionDB` as a prop instead of importing the regions directly

I also removed the links in the maps so we can get the URL from the app-level `RegionDB`, once that's implemented. Updated stories accordingly too.