### PR TITLE
Updates to metric compare table (extended names, population)

### DIFF
--- a/.changeset/orange-seahorses-turn.md
+++ b/.changeset/orange-seahorses-turn.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Update metric compare table: Add metric extended names to column headers; add population to location column.

--- a/.changeset/spotty-apes-notice.md
+++ b/.changeset/spotty-apes-notice.md
@@ -1,0 +1,6 @@
+---
+"@actnowcoalition/number-format": patch
+"@actnowcoalition/ui-components": patch
+---
+
+Add formatInteger() overload that takes options and use it from ui-components.

--- a/packages/number-format/src/index.ts
+++ b/packages/number-format/src/index.ts
@@ -9,8 +9,14 @@
  * @param value Number to format
  * @returns Formatted number (as string)
  */
-export function formatInteger(value: number): string {
-  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+export function formatInteger(
+  value: number,
+  options?: Intl.NumberFormatOptions
+): string {
+  return value.toLocaleString(undefined, {
+    ...options,
+    maximumFractionDigits: 0,
+  });
 }
 
 /**

--- a/packages/ui-components/src/common/utils/index.ts
+++ b/packages/ui-components/src/common/utils/index.ts
@@ -1,5 +1,5 @@
 export { default as importJson } from "./importJson";
-import { formatDecimal } from "@actnowcoalition/number-format";
+import { formatInteger } from "@actnowcoalition/number-format";
 
 /**
  * Format the population with thousands separator and keeping 3 significant
@@ -11,8 +11,7 @@ import { formatDecimal } from "@actnowcoalition/number-format";
  * ```
  */
 export function formatPopulation(population: number) {
-  return formatDecimal(population, {
+  return formatInteger(population, {
     maximumSignificantDigits: 3,
-    maximumFractionDigits: 0,
   });
 }

--- a/packages/ui-components/src/common/utils/index.ts
+++ b/packages/ui-components/src/common/utils/index.ts
@@ -1,1 +1,18 @@
 export { default as importJson } from "./importJson";
+import { formatDecimal } from "@actnowcoalition/number-format";
+
+/**
+ * Format the population with thousands separator and keeping 3 significant
+ * digits.
+ *
+ * @example
+ * ```ts
+ * formatPopulation(107766) // 108,000
+ * ```
+ */
+export function formatPopulation(population: number) {
+  return formatDecimal(population, {
+    maximumSignificantDigits: 3,
+    maximumFractionDigits: 0,
+  });
+}

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -10,6 +10,8 @@ import {
   getAriaSort,
 } from "../CompareTable";
 import { Row } from "./interfaces";
+import { Stack, Typography } from "@mui/material";
+import { formatPopulation } from "../../common/utils";
 
 export function createMetricColumn(
   metric: Metric,
@@ -24,7 +26,12 @@ export function createMetricColumn(
       const isSortActive = sortColumnId === column.columnId;
       return (
         <ColumnHeader
-          label={column.name}
+          label={
+            <HeaderLabel
+              primary={column.name}
+              secondary={metric.extendedName}
+            />
+          }
           sortDirection={isSortActive ? sortDirection : undefined}
           onClickSort={(dir) => onClickSort(dir, column.columnId)}
           aria-sort={getAriaSort(isSortActive, sortDirection)}
@@ -74,7 +81,7 @@ export function createLocationColumn(
       const isSortActive = sortColumnId === column.columnId;
       return (
         <ColumnHeader
-          label={column.name}
+          label={<HeaderLabel primary={column.name} secondary="Population" />}
           sortDirection={isSortActive ? sortDirection : undefined}
           onClickSort={(dir) => onClickSort(dir, column.columnId)}
           aria-sort={getAriaSort(isSortActive, sortDirection)}
@@ -84,9 +91,31 @@ export function createLocationColumn(
       );
     },
     renderCell: ({ row }) => (
-      <TableCell stickyColumn>{row.region.fullName}</TableCell>
+      <TableCell stickyColumn>
+        <Stack spacing={0.5}>
+          <Typography variant="labelSmall">{row.region.fullName}</Typography>
+          <Typography variant="paragraphSmall">
+            {formatPopulation(row.region.population)}
+          </Typography>
+        </Stack>
+      </TableCell>
     ),
     sorterAsc: (rowA, rowB) =>
       rowA.region.fullName < rowB.region.fullName ? -1 : 1,
   };
+}
+
+function HeaderLabel({
+  primary,
+  secondary,
+}: {
+  primary: string;
+  secondary: string;
+}) {
+  return (
+    <Stack spacing={1}>
+      <Typography variant="labelSmall">{primary}</Typography>
+      <Typography variant="paragraphSmall">{secondary}</Typography>
+    </Stack>
+  );
 }

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -1,10 +1,10 @@
 import React, { HTMLAttributes } from "react";
 import { Region } from "@actnowcoalition/regions";
-import { formatDecimal } from "@actnowcoalition/number-format";
 import { Autocomplete, AutocompleteProps, TextField } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import { createFilterOptions } from "@mui/material/useAutocomplete";
 import { SearchItem } from "./SearchItem/SearchItem";
+import { formatPopulation } from "../../common/utils";
 
 function stringifyOption(region: Region) {
   return region.fullName;
@@ -92,19 +92,3 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
     </div>
   );
 };
-
-/**
- * Format the population with thousands separator and keeping 3 significant
- * digits.
- *
- * @example
- * ```ts
- * formatPopulation(107766) // 108,000
- * ```
- */
-function formatPopulation(population: number) {
-  return formatDecimal(population, {
-    maximumSignificantDigits: 3,
-    maximumFractionDigits: 0,
-  });
-}


### PR DESCRIPTION
* Add metric extended names to metric columns.
* Add population to location column.

To be honest, I am not sure it looks great (especially with the long metric names we have in storybook), but I think this roughly matches the mocks:

![image](https://user-images.githubusercontent.com/206364/194130933-92c20e74-1e62-4a89-9213-e3b1545a58c4.png)
