### PR TITLE
Share button improvements

### DIFF
--- a/.changeset/few-knives-lie.md
+++ b/.changeset/few-knives-lie.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Improvements to share buttons

--- a/packages/ui-components/src/components/ShareButton/CopyLinkButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/CopyLinkButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
-import { Button } from "./ShareButton.style";
 import LinkIcon from "@mui/icons-material/Link";
+import Button from "@mui/material/Button";
 
 export const CopyLinkButton = ({
   url,
@@ -19,7 +19,11 @@ export const CopyLinkButton = ({
         onClick();
       }}
     >
-      <Button endIcon={<LinkIcon />} fullWidth>
+      <Button
+        endIcon={<LinkIcon />}
+        fullWidth
+        sx={{ ":hover": { backgroundColor: "transparent" } }}
+      >
         {copiedLink ? "Copied!" : "Copy Link"}
       </Button>
     </CopyToClipboard>

--- a/packages/ui-components/src/components/ShareButton/CopyLinkButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/CopyLinkButton.tsx
@@ -19,11 +19,7 @@ export const CopyLinkButton = ({
         onClick();
       }}
     >
-      <Button
-        endIcon={<LinkIcon />}
-        fullWidth
-        sx={{ ":hover": { backgroundColor: "transparent" } }}
-      >
+      <Button endIcon={<LinkIcon />} fullWidth>
         {copiedLink ? "Copied!" : "Copy Link"}
       </Button>
     </CopyToClipboard>

--- a/packages/ui-components/src/components/ShareButton/FacebookShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/FacebookShareButton.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { FacebookShareButton as ReactShareFacebookShareButton } from "react-share";
 import FacebookIcon from "@mui/icons-material/Facebook";
-import { StyledReactShareFacebookButton } from "./ShareButton.style";
-import { Typography, Stack } from "@mui/material";
+import { Button } from "@mui/material";
 
 type BaseProps = React.ComponentProps<typeof ReactShareFacebookShareButton>;
 
@@ -14,16 +13,14 @@ export const FacebookShareButton: React.FC<FacebookShareButtonProps> = ({
   onClick,
   ...otherProps
 }) => (
-  <StyledReactShareFacebookButton
-    {...otherProps}
-    onClick={onClick}
-    resetButtonStyle={false} /** allows us to customize styles */
-  >
-    <Stack spacing={0.75} direction="row" justifyContent="center">
-      <Typography variant="labelLarge" color="primary">
-        Facebook
-      </Typography>
-      <FacebookIcon color="primary" />
-    </Stack>
-  </StyledReactShareFacebookButton>
+  <ReactShareFacebookShareButton {...otherProps}>
+    <Button
+      onClick={onClick}
+      endIcon={<FacebookIcon />}
+      fullWidth
+      component="div"
+    >
+      Facebook
+    </Button>
+  </ReactShareFacebookShareButton>
 );

--- a/packages/ui-components/src/components/ShareButton/FacebookShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/FacebookShareButton.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import * as ReactShare from "react-share";
+import { FacebookShareButton as ReactShareFacebookShareButton } from "react-share";
 import FacebookIcon from "@mui/icons-material/Facebook";
-import { Button } from "./ShareButton.style";
+import { StyledReactShareFacebookButton } from "./ShareButton.style";
+import { Typography, Stack } from "@mui/material";
 
-type BaseProps = React.ComponentProps<typeof ReactShare.FacebookShareButton>;
+type BaseProps = React.ComponentProps<typeof ReactShareFacebookShareButton>;
 
 export interface FacebookShareButtonProps extends BaseProps {
   onClick: () => void;
@@ -13,7 +14,16 @@ export const FacebookShareButton: React.FC<FacebookShareButtonProps> = ({
   onClick,
   ...otherProps
 }) => (
-  <Button onClick={() => onClick()} endIcon={<FacebookIcon />} fullWidth>
-    <ReactShare.FacebookShareButton {...otherProps} />
-  </Button>
+  <StyledReactShareFacebookButton
+    {...otherProps}
+    onClick={onClick}
+    resetButtonStyle={false} /** allows us to customize styles */
+  >
+    <Stack spacing={0.75} direction="row" justifyContent="center">
+      <Typography variant="labelLarge" color="primary">
+        Facebook
+      </Typography>
+      <FacebookIcon color="primary" />
+    </Stack>
+  </StyledReactShareFacebookButton>
 );

--- a/packages/ui-components/src/components/ShareButton/ShareButton.stories.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.stories.tsx
@@ -26,6 +26,18 @@ const args: ShareButtonProps = {
 export const Default = Template.bind({});
 Default.args = args;
 
+export const SmallMainShareButton = Template.bind({});
+SmallMainShareButton.args = {
+  ...args,
+  size: "small",
+};
+
+export const LargeMainShareButton = Template.bind({});
+LargeMainShareButton.args = {
+  ...args,
+  size: "large",
+};
+
 export const CenterMenuOrigin = Template.bind({});
 CenterMenuOrigin.args = {
   ...args,

--- a/packages/ui-components/src/components/ShareButton/ShareButton.style.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.style.tsx
@@ -11,6 +11,7 @@ export const Menu = styled(MuiMenu)`
     padding: 0;
   }
 
+  /* Makes ReactShare buttons full-width */
   button {
     width: 100%;
   }

--- a/packages/ui-components/src/components/ShareButton/ShareButton.style.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.style.tsx
@@ -1,34 +1,21 @@
 import { styled } from "../../styles";
 import { Menu as MuiMenu, MenuItem as MuiMenuItem } from "@mui/material";
-import { FacebookShareButton, TwitterShareButton } from "react-share";
-import { css } from "@emotion/react";
 
 export const Menu = styled(MuiMenu)`
   .MuiMenu-paper {
     margin-top: ${(props) => props.theme.spacing(1)};
     min-width: 125px;
   }
+
   .MuiMenu-list {
     padding: 0;
+  }
+
+  button {
+    width: 100%;
   }
 `;
 
 export const MenuItem = styled(MuiMenuItem)`
   padding: 0;
-`;
-
-const ReactShareButtonStyles = css`
-  width: 100%;
-  cursor: pointer;
-  border: none;
-  background: none;
-  padding: 6px 8px;
-`;
-
-export const StyledReactShareFacebookButton = styled(FacebookShareButton)`
-  ${ReactShareButtonStyles};
-`;
-
-export const StyledReactShareTwitterButton = styled(TwitterShareButton)`
-  ${ReactShareButtonStyles};
 `;

--- a/packages/ui-components/src/components/ShareButton/ShareButton.style.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.style.tsx
@@ -1,9 +1,7 @@
 import { styled } from "../../styles";
-import {
-  Menu as MuiMenu,
-  MenuItem as MuiMenuItem,
-  Button as MuiButton,
-} from "@mui/material";
+import { Menu as MuiMenu, MenuItem as MuiMenuItem } from "@mui/material";
+import { FacebookShareButton, TwitterShareButton } from "react-share";
+import { css } from "@emotion/react";
 
 export const Menu = styled(MuiMenu)`
   .MuiMenu-paper {
@@ -19,6 +17,18 @@ export const MenuItem = styled(MuiMenuItem)`
   padding: 0;
 `;
 
-export const Button = styled(MuiButton)`
-  min-height: ${(props) => props.theme.spacing(5)};
+const ReactShareButtonStyles = css`
+  width: 100%;
+  cursor: pointer;
+  border: none;
+  background: none;
+  padding: 6px 8px;
+`;
+
+export const StyledReactShareFacebookButton = styled(FacebookShareButton)`
+  ${ReactShareButtonStyles};
+`;
+
+export const StyledReactShareTwitterButton = styled(TwitterShareButton)`
+  ${ReactShareButtonStyles};
 `;

--- a/packages/ui-components/src/components/ShareButton/ShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Button } from "@mui/material";
+import { Button, ButtonProps } from "@mui/material";
 import ShareIcon from "@mui/icons-material/Share";
 import { CopyLinkButton } from "./CopyLinkButton";
 import { TwitterShareButton } from "./TwitterShareButton";
@@ -11,7 +11,7 @@ const noop = () => {
   return;
 };
 
-export interface ShareButtonProps {
+interface ShareButtonOwnProps {
   url: string;
   quote: string;
   hashtags?: string[];
@@ -21,6 +21,8 @@ export interface ShareButtonProps {
   menuOrigin?: "left" | "center" | "right";
 }
 
+export type ShareButtonProps = ButtonProps & ShareButtonOwnProps;
+
 export const ShareButton: React.FC<ShareButtonProps> = ({
   url,
   quote,
@@ -29,6 +31,7 @@ export const ShareButton: React.FC<ShareButtonProps> = ({
   onShareTwitter = noop,
   onShareFacebook = noop,
   menuOrigin = "left",
+  ...muiButtonProps
 }) => {
   const [anchorButton, setAnchorButton] = useState<null | HTMLElement>(null);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -40,7 +43,12 @@ export const ShareButton: React.FC<ShareButtonProps> = ({
   };
   return (
     <>
-      <Button variant="outlined" endIcon={<ShareIcon />} onClick={handleClick}>
+      <Button
+        variant="outlined"
+        endIcon={<ShareIcon />}
+        onClick={handleClick}
+        {...muiButtonProps}
+      >
         Share
       </Button>
       <Menu

--- a/packages/ui-components/src/components/ShareButton/ShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.tsx
@@ -7,13 +7,17 @@ import { FacebookShareButton } from "./FacebookShareButton";
 import { Menu, MenuItem } from "./ShareButton.style";
 import isNull from "lodash/isNull";
 
+const noop = () => {
+  return;
+};
+
 export interface ShareButtonProps {
   url: string;
   quote: string;
   hashtags?: string[];
-  onCopyLink: () => void;
-  onShareTwitter: () => void;
-  onShareFacebook: () => void;
+  onCopyLink?: () => void;
+  onShareTwitter?: () => void;
+  onShareFacebook?: () => void;
   menuOrigin?: "left" | "center" | "right";
 }
 
@@ -21,9 +25,9 @@ export const ShareButton: React.FC<ShareButtonProps> = ({
   url,
   quote,
   hashtags = [],
-  onCopyLink,
-  onShareTwitter,
-  onShareFacebook,
+  onCopyLink = noop,
+  onShareTwitter = noop,
+  onShareFacebook = noop,
   menuOrigin = "left",
 }) => {
   const [anchorButton, setAnchorButton] = useState<null | HTMLElement>(null);

--- a/packages/ui-components/src/components/ShareButton/ShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.tsx
@@ -5,6 +5,7 @@ import { CopyLinkButton } from "./CopyLinkButton";
 import { TwitterShareButton } from "./TwitterShareButton";
 import { FacebookShareButton } from "./FacebookShareButton";
 import { Menu, MenuItem } from "./ShareButton.style";
+import isNull from "lodash/isNull";
 
 export interface ShareButtonProps {
   url: string;
@@ -40,7 +41,7 @@ export const ShareButton: React.FC<ShareButtonProps> = ({
       </Button>
       <Menu
         anchorEl={anchorButton}
-        open={Boolean(anchorButton)}
+        open={!isNull(anchorButton)}
         onClose={() => setAnchorButton(null)}
         anchorOrigin={{
           vertical: "bottom",

--- a/packages/ui-components/src/components/ShareButton/TwitterShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/TwitterShareButton.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import TwitterIcon from "@mui/icons-material/Twitter";
-import { Typography, Stack } from "@mui/material";
-import { StyledReactShareTwitterButton } from "./ShareButton.style";
+import { Button } from "@mui/material";
 import { TwitterShareButton as ReactShareTwitterShareButton } from "react-share";
 
 type BaseProps = React.ComponentProps<typeof ReactShareTwitterShareButton>;
@@ -14,16 +13,14 @@ export const TwitterShareButton: React.FC<TwitterShareButtonProps> = ({
   onClick,
   ...otherProps
 }) => (
-  <StyledReactShareTwitterButton
-    {...otherProps}
-    onClick={onClick}
-    resetButtonStyle={false} /** allows us to customize styles */
-  >
-    <Stack spacing={0.75} direction="row" justifyContent="center">
-      <Typography variant="labelLarge" color="primary">
-        Twitter
-      </Typography>
-      <TwitterIcon color="primary" />
-    </Stack>
-  </StyledReactShareTwitterButton>
+  <ReactShareTwitterShareButton {...otherProps}>
+    <Button
+      onClick={onClick}
+      endIcon={<TwitterIcon />}
+      fullWidth
+      component="div"
+    >
+      Twitter
+    </Button>
+  </ReactShareTwitterShareButton>
 );

--- a/packages/ui-components/src/components/ShareButton/TwitterShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/TwitterShareButton.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import * as ReactShare from "react-share";
 import TwitterIcon from "@mui/icons-material/Twitter";
-import { Button } from "./ShareButton.style";
+import { Typography, Stack } from "@mui/material";
+import { StyledReactShareTwitterButton } from "./ShareButton.style";
+import { TwitterShareButton as ReactShareTwitterShareButton } from "react-share";
 
-type BaseProps = React.ComponentProps<typeof ReactShare.TwitterShareButton>;
+type BaseProps = React.ComponentProps<typeof ReactShareTwitterShareButton>;
 
 export interface TwitterShareButtonProps extends BaseProps {
   onClick: () => void;
@@ -13,7 +14,16 @@ export const TwitterShareButton: React.FC<TwitterShareButtonProps> = ({
   onClick,
   ...otherProps
 }) => (
-  <Button onClick={() => onClick()} endIcon={<TwitterIcon />} fullWidth>
-    <ReactShare.TwitterShareButton {...otherProps} />
-  </Button>
+  <StyledReactShareTwitterButton
+    {...otherProps}
+    onClick={onClick}
+    resetButtonStyle={false} /** allows us to customize styles */
+  >
+    <Stack spacing={0.75} direction="row" justifyContent="center">
+      <Typography variant="labelLarge" color="primary">
+        Twitter
+      </Typography>
+      <TwitterIcon color="primary" />
+    </Stack>
+  </StyledReactShareTwitterButton>
 );

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-0.1.0.tgz#fa83caa21c419f20d7be7c10dafd70986613e6a0"
   integrity sha512-8dBa6CHFDuY/jAVtazVCDSl9796gaOLmsdMFX+uGBwQruEWpCq2jOkf/wvLypt9eoE+Dzi63Q5zbOIVXmlQRtQ==
 
-"@actnowcoalition/metrics@^0.2.1":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.2.2.tgz#46fb8434720d6ed2f3baf3a5ebd458354b6b7218"
-  integrity sha512-ueH74AB1calH601gVNYdcjpKMAfj7MmnxHQT0ra8d7p8vBgBdygzFeKy5hWd1IAp+ukFZb5XCE6DMzmc/QuoQw==
+"@actnowcoalition/metrics@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.2.3.tgz#a56f529363543b2d65fe020bc7d59a75631694c2"
+  integrity sha512-TSwqn0aMFNLrmdqTMdGlf4MaCj5mfx3BBWX9Fq4eS4lA5bbT8YJVVDjX/WSl61VZNxXXYLUIJ21YXyxgJUUuIA==
   dependencies:
     "@actnowcoalition/assert" "^0.1.0"
     "@actnowcoalition/number-format" "^0.1.0"


### PR DESCRIPTION
Fixes #256 

Updates:
- Fixes facebook+twitter share buttons. They previously were each a button nested within another button (a MUI button nested inside of a ReactShare button). This PR adds component="div" to the MUI button, so the dom doesn't register it as a second button
- Reverses the nesting of the ReactShare buttons (puts MUI button inside ReactShare button) so that the whole button is clickable
- Adds MUI `ButtonProps` to the top level `ShareButtonProps` and applies them to the anchor share button (so, for example, we could make the share button large or small using the native MUI `size` prop)
- Makes additional onClick props (onCopyLink, onShareTwitter, onShareFacebook) all optional and default to an empty function, so we don't manually need to pass empty functions if those props are unused