### PR TITLE
`AxesTimeseries` now supports custom axis options

### DIFF
--- a/.changeset/pink-mugs-notice.md
+++ b/.changeset/pink-mugs-notice.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": minor
+---
+
+AxisTimeseries now allows custom options for the axis

--- a/packages/ui-components/src/components/Axes/AxesTimeseries/AxesTimeseries.stories.tsx
+++ b/packages/ui-components/src/components/Axes/AxesTimeseries/AxesTimeseries.stories.tsx
@@ -3,6 +3,7 @@ import { Story, ComponentMeta } from "@storybook/react";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { AxesTimeseries, AxesTimeseriesProps } from "./AxesTimeseries";
 import { Group } from "@visx/group";
+import { formatPercent } from "@actnowcoalition/number-format";
 
 export default {
   title: "Charts/AxesTimeseries",
@@ -21,6 +22,11 @@ const dateScale = scaleTime({
 
 const yScale = scaleLinear({
   domain: [0, 500],
+  range: [chartHeight, 0],
+});
+
+const yScalePercent = scaleLinear({
+  domain: [0, 1.2],
   range: [chartHeight, 0],
 });
 
@@ -44,5 +50,17 @@ CustomNumYTicks.args = {
   height: chartHeight,
   dateScale,
   yScale,
-  yNumTicks: 5,
+  axisLeftProps: {
+    numTicks: 10,
+  },
+};
+
+export const CustomTickFormat = Template.bind({});
+CustomTickFormat.args = {
+  height: chartHeight,
+  dateScale,
+  yScale: yScalePercent,
+  axisLeftProps: {
+    tickFormat: (value: number) => formatPercent(value),
+  },
 };

--- a/packages/ui-components/src/components/Axes/AxesTimeseries/AxesTimeseries.tsx
+++ b/packages/ui-components/src/components/Axes/AxesTimeseries/AxesTimeseries.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { AxisLeft, AxisLeftProps, AxisBottom } from "../../Axis/Axis.style";
+import {
+  AxisLeft,
+  AxisLeftProps,
+  AxisBottom,
+  AxisBottomProps,
+} from "../../Axis/Axis.style";
 import { ScaleTime, ScaleLinear } from "d3-scale";
 
 export interface AxesTimeseriesProps {
@@ -7,7 +12,7 @@ export interface AxesTimeseriesProps {
   dateScale: ScaleTime<number, number>;
   yScale: ScaleLinear<number, number>;
   axisLeftProps?: Omit<AxisLeftProps, "scale">;
-  axisBottomProps?: Omit<AxisLeftProps, "scale">;
+  axisBottomProps?: Omit<AxisBottomProps, "scale">;
 }
 
 export const AxesTimeseries: React.FC<AxesTimeseriesProps> = ({

--- a/packages/ui-components/src/components/Axes/AxesTimeseries/AxesTimeseries.tsx
+++ b/packages/ui-components/src/components/Axes/AxesTimeseries/AxesTimeseries.tsx
@@ -1,24 +1,26 @@
 import React from "react";
-import { AxisLeft, AxisBottom } from "../../Axis/Axis.style";
+import { AxisLeft, AxisLeftProps, AxisBottom } from "../../Axis/Axis.style";
 import { ScaleTime, ScaleLinear } from "d3-scale";
 
 export interface AxesTimeseriesProps {
   height: number;
   dateScale: ScaleTime<number, number>;
   yScale: ScaleLinear<number, number>;
-  yNumTicks?: number;
+  axisLeftProps?: Omit<AxisLeftProps, "scale">;
+  axisBottomProps?: Omit<AxisLeftProps, "scale">;
 }
 
 export const AxesTimeseries: React.FC<AxesTimeseriesProps> = ({
   height,
   dateScale,
   yScale,
-  yNumTicks = 10,
+  axisLeftProps,
+  axisBottomProps,
 }) => {
   return (
     <>
-      <AxisLeft scale={yScale} numTicks={yNumTicks} />
-      <AxisBottom top={height} scale={dateScale} />
+      <AxisLeft scale={yScale} {...axisLeftProps} />
+      <AxisBottom top={height} scale={dateScale} {...axisBottomProps} />
     </>
   );
 };

--- a/packages/ui-components/src/components/Axis/Axis.style.tsx
+++ b/packages/ui-components/src/components/Axis/Axis.style.tsx
@@ -27,6 +27,7 @@ export const AxisLeft = styled((props: AxisLeftProps) => (
     tickLabelProps={() => ({
       textAnchor: "end", // Horizontal anchor
       verticalAnchor: "middle",
+      dx: "-.25em",
       ...baseTickLabelProps,
     })}
     stroke={theme.palette.border.default}

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -70,6 +70,7 @@ export const MetricLineChart: React.FC<MetricLineChartProps> = ({
           height={chartHeight}
           dateScale={dateScale}
           yScale={yScale}
+          axisLeftProps={{ tickFormat: (value) => metric.formatValue(value) }}
         />
         <LineChart timeseries={timeseries} xScale={dateScale} yScale={yScale} />
         {hoveredPoint && (


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/262 - Metric chart axes should use `Metric.formatValue`

The component now can take `axisLeftProps` and `axisBottomProps` so the parent component can further customize the axes. This component might be too simple to keep, but updating as is for now to have the y-axis for `MetricLineChart` using the same formatter function as the metric.

![image](https://user-images.githubusercontent.com/114084/193698506-3ce7db3b-15b4-467b-a5be-36ce87ccc517.png)
