### PR TITLE
Fix JSON fetching when not all fields are present for all rows

### DIFF
--- a/.changeset/perfect-parents-mate.md
+++ b/.changeset/perfect-parents-mate.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/metrics": patch
+---
+
+Fix JSON fetching when not all fields are present

--- a/packages/metrics/src/data_providers/CsvDataProvider.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.ts
@@ -96,7 +96,8 @@ export class CsvDataProvider extends CachingMetricDataProviderBase {
         region,
         metric,
         metricKey,
-        this.dateColumn
+        this.dateColumn,
+        /* strict= */ true
       );
     } else {
       metricData = dataRowToMetricData(

--- a/packages/metrics/src/data_providers/data_provider_utils.test.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.test.ts
@@ -20,6 +20,7 @@ describe("dataRowsToMetricData()", () => {
       [
         { date: "2022-08-01", region: "36", cool_metric: 100 },
         { date: "2022-07-31", region: "36", cool_metric: 90 },
+        { date: "2022-07-30", region: "36" }, // Ensure that missing data is handled correctly when strict === false.
       ],
       (row) => row.region
     );
@@ -37,7 +38,7 @@ describe("dataRowsToMetricData()", () => {
     expect(data.timeseries.minDate).toStrictEqual(new Date("2022-07-31"));
   });
 
-  test("dataRowsToMetricData() fails when there's no data for metric.", () => {
+  test("dataRowsToMetricData() fails when there's no data for metric and strict === true.", () => {
     const column = testMetric.dataReference?.column as string;
     const dataRows: Dictionary<DataRow[]> = groupBy(
       [{ date: "2022-08-01", region: "36", another_metric: 100 }],
@@ -49,7 +50,8 @@ describe("dataRowsToMetricData()", () => {
         newYork,
         testMetric,
         column,
-        /*dateKey=*/ "date"
+        /*dateKey=*/ "date",
+        /*strict=*/ true
       );
     }).toThrow();
   });

--- a/packages/metrics/src/data_providers/data_provider_utils.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.ts
@@ -48,6 +48,7 @@ export function dataRowToMetricData(
  * @param metric Metric to parse data for.
  * @param metricKey Key name of the items in the data-rows containing the metric values.
  * @param dateKey Key name of the items in the data-rows that contain the date-time values.
+ * @param strict If true, will throw an error if any field is missing in any row.
  * @returns Metric Data for the specified region and metric.
  */
 export function dataRowsToMetricData(
@@ -55,13 +56,16 @@ export function dataRowsToMetricData(
   region: Region,
   metric: Metric,
   metricKey: string,
-  dateKey: string
+  dateKey: string,
+  strict = false
 ) {
   const rows = dataRowsByRegionId[region.regionId] ?? [];
   const timeseries = new Timeseries(
     rows.map((row) => {
       const value = get(row, metricKey);
-      assert(value !== undefined, `Metric key ${metricKey} missing.`);
+      if (strict) {
+        assert(value !== undefined, `Metric key ${metricKey} missing.`);
+      }
       assert(
         typeof row[dateKey] === "string",
         `Date column must be a string. ${typeof row[dateKey]} found.`

--- a/packages/metrics/yarn.lock
+++ b/packages/metrics/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/number-format/-/number-format-0.1.0.tgz#0d6bf419c6e9f5622fe8cde7940f68ea0fdb5320"
   integrity sha512-BTdtEEqgV0zRk6sj2E/XU5j7tSiR/cE0sOVmISGW9pz58WNLVcFraIUH5XSArfzh7WLnWlsh5N+rJDgUoVsG/A==
 
-"@actnowcoalition/regions@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/regions/-/regions-0.1.0.tgz#4dba709a76cd3213222a5e9e0dfdaa83afa5c308"
-  integrity sha512-9DwFMXdGBFeW6JrW+bi6hiLIcyxcxOM01+3sube2r6KgHglc0c+V6M6PP2jr18nVK7H+ZU1DQ6hEwUJKYWw80w==
+"@actnowcoalition/regions@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/regions/-/regions-0.1.1.tgz#566cee94ed8a15b29578ce97511d58acfd18598c"
+  integrity sha512-qd03POpHNBJVYBPWu8DnEbdkUYd31iYYBYETwIuKzW/NQntgSkXD9zd8dvkkACMopYH3+cAvuP7jtyHoI0DJTg==
   dependencies:
     "@actnowcoalition/assert" "^0.1.0"
     lodash "^4.17.21"


### PR DESCRIPTION
Fixes error when fetching vaccine data from the CAN API, which fails because not all timeseries records contain the vaccine data fields. 


```Error fetching metric data: Error: INTERNAL ASSERTION FAILED: Metric key vaccinationsInitiatedRatio missing```.