### PR TITLE
Clip the map projection to avoid rendering outside the viewBox

### DIFF
--- a/.changeset/olive-buttons-grin.md
+++ b/.changeset/olive-buttons-grin.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Clip the map extent to fix the tooltip positioning (and more efficient rendering)

--- a/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/Maps/USStateMap/USStateMap.tsx
@@ -48,7 +48,12 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
   // in this case.
   const geoProjection = stateGeo.id === "02" ? geoAlbersUsa : geoMercator;
 
-  const projection = geoProjection().fitSize([width, height], stateGeo);
+  const projection = geoProjection()
+    .fitSize([width, height], stateGeo)
+    .clipExtent([
+      [0, 0],
+      [width, height],
+    ]);
   const geoPath = d3GeoPath().projection(projection);
 
   const regionsOfState = countiesGeographies.features.filter((geo) =>


### PR DESCRIPTION
Adding a small improvement to the state maps. The map will normally project render the entire shape being passed, which can be wasteful if part of the map falls outside the viewBox.

In the state map case, we show parts of neighbouring states, but the map was actually rendering the entire state outside the visible area. Adding the `.clipExtent([[0, 0], [width, heigh]])` option "cuts" the projection using the provided dimensions, which avoids unnecessary rendering.

This change also fixes another bug - the tooltip for the state is centered around the center of the whole state, not around the visible area. Now that the SVG shape is restricted to the visible section, the tooltip is correctly positioned.

**Before**

<img width="626" alt="image" src="https://user-images.githubusercontent.com/114084/194417645-65da0350-bcea-429a-ab11-04c845c1eda9.png">

Note: ☝️  This tooltip is from the "Before" image

**After**

<img width="618" alt="image" src="https://user-images.githubusercontent.com/114084/194417677-2e482c1e-4da6-4bc0-b724-950bf22d4ad5.png">

👌  Now the tooltip is positioned around the part of Ohio that's visible on the screen.