### PR TITLE
Update map components to have configurable region URLs

### DIFF
--- a/packages/ui-components/src/components/Maps/RenderMapProps.ts
+++ b/packages/ui-components/src/components/Maps/RenderMapProps.ts
@@ -1,5 +1,6 @@
 export interface RenderMapProps {
   renderTooltip: (regionId: string) => React.ReactElement | string;
   getFillColor?: (regionId: string) => string;
+  getRegionUrl?: (regionId: string) => string;
   width?: number;
 }

--- a/packages/ui-components/src/components/Maps/RenderMapProps.ts
+++ b/packages/ui-components/src/components/Maps/RenderMapProps.ts
@@ -1,6 +1,6 @@
 export interface RenderMapProps {
   renderTooltip: (regionId: string) => React.ReactElement | string;
   getFillColor?: (regionId: string) => string;
-  getRegionUrl?: (regionId: string) => string;
+  getRegionUrl?: (regionId: string) => string | undefined;
   width?: number;
 }

--- a/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import { states, counties, RegionDB } from "@actnowcoalition/regions";
+import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
 import { MetricId } from "../../../stories/mockMetricCatalog";
 import { MetricUSNationalMap } from "./MetricUSNationalMap";
 import { MetricUSNationalMapProps } from "./interfaces";
@@ -10,14 +10,16 @@ export default {
   component: MetricUSNationalMap,
 } as ComponentMeta<typeof MetricUSNationalMap>;
 
-const statesAndCounties = new RegionDB([...states.all, ...counties.all]);
+const statesAndCounties = new RegionDB([...states.all, ...counties.all], {
+  getRegionUrl: (region: Region) => `/us/${region.slug}`,
+});
 
 const Template: Story<MetricUSNationalMapProps> = (args) => (
   <MetricUSNationalMap {...args} />
 );
 
 const renderSimpleTooltip = (regionId: string) => {
-  return states.findByRegionIdStrict(regionId).fullName;
+  return statesAndCounties.findByRegionIdStrict(regionId).fullName;
 };
 
 /** States colored by mock metric data */
@@ -25,7 +27,7 @@ export const MetricAwareStates = Template.bind({});
 MetricAwareStates.args = {
   renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
   metric: MetricId.MOCK_CASES,
-  regionDB: states,
+  regionDB: statesAndCounties,
 };
 
 /** Counties colored by mock metric data */

--- a/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.stories.tsx
@@ -10,7 +10,7 @@ export default {
   component: MetricUSNationalMap,
 } as ComponentMeta<typeof MetricUSNationalMap>;
 
-const statesAndCounties = new RegionDB([...states.all, ...counties.all], {
+const regionDB = new RegionDB([...states.all, ...counties.all], {
   getRegionUrl: (region: Region) => `/us/${region.slug}`,
 });
 
@@ -18,23 +18,23 @@ const Template: Story<MetricUSNationalMapProps> = (args) => (
   <MetricUSNationalMap {...args} />
 );
 
-const renderSimpleTooltip = (regionId: string) => {
-  return statesAndCounties.findByRegionIdStrict(regionId).fullName;
+const renderTooltip = (regionId: string) => {
+  return regionDB.findByRegionIdStrict(regionId).fullName;
 };
 
 /** States colored by mock metric data */
 export const MetricAwareStates = Template.bind({});
 MetricAwareStates.args = {
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
   metric: MetricId.MOCK_CASES,
-  regionDB: statesAndCounties,
+  regionDB,
 };
 
 /** Counties colored by mock metric data */
 export const MetricAwareCounties = Template.bind({});
 MetricAwareCounties.args = {
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
   metric: MetricId.MOCK_CASES,
   showCounties: true,
-  regionDB: statesAndCounties,
+  regionDB,
 };

--- a/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/MetricUSNationalMap.tsx
@@ -21,6 +21,11 @@ export const MetricUSNationalMap: React.FC<MetricUSNationalMapProps> = ({
         const region = regionDB.findByRegionId(regionId);
         return region ? data.metricData(region, metric).getColor() : "#eee";
       }}
+      getRegionUrl={(regionId: string) => {
+        const region = regionDB.findByRegionId(regionId);
+        const url = region ? regionDB.getRegionUrl(region) : undefined;
+        return url;
+      }}
       showCounties={showCounties}
       {...otherProps}
     />

--- a/packages/ui-components/src/components/Maps/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/StatesMap.tsx
@@ -19,7 +19,7 @@ const StatesMap: React.FC<{
   renderTooltip,
   showCounties,
   getFillColor,
-  getRegionUrl,
+  getRegionUrl = () => undefined,
 }) => {
   return (
     <svg width={width} height={height}>
@@ -27,7 +27,7 @@ const StatesMap: React.FC<{
         const stateFips = `${geo.id}`;
         return (
           <Tooltip key={stateFips} title={renderTooltip(stateFips)}>
-            <a href={getRegionUrl && getRegionUrl(stateFips)}>
+            <a href={getRegionUrl(stateFips)}>
               <g>
                 {!showCounties && (
                   <RegionShapeBase

--- a/packages/ui-components/src/components/Maps/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/StatesMap.tsx
@@ -11,7 +11,7 @@ const StatesMap: React.FC<{
   renderTooltip: (regionId: string) => React.ReactElement | string;
   showCounties: boolean;
   getFillColor: (regionId: string) => string;
-  getRegionUrl?: (regionId: string) => string;
+  getRegionUrl?: (regionId: string) => string | undefined;
 }> = ({
   width,
   height,

--- a/packages/ui-components/src/components/Maps/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/StatesMap.tsx
@@ -11,6 +11,7 @@ const StatesMap: React.FC<{
   renderTooltip: (regionId: string) => React.ReactElement | string;
   showCounties: boolean;
   getFillColor: (regionId: string) => string;
+  getRegionUrl?: (regionId: string) => string;
 }> = ({
   width,
   height,
@@ -18,23 +19,25 @@ const StatesMap: React.FC<{
   renderTooltip,
   showCounties,
   getFillColor,
+  getRegionUrl,
 }) => {
-  // TODO(Pablo): Add wrapping link once we update the RegionsDB API
   return (
     <svg width={width} height={height}>
       {statesGeographies.features.map((geo) => {
         const stateFips = `${geo.id}`;
         return (
           <Tooltip key={stateFips} title={renderTooltip(stateFips)}>
-            <g>
-              {!showCounties && (
-                <RegionShapeBase
-                  d={geoPath(geo) ?? ""}
-                  fill={getFillColor(stateFips)}
-                />
-              )}
-              <RegionOverlay d={geoPath(geo) ?? ""} />
-            </g>
+            <a href={getRegionUrl && getRegionUrl(stateFips)}>
+              <g>
+                {!showCounties && (
+                  <RegionShapeBase
+                    d={geoPath(geo) ?? ""}
+                    fill={getFillColor(stateFips)}
+                  />
+                )}
+                <RegionOverlay d={geoPath(geo) ?? ""} />
+              </g>
+            </a>
           </Tooltip>
         );
       })}

--- a/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.tsx
+++ b/packages/ui-components/src/components/Maps/USNationalMap/USNationalMap.tsx
@@ -17,6 +17,7 @@ const USNationalMapInner: React.FC<USNationalMapProps> = ({
   renderTooltip,
   getFillColor = () => "lightGray",
   showCounties = false,
+  getRegionUrl,
 }) => {
   const height = defaultHeight * (width / defaultWidth);
   const scale = (defaultScale * width) / defaultWidth;
@@ -54,6 +55,7 @@ const USNationalMapInner: React.FC<USNationalMapProps> = ({
           renderTooltip={renderTooltip}
           showCounties={showCounties}
           getFillColor={getFillColor}
+          getRegionUrl={getRegionUrl}
         />
       </PositionAbsolute>
     </MapContainer>

--- a/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.stories.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import { MetricUSStateMap } from "./MetricUSStateMap";
+import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
 import { MetricId } from "../../../stories/mockMetricCatalog";
+import { MetricUSStateMap } from "./MetricUSStateMap";
 import { MetricUSStateMapProps } from "./interfaces";
-import { states, counties, RegionDB } from "@actnowcoalition/regions";
 
-const statesAndCounties = new RegionDB([...states.all, ...counties.all]);
+const regionDB = new RegionDB([...states.all, ...counties.all], {
+  getRegionUrl: (region: Region) => `/us/${region.slug}`,
+});
 const herkimerCountyNewYorkRegion = counties.findByRegionIdStrict("36043");
 
 export default {
@@ -17,24 +19,24 @@ const Template: Story<MetricUSStateMapProps> = (args) => (
   <MetricUSStateMap {...args} />
 );
 
-const renderSimpleTooltip = (regionId: string) => {
-  return statesAndCounties.findByRegionIdStrict(regionId).fullName;
+const renderTooltip = (regionId: string) => {
+  return regionDB.findByRegionIdStrict(regionId).fullName;
 };
 
 /** New York colored by mock metric data */
 export const MetricAwareNewYork = Template.bind({});
 MetricAwareNewYork.args = {
   stateRegionId: "36",
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
   metric: MetricId.MOCK_CASES,
-  regionDB: statesAndCounties,
+  regionDB,
 };
 
 export const MetricAwareNewYorkWithHighlightedCounty = Template.bind({});
 MetricAwareNewYorkWithHighlightedCounty.args = {
   stateRegionId: "36",
   currentRegion: herkimerCountyNewYorkRegion,
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
   metric: MetricId.MOCK_CASES,
-  regionDB: statesAndCounties,
+  regionDB,
 };

--- a/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/MetricUSStateMap.tsx
@@ -26,6 +26,11 @@ export const MetricUSStateMap: React.FC<MetricUSStateMapProps> = ({
         const region = regionDB.findByRegionId(regionId);
         return region ? data.metricData(region, metric).getColor() : "#eee";
       }}
+      getRegionUrl={(regionId: string) => {
+        const region = regionDB.findByRegionId(regionId);
+        const url = region ? regionDB.getRegionUrl(region) : undefined;
+        return url;
+      }}
       stateRegionId={stateRegionId}
       {...otherProps}
     />

--- a/packages/ui-components/src/components/Maps/USStateMap/USStateMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/USStateMap.stories.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
 import { USStateMap } from "./USStateMap";
-import { states, counties, RegionDB } from "@actnowcoalition/regions";
+import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
 import { USStateMapProps } from "./interfaces";
 
-const statesAndCounties = new RegionDB([...states.all, ...counties.all]);
+const regionDB = new RegionDB([...states.all, ...counties.all], {
+  getRegionUrl: (region: Region) => `/us/${region.slug}`,
+});
+
 const herkimerCountyNewYorkRegion = counties.findByRegionIdStrict("36043");
 
 export default {
@@ -14,14 +17,24 @@ export default {
 
 const Template: Story<USStateMapProps> = (args) => <USStateMap {...args} />;
 
-const renderSimpleTooltip = (regionId: string) => {
-  return statesAndCounties.findByRegionIdStrict(regionId).fullName;
+const renderTooltip = (regionId: string) => {
+  return regionDB.findByRegionIdStrict(regionId).fullName;
+};
+
+import { assert } from "@actnowcoalition/assert";
+
+const getRegionUrl = (regionId: string): string => {
+  const region = regionDB.findByRegionIdStrict(regionId);
+  const url = regionDB.getRegionUrl(region);
+  assert(typeof url === "string", "RegionDB.getRegionUrl must be configured");
+  return url;
 };
 
 export const NewYorkWithoutBorderingStates = Template.bind({});
 NewYorkWithoutBorderingStates.args = {
   stateRegionId: "36",
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
+  getRegionUrl,
   showBorderingStates: false,
   showCounties: false,
 };
@@ -29,26 +42,30 @@ NewYorkWithoutBorderingStates.args = {
 export const NewYorkWithBorderingStates = Template.bind({});
 NewYorkWithBorderingStates.args = {
   stateRegionId: "36",
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
+  getRegionUrl,
   showCounties: false,
 };
 
 export const NewYorkCountiesWithoutBorderingStates = Template.bind({});
 NewYorkCountiesWithoutBorderingStates.args = {
   stateRegionId: "36",
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
+  getRegionUrl,
   showBorderingStates: false,
 };
 
 export const NewYorkCountiesWithBorderingStates = Template.bind({});
 NewYorkCountiesWithBorderingStates.args = {
   stateRegionId: "36",
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
+  getRegionUrl,
 };
 
 export const NewYorkCountiesWithHighlightedCounty = Template.bind({});
 NewYorkCountiesWithHighlightedCounty.args = {
   stateRegionId: "36",
   currentRegion: herkimerCountyNewYorkRegion,
-  renderTooltip: (regionId: string) => renderSimpleTooltip(regionId),
+  renderTooltip,
+  getRegionUrl,
 };

--- a/packages/ui-components/src/components/Maps/USStateMap/USStateMap.stories.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/USStateMap.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
+import { assert } from "@actnowcoalition/assert";
 import { USStateMap } from "./USStateMap";
 import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
 import { USStateMapProps } from "./interfaces";
@@ -20,8 +21,6 @@ const Template: Story<USStateMapProps> = (args) => <USStateMap {...args} />;
 const renderTooltip = (regionId: string) => {
   return regionDB.findByRegionIdStrict(regionId).fullName;
 };
-
-import { assert } from "@actnowcoalition/assert";
 
 const getRegionUrl = (regionId: string): string => {
   const region = regionDB.findByRegionIdStrict(regionId);

--- a/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
@@ -25,6 +25,7 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
   currentRegion,
   showCounties = true,
   showBorderingStates = true,
+  getRegionUrl,
 }) => {
   const height = defaultHeight * (width / defaultWidth);
 
@@ -84,9 +85,11 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
             const stateFips = `${geo.id}`;
             return (
               <Tooltip title={renderTooltip(stateFips)} key={stateFips}>
-                <g>
-                  <BorderingRegion d={geoPath(geo) ?? ""} />
-                </g>
+                <a href={getRegionUrl && getRegionUrl(stateFips)}>
+                  <g>
+                    <BorderingRegion d={geoPath(geo) ?? ""} />
+                  </g>
+                </a>
               </Tooltip>
             );
           })}
@@ -96,9 +99,11 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
           const geoId = `${geo.id}`;
           return (
             <Tooltip title={renderTooltip(geoId)} key={geoId}>
-              <g>
-                <RegionOverlay d={geoPath(geo) ?? ""} />
-              </g>
+              <a href={getRegionUrl && getRegionUrl(geoId)}>
+                <g>
+                  <RegionOverlay d={geoPath(geo) ?? ""} />
+                </g>
+              </a>
             </Tooltip>
           );
         })}

--- a/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
@@ -25,7 +25,7 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
   currentRegion,
   showCounties = true,
   showBorderingStates = true,
-  getRegionUrl,
+  getRegionUrl = () => undefined,
 }) => {
   const height = defaultHeight * (width / defaultWidth);
 
@@ -85,7 +85,7 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
             const stateFips = `${geo.id}`;
             return (
               <Tooltip title={renderTooltip(stateFips)} key={stateFips}>
-                <a href={getRegionUrl && getRegionUrl(stateFips)}>
+                <a href={getRegionUrl(stateFips)}>
                   <g>
                     <BorderingRegion d={geoPath(geo) ?? ""} />
                   </g>
@@ -99,7 +99,7 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
           const geoId = `${geo.id}`;
           return (
             <Tooltip title={renderTooltip(geoId)} key={geoId}>
-              <a href={getRegionUrl && getRegionUrl(geoId)}>
+              <a href={getRegionUrl(geoId)}>
                 <g>
                   <RegionOverlay d={geoPath(geo) ?? ""} />
                 </g>

--- a/packages/ui-components/src/components/Maps/USStateMap/interfaces.ts
+++ b/packages/ui-components/src/components/Maps/USStateMap/interfaces.ts
@@ -7,6 +7,7 @@ export interface USStateMapProps extends RenderMapProps {
   currentRegion?: Region;
   showCounties?: boolean;
   showBorderingStates?: boolean;
+  getRegionUrl?: (regionId: string) => string | undefined;
 }
 
 export interface MetricUSStateMapProps extends USStateMapProps {


### PR DESCRIPTION
Close #220 

Updated the base maps to take an optional `getRegionUrl` function, and the metric-aware maps to use the `getRegionUrl` from the `RegionDB`. Updated the stories accordingly and simplified them a bit.