### PR TITLE
Improve button styling

### DIFF
--- a/.changeset/angry-lies-type.md
+++ b/.changeset/angry-lies-type.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Improve button styling

--- a/packages/ui-components/src/stories/Buttons.stories.tsx
+++ b/packages/ui-components/src/stories/Buttons.stories.tsx
@@ -36,3 +36,14 @@ export const Group = () => (
     <Button endIcon={<FacebookIcon />}>Facebook</Button>
   </ButtonGroup>
 );
+
+export const InLargeContainer = () => (
+  <Stack direction="row" height={200} border="1px solid blue" gap={1}>
+    <Button variant="contained" endIcon={<LinkIcon />}>
+      Copy Link
+    </Button>
+    <Button variant="outlined" endIcon={<TwitterIcon />}>
+      Twitter
+    </Button>
+  </Stack>
+);

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -5,6 +5,73 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 const referenceTheme = createTheme();
 
 const components: ThemeOptions["components"] = {
+  MuiButton: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        textTransform: "none",
+        fontFamily: theme.typography.labelLarge.fontFamily,
+        fontSize: theme.typography.labelLarge.fontSize,
+        fontWeight: theme.typography.labelLarge.fontWeight,
+        lineHeight: theme.typography.labelLarge.lineHeight,
+      }),
+      outlinedPrimary: ({ theme }) => ({
+        borderColor: theme.palette.border.default,
+      }),
+    },
+  },
+
+  MuiChip: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        borderColor: theme.palette.border.default,
+      }),
+      label: ({ theme }) => ({
+        ...theme.typography.labelSmall,
+        color: theme.palette.secondary.dark,
+      }),
+      deleteIcon: ({ theme }) => ({
+        color: theme.palette.text.disabled,
+        ":hover": {
+          color: theme.palette.secondary.dark,
+        },
+      }),
+    },
+  },
+
+  MuiTab: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        textTransform: "none",
+        padding: `0 0 ${theme.spacing(2)} 0`,
+        margin: `0 ${theme.spacing(2)}`,
+        ":first-of-type": {
+          marginLeft: "0",
+        },
+        ":last-of-type": {
+          marginRight: "0",
+        },
+        ":not(&.Mui-selected)": {
+          span: {
+            color: theme.palette.text.secondary,
+          },
+        },
+      }),
+    },
+  },
+
+  MuiTabs: {
+    styleOverrides: {
+      indicator: ({ theme }) => ({
+        height: "2px",
+        backgroundColor: theme.palette.common.black,
+      }),
+      flexContainer: ({ theme }) => ({
+        borderBottom: `1px solid ${theme.palette.border.default}`,
+        width: "fit-content",
+      }),
+    },
+  },
+
   MuiTextField: {
     defaultProps: {
       SelectProps: {
@@ -38,72 +105,7 @@ const components: ThemeOptions["components"] = {
       }),
     },
   },
-  MuiTabs: {
-    styleOverrides: {
-      indicator: ({ theme }) => ({
-        height: "2px",
-        backgroundColor: theme.palette.common.black,
-      }),
-      flexContainer: ({ theme }) => ({
-        borderBottom: `1px solid ${theme.palette.border.default}`,
-        width: "fit-content",
-      }),
-    },
-  },
-  MuiTab: {
-    styleOverrides: {
-      root: ({ theme }) => ({
-        textTransform: "none",
-        padding: `0 0 ${theme.spacing(2)} 0`,
-        margin: `0 ${theme.spacing(2)}`,
-        ":first-of-type": {
-          marginLeft: "0",
-        },
-        ":last-of-type": {
-          marginRight: "0",
-        },
-        ":not(&.Mui-selected)": {
-          span: {
-            color: theme.palette.text.secondary,
-          },
-        },
-      }),
-    },
-  },
-  MuiButton: {
-    styleOverrides: {
-      root: ({ theme }) => ({
-        textTransform: "none",
-        fontFamily: theme.typography.labelLarge.fontFamily,
-        fontSize: theme.typography.labelLarge.fontSize,
-        fontWeight: theme.typography.labelLarge.fontWeight,
-        lineHeight: theme.typography.labelLarge.lineHeight,
-      }),
-      outlinedPrimary: ({ theme }) => ({
-        borderColor: theme.palette.border.default,
-      }),
-    },
-  },
-  MuiTooltip: {
-    styleOverrides: {
-      tooltip: ({ theme }) => ({
-        backgroundColor: "black",
-        color: "white",
-        fontSize: theme.typography.paragraphLarge.fontSize,
-        lineHeight: theme.typography.paragraphLarge.lineHeight,
-        padding: theme.spacing(2),
-        "& a": {
-          color: "white",
-        },
-        [referenceTheme.breakpoints.down("sm")]: {
-          padding: "20px 24px",
-        },
-      }),
-      arrow: {
-        color: "black",
-      },
-    },
-  },
+
   MuiToggleButtonGroup: {
     styleOverrides: {
       root: ({ theme }) => ({
@@ -145,21 +147,25 @@ const components: ThemeOptions["components"] = {
       }),
     },
   },
-  MuiChip: {
+
+  MuiTooltip: {
     styleOverrides: {
-      root: ({ theme }) => ({
-        borderColor: theme.palette.border.default,
-      }),
-      label: ({ theme }) => ({
-        ...theme.typography.labelSmall,
-        color: theme.palette.secondary.dark,
-      }),
-      deleteIcon: ({ theme }) => ({
-        color: theme.palette.text.disabled,
-        ":hover": {
-          color: theme.palette.secondary.dark,
+      tooltip: ({ theme }) => ({
+        backgroundColor: "black",
+        color: "white",
+        fontSize: theme.typography.paragraphLarge.fontSize,
+        lineHeight: theme.typography.paragraphLarge.lineHeight,
+        padding: theme.spacing(2),
+        "& a": {
+          color: "white",
+        },
+        [referenceTheme.breakpoints.down("sm")]: {
+          padding: "20px 24px",
         },
       }),
+      arrow: {
+        color: "black",
+      },
     },
   },
 };

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -167,7 +167,7 @@ const components: ThemeOptions["components"] = {
           color: "white",
         },
         [referenceTheme.breakpoints.down("sm")]: {
-          padding: "20px 24px",
+          padding: theme.spacing(2.5, 3),
         },
       }),
       arrow: {

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -13,6 +13,13 @@ const components: ThemeOptions["components"] = {
         fontSize: theme.typography.labelLarge.fontSize,
         fontWeight: theme.typography.labelLarge.fontWeight,
         lineHeight: theme.typography.labelLarge.lineHeight,
+        height: "fit-content",
+        minWidth: "fit-content",
+        width: "fit-content",
+        boxShadow: "none",
+        "&: hover": {
+          boxShadow: "none",
+        },
       }),
       outlinedPrimary: ({ theme }) => ({
         borderColor: theme.palette.border.default,


### PR DESCRIPTION
In the september hackathon repo, we noticed that buttons were growing to the height of their parent container (screenshot below). This PR adds styling to the buttons at the theme level that makes them maintain the correct sizing. (Also, removes box shadows)

Bug:

<img width="872" alt="Screen Shot 2022-10-05 at 3 31 17 PM" src="https://user-images.githubusercontent.com/44076375/194146948-f4d627fb-e56e-4b9f-82e8-53af6c077ded.png">

[Storybook demo of fix](https://act-now-packages--pr275-casulin-button-heigh-jq3muh82.web.app/storybook/index.html?path=/story/design-system-buttons--in-large-container)