### PR TITLE
Update `MetricLegendThreshold` to have thresholds between levels

### DIFF
--- a/.changeset/yellow-glasses-arrive.md
+++ b/.changeset/yellow-glasses-arrive.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Update the MetricLegendThreshold component to show threshold values between labels

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Typography } from "@mui/material";
+import { Typography, Paper } from "@mui/material";
 import { ComponentMeta } from "@storybook/react";
 import { MetricId } from "../../stories/mockMetricCatalog";
 import {
@@ -14,9 +14,9 @@ export default {
 } as ComponentMeta<typeof MetricLegendThreshold>;
 
 const Template: Story<MetricLegendThresholdProps> = (args) => (
-  <div style={{ width: 500, border: "1px solid #ddd" }}>
+  <Paper sx={{ width: 500, padding: 2 }}>
     <MetricLegendThreshold {...args} />
-  </div>
+  </Paper>
 );
 
 // Horizontal legend threshold props

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -1,13 +1,25 @@
 import React from "react";
-import { LegendThreshold } from "../LegendThreshold";
-import { Metric, MetricLevel } from "@actnowcoalition/metrics";
-import { useMetricCatalog } from "../MetricCatalogContext";
-import { assert } from "@actnowcoalition/assert";
 import { Stack, Typography } from "@mui/material";
+import { Metric } from "@actnowcoalition/metrics";
+import { assert } from "@actnowcoalition/assert";
+import { LegendThreshold } from "../LegendThreshold";
+import { useMetricCatalog } from "../MetricCatalogContext";
 
-const getItemColor = (item: MetricLevel) => item.color;
-const getItemLabel = (item: MetricLevel) => item.name ?? item.id;
-const getItemSublabel = (item: MetricLevel) => item.description ?? "";
+interface LevelItem {
+  /** Level name (e.g. "High") */
+  name: string;
+  /** Level color */
+  color: string;
+  /** Description of the level */
+  description: string | undefined;
+  /** Formatted value of the threshold at the end of the current level */
+  endThreshold: string;
+}
+
+const getItemColor = (item: LevelItem) => item.color;
+const getItemLabelHorizontal = (item: LevelItem) => item.endThreshold;
+const getItemLabelVertical = (item: LevelItem) => item.name;
+const getItemSublabel = (item: LevelItem) => item.description ?? "";
 
 interface CommonMetricLegendThresholdProps {
   /** Metric to display thresholds for. */
@@ -68,22 +80,15 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
 }) => {
   const metricCatalog = useMetricCatalog();
   metric = metricCatalog.getMetric(metric);
-  const items = metric.levelSet?.levels;
-  assert(
-    items,
-    "Metric must have thresholds to use MetricLegendThreshold." +
-      `No thresholds found for metric ${metric}.`
-  );
-  const isHorizontal = legendThresholdProps.orientation === "horizontal";
-  const derivedProps = isHorizontal
-    ? { items, getItemColor, getItemLabel }
-    : { items, getItemColor, getItemLabel, getItemSublabel };
+
+  const items = getLevelItems(metric);
+  const commonProps = { items, getItemColor, ...legendThresholdProps };
 
   if (!includeOverview) {
-    return <LegendThreshold {...derivedProps} {...legendThresholdProps} />;
+    return <LegendThreshold {...commonProps} {...legendThresholdProps} />;
   }
 
-  if (isHorizontal) {
+  if (legendThresholdProps.orientation === "horizontal") {
     return (
       <Stack spacing={2} alignItems="center">
         <Stack spacing={0.5}>
@@ -92,9 +97,9 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
         </Stack>
         <Stack direction="row" spacing={1} alignItems="center">
           {startLabel && startLabel}
-          <LegendThreshold<MetricLevel>
-            {...derivedProps}
-            {...legendThresholdProps}
+          <LegendThreshold<LevelItem>
+            {...commonProps}
+            getItemLabel={getItemLabelHorizontal}
           />
           {endLabel && endLabel}
         </Stack>
@@ -109,9 +114,11 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
         </Stack>
         <Stack direction="column" spacing={1}>
           {startLabel && startLabel}
-          <LegendThreshold<MetricLevel>
-            {...derivedProps}
-            {...legendThresholdProps}
+          <LegendThreshold<LevelItem>
+            {...commonProps}
+            orientation="vertical"
+            getItemLabel={getItemLabelVertical}
+            getItemSublabel={getItemSublabel}
           />
           {endLabel && endLabel}
         </Stack>
@@ -119,3 +126,25 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
     );
   }
 };
+
+function getLevelItems(metric: Metric): LevelItem[] {
+  const metricLevels = metric.levelSet?.levels;
+  const metricThresholds = metric.thresholds;
+  assert(
+    metricLevels,
+    "Metric must have levels and thresholds to use MetricLegendThreshold." +
+      `No levels found for metric ${metric}.`
+  );
+  assert(
+    metricThresholds,
+    "Metric must have levels and thresholds to use MetricLegendThreshold." +
+      `No thresholds found for metric ${metric}.`
+  );
+
+  return metricLevels.map((level, levelIndex) => ({
+    name: level.name ?? level.id,
+    color: level.color,
+    description: level.description,
+    endThreshold: metric.formatValue(metricThresholds[levelIndex]),
+  }));
+}

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -13,11 +13,11 @@ interface LevelItem {
   /** Description of the level */
   description: string | undefined;
   /** Formatted value of the threshold at the end of the current level */
-  endThreshold: string;
+  endThreshold?: string;
 }
 
 const getItemColor = (item: LevelItem) => item.color;
-const getItemLabelHorizontal = (item: LevelItem) => item.endThreshold;
+const getItemLabelHorizontal = (item: LevelItem) => item.endThreshold ?? "";
 const getItemLabelVertical = (item: LevelItem) => item.name;
 const getItemSublabel = (item: LevelItem) => item.description ?? "";
 
@@ -82,10 +82,12 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
   metric = metricCatalog.getMetric(metric);
 
   const items = getLevelItems(metric);
+
+  // Common props regardless of horizontal / vertical orientation
   const commonProps = { items, getItemColor, ...legendThresholdProps };
 
   if (!includeOverview) {
-    return <LegendThreshold {...commonProps} {...legendThresholdProps} />;
+    return <LegendThreshold {...commonProps} />;
   }
 
   if (legendThresholdProps.orientation === "horizontal") {
@@ -96,12 +98,12 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
           <Typography variant="paragraphSmall">{supportingText}</Typography>
         </Stack>
         <Stack direction="row" spacing={1} alignItems="center">
-          {startLabel && startLabel}
+          {startLabel}
           <LegendThreshold<LevelItem>
             {...commonProps}
             getItemLabel={getItemLabelHorizontal}
           />
-          {endLabel && endLabel}
+          {endLabel}
         </Stack>
       </Stack>
     );
@@ -113,14 +115,14 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
           <Typography variant="paragraphSmall">{supportingText}</Typography>
         </Stack>
         <Stack direction="column" spacing={1}>
-          {startLabel && startLabel}
+          {startLabel}
           <LegendThreshold<LevelItem>
             {...commonProps}
             orientation="vertical"
             getItemLabel={getItemLabelVertical}
             getItemSublabel={getItemSublabel}
           />
-          {endLabel && endLabel}
+          {endLabel}
         </Stack>
       </Stack>
     );
@@ -135,16 +137,12 @@ function getLevelItems(metric: Metric): LevelItem[] {
     "Metric must have levels and thresholds to use MetricLegendThreshold." +
       `No levels found for metric ${metric}.`
   );
-  assert(
-    metricThresholds,
-    "Metric must have levels and thresholds to use MetricLegendThreshold." +
-      `No thresholds found for metric ${metric}.`
-  );
-
   return metricLevels.map((level, levelIndex) => ({
     name: level.name ?? level.id,
     color: level.color,
     description: level.description,
-    endThreshold: metric.formatValue(metricThresholds[levelIndex]),
+    endThreshold: metricThresholds
+      ? metric.formatValue(metricThresholds[levelIndex])
+      : undefined,
   }));
 }


### PR DESCRIPTION
Close #254  - MetricLegendThreshold component should show thresholds between labels

<img width="489" alt="image" src="https://user-images.githubusercontent.com/114084/193652178-f3feaae8-1653-4bce-8b21-fd0e9df67b83.png">

I added a utility function to format the items that we pass to the `LegendThreshold` component so we have all we need to show thresholds, level name, color and description. It works as expected for both horizontal and vertical orientations.
