### PR TITLE
Add tooltip and marker dot to `MetricLineChart`

### DIFF
--- a/.changeset/early-dancers-cover.md
+++ b/.changeset/early-dancers-cover.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Add tooltip and line marker to MetricLineChart

--- a/packages/ui-components/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/packages/ui-components/src/components/InfoTooltip/InfoTooltip.tsx
@@ -2,7 +2,9 @@ import React, { useState } from "react";
 import { Tooltip, TooltipProps as MuiTooltipProps } from "@mui/material";
 import { CloseIcon } from "./InfoTooltip.style";
 
-export const InfoTooltip: React.FC<MuiTooltipProps> = ({
+export type InfoTooltipProps = MuiTooltipProps;
+
+export const InfoTooltip: React.FC<InfoTooltipProps> = ({
   children,
   title,
   ...otherProps

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.styles.ts
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.styles.ts
@@ -1,0 +1,6 @@
+import { styled } from "../../styles";
+
+export const CircleMarker = styled("circle")`
+  stroke: ${({ theme }) => theme.palette.common.white};
+  stroke-width: 3px;
+`;

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -78,6 +78,7 @@ export const MetricLineChart: React.FC<MetricLineChartProps> = ({
             region={region}
             point={hoveredPoint}
             placement="top"
+            disableInteractive
             open
           >
             <CircleMarker

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -76,10 +76,9 @@ export const MetricLineChart: React.FC<MetricLineChartProps> = ({
           <MetricTooltip
             metric={metric}
             region={region}
-            date={hoveredPoint.date}
-            value={hoveredPoint.value}
+            point={hoveredPoint}
             placement="top"
-            open={true}
+            open
           >
             <CircleMarker
               cx={dateScale(hoveredPoint.date)}

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -1,15 +1,42 @@
-import React from "react";
-import { TimeseriesLineChart } from "./TimeseriesLineChart";
-import { MetricLineChartProps } from "./interfaces";
+import React, { useState } from "react";
+import { scaleLinear, scaleTime } from "@visx/scale";
+import { Group } from "@visx/group";
+import { TimeseriesPoint } from "@actnowcoalition/metrics";
 import { useData } from "../../common/hooks";
+import { AxesTimeseries } from "../Axes";
+import { ChartOverlayX, ChartOverlayXProps } from "../ChartOverlayX";
+import { LineChart } from "../LineChart";
+import { useMetricCatalog } from "../MetricCatalogContext";
+import { MetricTooltip } from "../MetricTooltip";
+import { CircleMarker } from "./MetricLineChart.styles";
+import { MetricLineChartProps } from "./interfaces";
 
 export const MetricLineChart: React.FC<MetricLineChartProps> = ({
-  metric,
+  metric: metricOrId,
   region,
   width,
   height,
+  marginTop = 10,
+  marginBottom = 30,
+  marginLeft = 70,
+  marginRight = 20,
 }) => {
+  const metricCatalog = useMetricCatalog();
+  const metric = metricCatalog.getMetric(metricOrId);
   const { data } = useData(region, metric, true);
+
+  const [hoveredPoint, setHoveredPoint] =
+    useState<TimeseriesPoint<number> | null>(null);
+
+  const onMouseLeave = () => {
+    setHoveredPoint(null);
+  };
+  const onMouseMove: ChartOverlayXProps["onMouseMove"] = ({ date }) => {
+    const point = timeseries.findNearestDate(date);
+    if (point) {
+      setHoveredPoint(point);
+    }
+  };
 
   if (!data) {
     return null;
@@ -21,11 +48,56 @@ export const MetricLineChart: React.FC<MetricLineChartProps> = ({
     return null;
   }
 
+  const chartHeight = height - marginTop - marginBottom;
+  const chartWidth = width - marginLeft - marginRight;
+
+  const { minDate, maxDate, maxValue } = timeseries;
+
+  const dateScale = scaleTime({
+    domain: [minDate, maxDate],
+    range: [0, chartWidth],
+  });
+
+  const yScale = scaleLinear({
+    domain: [0, maxValue],
+    range: [chartHeight, 0],
+  });
+
   return (
-    <TimeseriesLineChart
-      width={width}
-      height={height}
-      timeseries={timeseries}
-    />
+    <svg width={width} height={height}>
+      <Group left={marginLeft} top={marginTop}>
+        <AxesTimeseries
+          height={chartHeight}
+          dateScale={dateScale}
+          yScale={yScale}
+        />
+        <LineChart timeseries={timeseries} xScale={dateScale} yScale={yScale} />
+        {hoveredPoint && (
+          <MetricTooltip
+            metric={metric}
+            region={region}
+            date={hoveredPoint.date}
+            value={hoveredPoint.value}
+            placement="top"
+            open={true}
+          >
+            <CircleMarker
+              cx={dateScale(hoveredPoint.date)}
+              cy={yScale(hoveredPoint.value)}
+              r={6}
+              fill="black"
+            />
+          </MetricTooltip>
+        )}
+        <ChartOverlayX
+          width={chartWidth}
+          height={chartHeight}
+          xScale={dateScale}
+          offset={marginLeft}
+          onMouseMove={onMouseMove}
+          onMouseLeave={onMouseLeave}
+        />
+      </Group>
+    </svg>
   );
 };

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { states } from "@actnowcoalition/regions";
+import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
+import { MetricTooltip, MetricTooltipContent } from ".";
+
+export default {
+  title: "Components/MetricTooltip",
+  component: MetricTooltip,
+} as ComponentMeta<typeof MetricTooltip>;
+
+const date = new Date("2022-03-15");
+const value = 12.54;
+const metric = metricCatalog.getMetric(MetricId.MOCK_CASES);
+const region = states.findByRegionIdStrict("53");
+
+const Template: ComponentStory<typeof MetricTooltip> = (args) => (
+  <svg width={600} height={400} style={{ border: "solid 1px #ddd" }}>
+    <MetricTooltip {...args}>
+      <circle cx={300} cy={200} r={30} />
+    </MetricTooltip>
+  </svg>
+);
+
+export const Example = Template.bind({});
+Example.args = {
+  region,
+  metric,
+  date,
+  value,
+  placement: "top",
+};
+
+export const Content = () => (
+  <MetricTooltipContent
+    region={region}
+    metric={metric}
+    date={date}
+    value={value}
+  />
+);

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { TimeseriesPoint } from "@actnowcoalition/metrics";
-import { Group } from "@visx/group";
 import { states } from "@actnowcoalition/regions";
 import { colors } from "@mui/material";
 import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
@@ -28,12 +27,12 @@ const Template: ComponentStory<typeof MetricTooltip> = (args) => (
     style={{ backgroundColor: colors.blue[50] }}
   >
     <MetricTooltip {...args}>
-      <Group left={width / 2} top={height / 2}>
+      <g transform={`translate(${width / 2}, ${height / 2})`}>
         <circle r={60} fill={colors.purple[900]} />
         <text fill="white" textAnchor="middle" dominantBaseline="middle">
           Hover me
         </text>
-      </Group>
+      </g>
     </MetricTooltip>
   </svg>
 );

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { TimeseriesPoint } from "@actnowcoalition/metrics";
+import { Group } from "@visx/group";
 import { states } from "@actnowcoalition/regions";
 import { colors } from "@mui/material";
-
 import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
 import { MetricTooltip, MetricTooltipContent } from ".";
 
@@ -11,10 +12,12 @@ export default {
   component: MetricTooltip,
 } as ComponentMeta<typeof MetricTooltip>;
 
-const date = new Date("2022-03-15");
-const value = 12.54;
 const metric = metricCatalog.getMetric(MetricId.MOCK_CASES);
 const region = states.findByRegionIdStrict("53");
+const point: TimeseriesPoint<number> = {
+  date: new Date("2022-03-15"),
+  value: 12.54,
+};
 
 const [width, height] = [600, 400];
 
@@ -25,23 +28,12 @@ const Template: ComponentStory<typeof MetricTooltip> = (args) => (
     style={{ backgroundColor: colors.blue[50] }}
   >
     <MetricTooltip {...args}>
-      <g>
-        <circle
-          cx={width / 2}
-          cy={height / 2}
-          r={60}
-          fill={colors.purple[900]}
-        />
-        <text
-          x={300}
-          y={200}
-          fill="white"
-          textAnchor="middle"
-          dominantBaseline="middle"
-        >
+      <Group left={width / 2} top={height / 2}>
+        <circle r={60} fill={colors.purple[900]} />
+        <text fill="white" textAnchor="middle" dominantBaseline="middle">
           Hover me
         </text>
-      </g>
+      </Group>
     </MetricTooltip>
   </svg>
 );
@@ -50,16 +42,10 @@ export const Example = Template.bind({});
 Example.args = {
   region,
   metric,
-  date,
-  value,
+  point,
   placement: "top",
 };
 
 export const Content = () => (
-  <MetricTooltipContent
-    region={region}
-    metric={metric}
-    date={date}
-    value={value}
-  />
+  <MetricTooltipContent region={region} metric={metric} point={point} />
 );

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { states } from "@actnowcoalition/regions";
+import { colors } from "@mui/material";
+
 import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
 import { MetricTooltip, MetricTooltipContent } from ".";
 
@@ -14,10 +16,32 @@ const value = 12.54;
 const metric = metricCatalog.getMetric(MetricId.MOCK_CASES);
 const region = states.findByRegionIdStrict("53");
 
+const [width, height] = [600, 400];
+
 const Template: ComponentStory<typeof MetricTooltip> = (args) => (
-  <svg width={600} height={400} style={{ border: "solid 1px #ddd" }}>
+  <svg
+    width={width}
+    height={height}
+    style={{ backgroundColor: colors.blue[50] }}
+  >
     <MetricTooltip {...args}>
-      <circle cx={300} cy={200} r={30} />
+      <g>
+        <circle
+          cx={width / 2}
+          cy={height / 2}
+          r={60}
+          fill={colors.purple[900]}
+        />
+        <text
+          x={300}
+          y={200}
+          fill="white"
+          textAnchor="middle"
+          dominantBaseline="middle"
+        >
+          Hover me
+        </text>
+      </g>
     </MetricTooltip>
   </svg>
 );

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -8,7 +8,7 @@ import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
 import { MetricTooltip, MetricTooltipContent } from ".";
 
 export default {
-  title: "Components/MetricTooltip",
+  title: "Charts/MetricTooltip",
   component: MetricTooltip,
 } as ComponentMeta<typeof MetricTooltip>;
 

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import { Stack, Typography } from "@mui/material";
+import { Stack, Typography, Tooltip, TooltipProps } from "@mui/material";
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 import { formatDateTime, DateFormat } from "@actnowcoalition/time-utils";
-import { InfoTooltip, InfoTooltipProps } from "../InfoTooltip";
 
 export interface MetricTooltipProps extends MetricTooltipContentProps {
   children: React.ReactNode;
@@ -15,9 +14,10 @@ export const MetricTooltip = ({
   date,
   value,
   ...tooltipProps
-}: MetricTooltipProps & Omit<InfoTooltipProps, "title">) => {
+}: MetricTooltipProps & Omit<TooltipProps, "title">) => {
   return (
-    <InfoTooltip
+    <Tooltip
+      arrow
       title={
         <MetricTooltipContent
           metric={metric}

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -5,6 +5,7 @@ import { Region } from "@actnowcoalition/regions";
 import { formatDateTime, DateFormat } from "@actnowcoalition/time-utils";
 
 export interface MetricTooltipProps extends MetricTooltipContentProps {
+  /** Children is the component that, when hovered, should open the tooltip */
   children: React.ReactNode;
 }
 
@@ -13,21 +14,26 @@ export const MetricTooltip = ({
   region,
   point,
   ...tooltipProps
-}: MetricTooltipProps & Omit<TooltipProps, "title">) => {
-  return (
-    <Tooltip
-      arrow
-      title={
-        <MetricTooltipContent metric={metric} region={region} point={point} />
-      }
-      {...tooltipProps}
-    />
-  );
-};
+}: MetricTooltipProps & Omit<TooltipProps, "title">) => (
+  <Tooltip
+    arrow
+    title={
+      <MetricTooltipContent metric={metric} region={region} point={point} />
+    }
+    {...tooltipProps}
+  />
+);
 
 export interface MetricTooltipContentProps {
+  /** Metric to use to render the tooltip */
   metric: Metric;
+  /** Region to use to render the tooltip */
   region: Region;
+  /**
+   * Point with the date and value to show in the tooltip. The date and
+   * value of the point usually correspond to the point being hovered
+   * by the user. See `ChartOverlayX`, for example.
+   */
   point: TimeseriesPoint<number>;
 }
 

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Stack, Typography } from "@mui/material";
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+import { formatDateTime, DateFormat } from "@actnowcoalition/time-utils";
+import { InfoTooltip, InfoTooltipProps } from "../InfoTooltip";
+
+export interface MetricTooltipProps extends MetricTooltipContentProps {
+  children: React.ReactNode;
+}
+
+export const MetricTooltip = ({
+  metric,
+  region,
+  date,
+  value,
+  ...tooltipProps
+}: MetricTooltipProps & Omit<InfoTooltipProps, "title">) => {
+  return (
+    <InfoTooltip
+      title={
+        <MetricTooltipContent
+          metric={metric}
+          region={region}
+          date={date}
+          value={value}
+        />
+      }
+      {...tooltipProps}
+    />
+  );
+};
+
+export interface MetricTooltipContentProps {
+  metric: Metric;
+  region: Region;
+  date: Date;
+  value: number;
+}
+
+export const MetricTooltipContent = ({
+  metric,
+  region,
+  date,
+  value,
+}: MetricTooltipContentProps) => {
+  return (
+    <Stack spacing={0.5}>
+      <Typography variant="overline" color="inherit">
+        {formatDateTime(date, DateFormat.MMMM_D_YYYY)}
+      </Typography>
+      <Typography variant="overline" color="inherit">
+        {metric.name}
+      </Typography>
+      <Typography variant="dataEmphasizedSmall" color="inherit">
+        {metric.formatValue(value, "---")}
+      </Typography>
+      <Typography
+        variant="paragraphSmall"
+        color="inherit"
+      >{`in ${region.fullName}`}</Typography>
+    </Stack>
+  );
+};

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Stack, Typography, Tooltip, TooltipProps } from "@mui/material";
-import { Metric } from "@actnowcoalition/metrics";
+import { Metric, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 import { formatDateTime, DateFormat } from "@actnowcoalition/time-utils";
 
@@ -11,20 +11,14 @@ export interface MetricTooltipProps extends MetricTooltipContentProps {
 export const MetricTooltip = ({
   metric,
   region,
-  date,
-  value,
+  point,
   ...tooltipProps
 }: MetricTooltipProps & Omit<TooltipProps, "title">) => {
   return (
     <Tooltip
       arrow
       title={
-        <MetricTooltipContent
-          metric={metric}
-          region={region}
-          date={date}
-          value={value}
-        />
+        <MetricTooltipContent metric={metric} region={region} point={point} />
       }
       {...tooltipProps}
     />
@@ -34,26 +28,24 @@ export const MetricTooltip = ({
 export interface MetricTooltipContentProps {
   metric: Metric;
   region: Region;
-  date: Date;
-  value: number;
+  point: TimeseriesPoint<number>;
 }
 
 export const MetricTooltipContent = ({
   metric,
   region,
-  date,
-  value,
+  point,
 }: MetricTooltipContentProps) => {
   return (
     <Stack spacing={0.5}>
       <Typography variant="overline" color="inherit">
-        {formatDateTime(date, DateFormat.MMMM_D_YYYY)}
+        {formatDateTime(point.date, DateFormat.MMMM_D_YYYY)}
       </Typography>
       <Typography variant="overline" color="inherit">
         {metric.name}
       </Typography>
       <Typography variant="dataEmphasizedSmall" color="inherit">
-        {metric.formatValue(value, "---")}
+        {metric.formatValue(point.value, "---")}
       </Typography>
       <Typography
         variant="paragraphSmall"

--- a/packages/ui-components/src/components/MetricTooltip/index.ts
+++ b/packages/ui-components/src/components/MetricTooltip/index.ts
@@ -1,0 +1,1 @@
+export * from "./MetricTooltip";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -98,6 +98,7 @@ export * from "./components/MetricLineChart";
 export * from "./components/MetricOverview";
 export * from "./components/MetricScoreOverview";
 export * from "./components/MetricSparklines";
+export * from "./components/MetricTooltip";
 export * from "./components/MetricValue";
 export * from "./components/MultiProgressBar";
 export * from "./components/ProgressBar";

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -57,7 +57,7 @@ const components: ThemeOptions["components"] = {
         color: "white",
         fontSize: theme.typography.paragraphLarge.fontSize,
         lineHeight: theme.typography.paragraphLarge.lineHeight,
-        padding: "16px",
+        padding: theme.spacing(2),
         "& a": {
           color: "white",
         },


### PR DESCRIPTION
This PR implements the `MetricTooltip` component which renders a tooltip for a given `metric`, `region` and `point` with the date and value to show in the tooltip. The position of the tooltip is controlled by the children of the tooltip, and the orientation of the tooltip adapts when necessary.

**Storybook**

 - [MetricLineChart](https://act-now-packages--pr245-pablo-chart-tooltip-g3t5mrhe.web.app/storybook/index.html?path=/story/charts-metriclinechart--new-york-mock-cases)
- [MetricTooltip](https://act-now-packages--pr245-pablo-chart-tooltip-g3t5mrhe.web.app/storybook/index.html?path=/story/components-metrictooltip--example)

<img width="578" alt="image" src="https://user-images.githubusercontent.com/114084/192910295-8e6cac04-adcc-4995-9c7f-f9b1c236101f.png">

I had to change the implementation of `MetricLineChart` (but not the interface) to contain most of the logic that used to be in `TimeseriesLineChart` (I left that component untouched). I discussed this briefly with @chasulin and we decided to punt on it, but it was actually necessary to add the tooltip functionality.
