### PR TITLE
Update URL routing for RegionSearch

### DIFF
--- a/.changeset/curvy-cameras-call.md
+++ b/.changeset/curvy-cameras-call.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Update URL routing for RegionSearch

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
@@ -17,11 +17,8 @@ const regionDB = new RegionDB([...states.all, ...counties.all], {
   getRegionUrl: (region: Region): string => `/us/${region.slug}`,
 });
 
-const getRegionUrl = (regionOrId: string | Region): string => {
-  const region =
-    typeof regionOrId === "string"
-      ? regionDB.findByRegionIdStrict(regionOrId)
-      : regionOrId;
+const getRegionUrl = (regionId: string): string => {
+  const region = regionDB.findByRegionIdStrict(regionId);
   const url = regionDB.getRegionUrl(region);
   assert(typeof url === "string", "RegionDB.getRegionUrl must be configured");
   return url;

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
@@ -5,11 +5,27 @@ import MapIcon from "@mui/icons-material/Map";
 import sortBy from "lodash/sortBy";
 import { states, counties, metros } from "@actnowcoalition/regions";
 import { RegionSearch } from ".";
+import { RegionDB, Region } from "@actnowcoalition/regions";
+import { assert } from "@actnowcoalition/assert";
 
 export default {
   title: "Components/RegionSearch",
   component: RegionSearch,
 } as ComponentMeta<typeof RegionSearch>;
+
+const regionDB = new RegionDB([...states.all, ...counties.all], {
+  getRegionUrl: (region: Region): string => `/us/${region.slug}`,
+});
+
+const getRegionUrl = (regionOrId: string | Region): string => {
+  const region =
+    typeof regionOrId === "string"
+      ? regionDB.findByRegionIdStrict(regionOrId)
+      : regionOrId;
+  const url = regionDB.getRegionUrl(region);
+  assert(typeof url === "string", "RegionDB.getRegionUrl must be configured");
+  return url;
+};
 
 const Template: ComponentStory<typeof RegionSearch> = (args) => (
   <RegionSearch {...args} />
@@ -29,6 +45,7 @@ StatesOnly.args = {
   options: states.all,
   inputLabel: "States",
   LinkComponent: AnchorLinkComponent,
+  getRegionUrl: getRegionUrl,
 };
 
 export const CustomRenderInput = Template.bind({});
@@ -36,6 +53,7 @@ CustomRenderInput.args = {
   options: states.all,
   inputLabel: "States",
   LinkComponent: AnchorLinkComponent,
+  getRegionUrl: getRegionUrl,
   renderInput: (params) => (
     <TextField
       {...params}
@@ -58,6 +76,7 @@ CountiesOnly.args = {
   options: sortBy(counties.all, (county) => county.population * -1),
   inputLabel: "Counties",
   LinkComponent: AnchorLinkComponent,
+  getRegionUrl: getRegionUrl,
 };
 
 const allRegions = [...states.all, ...counties.all, ...metros.all];
@@ -65,4 +84,5 @@ export const AllRegions = Template.bind({});
 AllRegions.args = {
   options: allRegions,
   LinkComponent: AnchorLinkComponent,
+  getRegionUrl: getRegionUrl,
 };

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -30,6 +30,7 @@ export interface RegionSearchProps
     children: React.ReactElement;
     targetUrl: string;
   }>;
+  getRegionUrl: (regionId: string) => string;
   /** Placeholder text to show in the inner text field  */
   inputLabel?: string;
   /** Optional renderInput function. See https://mui.com/material-ui/api/autocomplete/ */
@@ -41,6 +42,7 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
   inputLabel = "City, county, state, or district",
   renderInput: customRenderInput,
   LinkComponent,
+  getRegionUrl,
   ...otherAutocompleteProps
 }) => {
   const defaultRenderInput: CustomAutocompleteProps["renderInput"] = (
@@ -68,7 +70,7 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
           option: Region
         ) => {
           return (
-            <LinkComponent targetUrl={option.relativeUrl}>
+            <LinkComponent targetUrl={getRegionUrl(option.regionId)}>
               <SearchItem
                 itemLabel={option.shortName}
                 itemSublabel={`${option.population} population`}

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-0.1.0.tgz#fa83caa21c419f20d7be7c10dafd70986613e6a0"
   integrity sha512-8dBa6CHFDuY/jAVtazVCDSl9796gaOLmsdMFX+uGBwQruEWpCq2jOkf/wvLypt9eoE+Dzi63Q5zbOIVXmlQRtQ==
 
-"@actnowcoalition/metrics@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.2.0.tgz#28e156481bd4d0ecaac8f51f42ba0ce384d0a794"
-  integrity sha512-ohCbCUwD2tAABz/gzbX/omEMgn7Z4faz39ASatACb+jrc8QkFWmi+W5ckp0kgtHfp5hZFuUNebOvQTIbp54MWA==
+"@actnowcoalition/metrics@^0.2.1":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.2.2.tgz#46fb8434720d6ed2f3baf3a5ebd458354b6b7218"
+  integrity sha512-ueH74AB1calH601gVNYdcjpKMAfj7MmnxHQT0ra8d7p8vBgBdygzFeKy5hWd1IAp+ukFZb5XCE6DMzmc/QuoQw==
   dependencies:
     "@actnowcoalition/assert" "^0.1.0"
     "@actnowcoalition/number-format" "^0.1.0"


### PR DESCRIPTION
Based on changes in https://github.com/covid-projections/act-now-packages/pull/240

RegionSearch component is not navigating to location pages due to the routing not being updated yet.

Example use: https://github.com/covid-projections/hackathon-august-2022/pull/13/files