### PR TITLE
demo: RegionLink component

### DIFF
--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Paper } from "@mui/material";
-import { states } from "@actnowcoalition/regions";
+import { states, Region } from "@actnowcoalition/regions";
 import { MetricId } from "../../stories/mockMetricCatalog";
-import { MetricCompareTable } from ".";
+import { MetricCompareTable, RegionLinkComponentProp } from ".";
 
 export default {
   title: "Metrics/MetricCompareTable",
@@ -16,8 +16,31 @@ const Template: ComponentStory<typeof MetricCompareTable> = (args) => (
   </Paper>
 );
 
+const RegionLinkComponent: RegionLinkComponentProp = ({
+  children,
+  region,
+}: {
+  children: React.ReactNode;
+  region: Region;
+}) => (
+  <a
+    href={`/states/${region.slug}`}
+    aria-label={region.shortName}
+    style={{ display: "block", textDecoration: "none", color: "initial" }}
+  >
+    {children}
+  </a>
+);
+
 export const Example = Template.bind({});
 Example.args = {
+  regions: states.all,
+  metrics: [MetricId.PI, MetricId.MOCK_CASES, MetricId.PASS_FAIL],
+  RegionLinkComponent,
+};
+
+export const WithoutRegionLink = Template.bind({});
+WithoutRegionLink.args = {
   regions: states.all,
   metrics: [MetricId.PI, MetricId.MOCK_CASES, MetricId.PASS_FAIL],
 };

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, Fragment } from "react";
 import {
   ColumnDefinition,
   CompareTable,
@@ -13,6 +13,7 @@ import { createMetricColumn, createLocationColumn } from "./utils";
 export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
   regions,
   metrics: metricOrIds,
+  RegionLinkComponent = Fragment,
   ...otherCompareTableProps
 }) => {
   // TODO(Pablo): It might be better to define and set a context to control the
@@ -41,9 +42,20 @@ export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
   }));
 
   const columns: ColumnDefinition<Row>[] = [
-    createLocationColumn(sortDirection, sortColumnId, onClickSort),
+    createLocationColumn(
+      sortDirection,
+      sortColumnId,
+      onClickSort,
+      RegionLinkComponent
+    ),
     ...metrics.map((metric) =>
-      createMetricColumn(metric, sortDirection, sortColumnId, onClickSort)
+      createMetricColumn(
+        metric,
+        sortDirection,
+        sortColumnId,
+        onClickSort,
+        RegionLinkComponent
+      )
     ),
   ];
 

--- a/packages/ui-components/src/components/MetricCompareTable/interfaces.ts
+++ b/packages/ui-components/src/components/MetricCompareTable/interfaces.ts
@@ -1,6 +1,7 @@
 import { Region } from "@actnowcoalition/regions";
 import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
 import { CompareTableProps } from "../CompareTable";
+import React from "react";
 
 export interface Row {
   /** Unique ID for the row. */
@@ -11,10 +12,17 @@ export interface Row {
   multiMetricDataStore: MultiMetricDataStore;
 }
 
+export type RegionLinkComponentProp = React.JSXElementConstructor<{
+  region: Region;
+  children: React.ReactNode;
+}>;
+
 export interface MetricCompareTableProps
   extends Omit<CompareTableProps<Row>, "rows" | "columns"> {
   /** List of regions (first column)  */
   regions: Region[];
   /** List of metrics or metricID - order of the columns will match */
   metrics: (Metric | string)[];
+  /**  The link component needs an href prop */
+  RegionLinkComponent?: RegionLinkComponentProp;
 }

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -9,13 +9,14 @@ import {
   SortDirection,
   getAriaSort,
 } from "../CompareTable";
-import { Row } from "./interfaces";
+import { Row, RegionLinkComponentProp } from "./interfaces";
 
 export function createMetricColumn(
   metric: Metric,
   sortDirection: SortDirection,
   sortColumnId: string,
-  onClickSort: (direction: SortDirection, columnId: string) => void
+  onClickSort: (direction: SortDirection, columnId: string) => void,
+  RegionLinkComponent: RegionLinkComponentProp
 ): ColumnDefinition<Row> {
   return {
     columnId: metric.id,
@@ -33,12 +34,14 @@ export function createMetricColumn(
     },
     renderCell: ({ row }) => (
       <TableCell>
-        <MetricValue
-          metric={metric}
-          region={row.region}
-          variant="dataTabular"
-          justifyContent="end"
-        />
+        <RegionLinkComponent region={row.region}>
+          <MetricValue
+            metric={metric}
+            region={row.region}
+            variant="dataTabular"
+            justifyContent="end"
+          />
+        </RegionLinkComponent>
       </TableCell>
     ),
     sorterAsc: (rowA, rowB) => {
@@ -65,7 +68,8 @@ export function createMetricColumn(
 export function createLocationColumn(
   sortDirection: SortDirection,
   sortColumnId: string,
-  onClickSort: (direction: SortDirection, columnId: string) => void
+  onClickSort: (direction: SortDirection, columnId: string) => void,
+  RegionLinkComponent: RegionLinkComponentProp
 ): ColumnDefinition<Row> {
   return {
     columnId: "location",
@@ -84,7 +88,11 @@ export function createLocationColumn(
       );
     },
     renderCell: ({ row }) => (
-      <TableCell stickyColumn>{row.region.fullName}</TableCell>
+      <TableCell stickyColumn>
+        <RegionLinkComponent region={row.region}>
+          {row.region.fullName}
+        </RegionLinkComponent>
+      </TableCell>
     ),
     sorterAsc: (rowA, rowB) =>
       rowA.region.fullName < rowB.region.fullName ? -1 : 1,


### PR DESCRIPTION
Close #208  - In some components (maps, metric-aware compare table), we need to add links to location pages on some of the inner elements of the components. For the map, for example, each shape should link to location pages.

The _link_ element to be used depends on how routing works for that particular application. For CAN, for example, we use the `Link` component from `react-router`, on the template, we use `Link` from `next/link`, and on other apps we might want to use the native anchor element `a`. One option to solve this is to pass a component (with a given interface) as a prop, so each app can pass the type of link that they want (and attach additional props too). The [MUI Accordion](https://github.com/mui/material-ui/blob/master/packages/mui-material/src/Accordion/Accordion.js) component uses a similar pattern to allow users to customize the transition.

This demo adds a `RegionLinkComponent` prop that can be used to wrap the linking element to the corresponding region page, without tying it to a specific type of link component. For example, if we wanted to use `MetricCompareTable` using the Link from `react-router`, we could:

```tsx
import { Link } from "react-router";

<MetricCompareTable
  regions={regions}
  metrics={metrics}
  RegionLinkComponent={({ region, children }) => (
    <Link to={regionDB.getRegionUrl(region)} aria-label={region.shortName}>
      {children}
    </Link>
  )}
/>
```

Looking for feedback on the pattern for now. On the implementation side, we will need to style the table cell and the link a bit to make sure that we have good hover states (for the row) and to ensure that the link covers the entire cell.

