### PR TITLE
Remove nils from timeseries fetched from CAN or CSV.

### DIFF
--- a/.changeset/funny-apricots-think.md
+++ b/.changeset/funny-apricots-think.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/metrics": patch
+---
+
+Remove null values from timeseries fetched from CSV or CAN.

--- a/packages/metrics/src/data_providers/data_provider_utils.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.ts
@@ -71,11 +71,11 @@ export function dataRowsToMetricData(
         value: value as unknown,
       };
     })
-  );
+  ).removeNils();
   return new MetricData(
     metric,
     region,
-    timeseries.removeNils().lastValue ?? null,
+    timeseries.lastValue ?? null,
     timeseries
   );
 }


### PR DESCRIPTION
I ran into an issue with CAN data breaking the sparklines because it had nulls in it.  We could make the sparklines remove / deal with the null data, but I think we probably don't want it in the first place.  So I'm just removing it up front in the data provider.

I actually think we should maybe change `Timeseries` so that it doesn't allow `null`s in the Timeseries at all.  I added a topic to standup for tomorrow.