### PR TITLE
Improve error messages when levels and thresholds are not consistent

### DIFF
--- a/.changeset/smooth-singers-tan.md
+++ b/.changeset/smooth-singers-tan.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/metrics": patch
+---
+
+Better error messages when thresholds and levels are incompatible

--- a/packages/metrics/src/Metric/Metric.ts
+++ b/packages/metrics/src/Metric/Metric.ts
@@ -96,9 +96,17 @@ export class Metric {
       "Categories and levels should not both be defined."
     );
 
+    // We should either have both levels and thresholds, or both should
+    // be undefined
+    if (!!this.thresholds !== !!this.levelSet) {
+      assert(this.thresholds, `Missing thresholds for metric ${this}`);
+      assert(this.levelSet, `Missing levels for metric ${this}`);
+    }
+
     assert(
       this.thresholds === undefined ||
         (this.levelSet &&
+          this.thresholds &&
           this.thresholds.length === this.levelSet.levels.length - 1),
       "There should be 1 fewer thresholds than levels."
     );


### PR DESCRIPTION
Close #273 

Added error messages for when we have thresholds and not levels, and levels without thresholds. I added some unit tests to check for that and also to test the error thrown when the number of levels and thresholds are inconsistent with each other.