### PR TITLE
Ensure we don't have multiple fetches for the same CSV going at once.

### DIFF
--- a/.changeset/wicked-spies-pay.md
+++ b/.changeset/wicked-spies-pay.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/metrics": patch
+---
+
+Avoid re-fetching CSV files when a fetch is already in progress.

--- a/packages/metrics/src/data_providers/CsvDataProvider.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.ts
@@ -41,6 +41,7 @@ export class CsvDataProvider extends CachingMetricDataProviderBase {
   private readonly dateColumn?: string;
   private readonly url?: string;
   private readonly csvText?: string;
+  private fetchedTextPromise: Promise<string> | undefined;
 
   private dataRowsByRegionId: { [regionId: string]: DataRow[] } = {};
 
@@ -59,7 +60,10 @@ export class CsvDataProvider extends CachingMetricDataProviderBase {
   async populateCache(): Promise<void> {
     let csvText;
     if (this.url) {
-      csvText = await this.fetchCsvText();
+      // We might already be fetching the CSV, in which case we can just wait on
+      // the existing promise.
+      this.fetchedTextPromise = this.fetchedTextPromise ?? this.fetchCsvText();
+      csvText = await this.fetchedTextPromise;
     } else {
       assert(this.csvText, "Either url or csvData must be provided.");
       csvText = this.csvText;
@@ -115,6 +119,7 @@ export class CsvDataProvider extends CachingMetricDataProviderBase {
    */
   private async fetchCsvText(): Promise<string> {
     assert(this.url, "URL must be specified in order to use fetchCsvText()");
+    console.log("Fetching", this.url);
     const response = await fetch(this.url);
     if (response.status !== 200) {
       throw new Error(


### PR DESCRIPTION
I noticed that when you go to https://hackathon-august-2022.vercel.app/ there are dozens of requests for monkeypox.csv in the network tab of chrome dev tools.  While we were caching the response already, there was a window of time where we are waiting for the response and more metric fetches could being triggered.

What we need to do is cache the *promise* so as long as the CSV fetch has been initiated we won't start a new one.