### PR TITLE
Implement `TableContainer` to contain/size compare tables

### DIFF
--- a/.changeset/few-lions-fold.md
+++ b/.changeset/few-lions-fold.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Export TableContainer to contain and size compare tables

--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { ComponentMeta } from "@storybook/react";
-import { Paper, Typography } from "@mui/material";
+import { Typography } from "@mui/material";
 import { formatInteger } from "@actnowcoalition/number-format";
 import { states, Region } from "@actnowcoalition/regions";
 import {
@@ -10,6 +10,7 @@ import {
   ColumnDefinition,
   ColumnHeader,
   compare,
+  TableContainer,
 } from ".";
 
 export default {
@@ -154,8 +155,8 @@ const StatefulCompareTable: React.FC<{
 
 export const Example = () => {
   return (
-    <Paper sx={{ maxWidth: 400, height: 600, overflow: "auto" }}>
+    <TableContainer sx={{ maxWidth: 400, height: 600 }}>
       <StatefulCompareTable rows={rows} />
-    </Paper>
+    </TableContainer>
   );
 };

--- a/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
@@ -5,9 +5,12 @@ import {
   TableRow as MuiTableRow,
   TableCell as MuiTableCell,
   tableCellClasses,
+  TableContainer as MuiTableContainer,
 } from "@mui/material";
 import React from "react";
 import { styled } from "../../styles";
+
+export const TableContainer = styled(MuiTableContainer)``;
 
 export const Table = styled(MuiTable)`
   border-collapse: separate;

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { Paper } from "@mui/material";
 import { states } from "@actnowcoalition/regions";
 import { MetricId } from "../../stories/mockMetricCatalog";
+import { TableContainer } from "../CompareTable";
 import { MetricCompareTable } from ".";
 
 export default {
@@ -11,9 +11,9 @@ export default {
 } as ComponentMeta<typeof MetricCompareTable>;
 
 const Template: ComponentStory<typeof MetricCompareTable> = (args) => (
-  <Paper sx={{ maxWidth: 600, height: 500, overflow: "auto" }}>
+  <TableContainer sx={{ maxWidth: 600, height: 500 }}>
     <MetricCompareTable {...args} />
-  </Paper>
+  </TableContainer>
 );
 
 export const Example = Template.bind({});


### PR DESCRIPTION
Originally, we wanted to update the Table component itself to have an integrated container that will have height and the right overflow attribute, but I think that exposing `TableContainer` is a bit more flexible. For example, we can set different `width` and `height` depending on the breakpoint:

```tsx
<TableContainer sx={{ maxHeight: { xs: 233, md: 167 } }}>
  <MetricCompareTable {/* ... */} />
</TableContainer>
```

we could incorporate the `TableContainer` in the `CompareTable` component, but we are already accepting all the props from `MuiTable`, so applying the `sx` props to the TableContainer instead of to the underlying `MuiTable` will make the API of the `CompareTable` component a bit inconsistent.

That being said, I'm open to suggestions to integrate the component and simplify things!

<img width="622" alt="image" src="https://user-images.githubusercontent.com/114084/193942598-eed300e1-8cea-4c66-be75-cb6d7b4a0aad.png">
