### PR TITLE
Fix MetricCompareTable, MetricDot, and MetricValue to not fetch timeseries data.

### DIFF
--- a/.changeset/rotten-cobras-protect.md
+++ b/.changeset/rotten-cobras-protect.md
@@ -1,0 +1,6 @@
+---
+"@actnowcoalition/metrics": minor
+"@actnowcoalition/ui-components": minor
+---
+
+Change the default for includeTimeseries to false when fetching data and fix the MetricCompareTable, MetricDot, and MetricValue to not fetch timeseries.

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.ts
@@ -102,13 +102,13 @@ export class MetricCatalog {
    *
    * @param region The region to get data for.
    * @param metric The metric to get data for as either a string or `Metric` object.
-   * @param includeTimeseries Whether to fetch timeseries data or not.
+   * @param includeTimeseries Whether to fetch timeseries data or not (default false).
    * @returns The metric data.
    */
   async fetchData(
     region: Region,
     metric: string | Metric,
-    includeTimeseries = true
+    includeTimeseries = false
   ): Promise<MetricData> {
     const dataStore = await this.fetchDataForMetrics(
       region,
@@ -123,13 +123,13 @@ export class MetricCatalog {
    *
    * @param region The region to get data for.
    * @param metrics The metrics to get data for as either strings or `Metric` objects.
-   * @param includeTimeseries Whether to fetch timeseries data or not.
+   * @param includeTimeseries Whether to fetch timeseries data or not (default false).
    * @returns The metric data.
    */
   async fetchDataForMetrics(
     region: Region,
     metrics: Array<string | Metric>,
-    includeTimeseries = true
+    includeTimeseries = false
   ): Promise<MultiMetricDataStore> {
     const dataStore = await this.fetchDataForRegionsAndMetrics(
       [region],
@@ -144,13 +144,13 @@ export class MetricCatalog {
    *
    * @param regions The regions to get data for.
    * @param metrics The metrics to get data for as either strings or `Metric` objects.
-   * @param includeTimeseries Whether to fetch timeseries data or not.
+   * @param includeTimeseries Whether to fetch timeseries data or not (default false).
    * @returns The metric data.
    */
   async fetchDataForRegionsAndMetrics(
     regions: Region[],
     metrics: Array<string | Metric>,
-    includeTimeseries = true
+    includeTimeseries = false
   ): Promise<MultiRegionMultiMetricDataStore> {
     this.dataFetchesCount++;
 

--- a/packages/ui-components/src/common/hooks/metric-data.ts
+++ b/packages/ui-components/src/common/hooks/metric-data.ts
@@ -24,13 +24,13 @@ export type DataOrError<T> = { data?: T; error?: Error };
  *
  * @param region The region to get data for.
  * @param metric The metric to get data for as either a string or `Metric` object.
- * @param includeTimeseries Whether to fetch timeseries data or not.
+ * @param includeTimeseries Whether to fetch timeseries data or not (default false).
  * @returns The metric data.
  */
 export function useData(
   region: Region,
   metric: string | Metric,
-  includeTimeseries = true
+  includeTimeseries = false
 ): DataOrError<MetricData> {
   const { data: dataStore, error } = useDataForMetrics(
     region,
@@ -46,13 +46,13 @@ export function useData(
  *
  * @param region The region to get data for.
  * @param metrics The metrics to get data for as either strings or `Metric` objects.
- * @param includeTimeseries Whether to fetch timeseries data or not.
+ * @param includeTimeseries Whether to fetch timeseries data or not (default false).
  * @returns The metric data.
  */
 export function useDataForMetrics(
   region: Region,
   metrics: Array<string | Metric>,
-  includeTimeseries = true
+  includeTimeseries = false
 ): DataOrError<MultiMetricDataStore> {
   const { data: dataStore, error } = useDataForRegionsAndMetrics(
     [region],
@@ -68,7 +68,7 @@ export function useDataForMetrics(
  *
  * @param regions The regions to get data for.
  * @param metrics The metrics to get data for as either strings or `Metric` objects.
- * @param includeTimeseries Whether to fetch timeseries data or not.
+ * @param includeTimeseries Whether to fetch timeseries data or not (default false).
  * @param optCatalog Optional metric catalog to use. If not provided, the
  * catalog is fetched via useMetricCatalog().
  * @returns The metric data.
@@ -76,7 +76,7 @@ export function useDataForMetrics(
 export function useDataForRegionsAndMetrics(
   regions: Region[],
   metrics: Array<string | Metric>,
-  includeTimeseries = true,
+  includeTimeseries = false,
   optCatalog?: MetricCatalog
 ): DataOrError<MultiRegionMultiMetricDataStore> {
   // HACK: optCatalog should override the context catalog, but

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
@@ -16,7 +16,7 @@ const MetricAwareDemo: React.FC<{
   const metric = metricCatalog.getMetric(metricOrId);
 
   // Get data from the metric catalog
-  const { data, error } = useData(region, metric);
+  const { data, error } = useData(region, metric, /*includeTimeseries=*/ false);
 
   // The component needs to handle error and loading states
   if (error || !data) {

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -28,7 +28,11 @@ export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
   const metricCatalog = useMetricCatalog();
   const metrics = metricOrIds.map((m) => metricCatalog.getMetric(m));
 
-  const { data, error } = useDataForRegionsAndMetrics(regions, metrics);
+  const { data, error } = useDataForRegionsAndMetrics(
+    regions,
+    metrics,
+    /*includeTimeseries=*/ false
+  );
 
   if (!data || error) {
     return null;

--- a/packages/ui-components/src/components/MetricDot/MetricDot.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.tsx
@@ -24,7 +24,7 @@ export const MetricDot: React.FC<MetricDotProps> = ({
 }) => {
   const metricCatalog = useMetricCatalog();
   const metric = metricCatalog.getMetric(metricOrId);
-  const { data, error } = useData(region, metric);
+  const { data, error } = useData(region, metric, /*includeTimeseries=*/ false);
 
   if (!(metric.levelSet || metric.categories) || error || !data) {
     return <PlaceholderDot />;

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -29,10 +29,11 @@ export const MetricSparklines: React.FC<MetricSparklinesProps> = ({
   const metricCatalog = useMetricCatalog();
   metricLineChart = metricCatalog.getMetric(metricLineChart);
   metricBarChart = metricCatalog.getMetric(metricBarChart);
-  const { data, error } = useDataForMetrics(region, [
-    metricLineChart,
-    metricBarChart,
-  ]);
+  const { data, error } = useDataForMetrics(
+    region,
+    [metricLineChart, metricBarChart],
+    /*includeTimeseries=*/ true
+  );
   if (error) {
     throw error;
   } else if (!data) {

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -27,7 +27,7 @@ export const MetricValue: React.FC<MetricValueProps> = ({
   const metricCatalog = useMetricCatalog();
   const metric = metricCatalog.getMetric(metricOrId);
 
-  const { data, error } = useData(region, metric);
+  const { data, error } = useData(region, metric, /*includeTimeseries=*/ false);
 
   if (!data || error) {
     return <Typography variant={variant} />;


### PR DESCRIPTION
Also change the default for includeTimeseries to false when fetching data.