### PR TITLE
Add simple formatting to region population in RegionSearch

### DIFF
--- a/.changeset/calm-eggs-promise.md
+++ b/.changeset/calm-eggs-promise.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Update the number format of the population on RegionSearch options

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLAttributes } from "react";
 import { Region } from "@actnowcoalition/regions";
+import { formatDecimal } from "@actnowcoalition/number-format";
 import { Autocomplete, AutocompleteProps, TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import { createFilterOptions } from "@mui/material/useAutocomplete";
@@ -19,7 +20,7 @@ export type CustomAutocompleteProps = AutocompleteProps<
   Region,
   false, // multiple
   false, // disableClearable
-  false, // freeSsolo
+  false, // freeSolo
   "div" // ChipComponent
 >;
 
@@ -73,7 +74,9 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
             <LinkComponent targetUrl={getRegionUrl(option.regionId)}>
               <SearchItem
                 itemLabel={option.shortName}
-                itemSublabel={`${option.population} population`}
+                itemSublabel={`${formatPopulation(
+                  option.population
+                )} population`}
                 {...props}
               />
             </LinkComponent>
@@ -89,3 +92,19 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
     </div>
   );
 };
+
+/**
+ * Format the population with thousands separator and keeping 3 significant
+ * digits.
+ *
+ * @example
+ * ```ts
+ * formatPopulation(107766) // 108,000
+ * ```
+ */
+function formatPopulation(population: number) {
+  return formatDecimal(population, {
+    maximumSignificantDigits: 3,
+    maximumFractionDigits: 0,
+  });
+}


### PR DESCRIPTION
Just updating the formatting for the population field on RegionSearch items.

**Before**

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/114084/193945552-3ac6c92a-819c-40a7-8359-5df470f4e7ac.png">

**After**

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/114084/193945393-601c89ec-5f01-45bb-bf7f-bac49888a2e8.png">
