### PR TITLE
Implement ChartOverlayXY component

### DIFF
--- a/.changeset/chatty-cats-count.md
+++ b/.changeset/chatty-cats-count.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Implement ChartOverlayXY component

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -69,6 +69,7 @@
     "@visx/responsive": "^2.10.0",
     "@visx/scale": "^2.2.2",
     "@visx/shape": "^2.12.2",
+    "@visx/voronoi": "^2.10.0",
     "d3-geo": "^2.0.2",
     "d3-scale-chromatic": "^3.0.0",
     "geo-albers-usa-territories": "^0.1.0",

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from "react";
+import isNumber from "lodash/isNumber";
+import { ComponentMeta } from "@storybook/react";
+import { Group } from "@visx/group";
+import { scaleUtc, scaleLinear } from "@visx/scale";
+import { Timeseries } from "@actnowcoalition/metrics";
+import { AxisBottom, AxisLeft } from "../Axis";
+import { LineChart } from "../LineChart";
+import { ChartOverlayXY, PointInfo } from ".";
+
+export default {
+  title: "Charts/ChartOverlayXY",
+  component: ChartOverlayXY,
+} as ComponentMeta<typeof ChartOverlayXY>;
+
+const width = 600;
+const height = 400;
+const padding = 40;
+const innerWidth = width - 2 * padding;
+const innerHeight = height - 2 * padding;
+
+const dates = [
+  new Date("2022-01-01"),
+  new Date("2022-01-02"),
+  new Date("2022-01-03"),
+  new Date("2022-01-04"),
+  new Date("2022-01-05"),
+  new Date("2022-01-06"),
+];
+
+function generateSeries(dates: Date[], maxValue: number): Timeseries<number> {
+  const points = dates.map((date) => ({
+    date,
+    value: maxValue * Math.random(),
+  }));
+  return new Timeseries<number>(points);
+}
+
+const seriesList = [
+  { timeseries: generateSeries(dates, 10), color: "#2196f3" },
+  { timeseries: generateSeries(dates, 20), color: "#66bb6a" },
+  { timeseries: generateSeries(dates, 30), color: "#fb8c00" },
+];
+
+const xScale = scaleUtc({
+  domain: [dates[0], dates[dates.length - 1]],
+  range: [0, innerWidth],
+});
+
+const yScale = scaleLinear({
+  domain: [0, 30],
+  range: [innerHeight, 0],
+});
+
+export const Example = () => {
+  const [pointIndex, setPointIndex] = useState<number | null>(null);
+  const [timeseriesIndex, setTimeseriesIndex] = useState<number | null>(null);
+
+  const isHoveringPoint = isNumber(pointIndex) && isNumber(timeseriesIndex);
+
+  const onMouseMove = ({ pointIndex, timeseriesIndex }: PointInfo) => {
+    if (isNumber(pointIndex) && isNumber(timeseriesIndex)) {
+      setPointIndex(pointIndex);
+      setTimeseriesIndex(timeseriesIndex);
+    }
+  };
+
+  const onMouseOut = () => {
+    setPointIndex(null);
+    setTimeseriesIndex(null);
+  };
+
+  return (
+    <svg width={width} height={height} style={{ border: "solid 1px #ddd" }}>
+      <Group left={padding} top={padding}>
+        <AxisBottom top={innerHeight} scale={xScale} />
+        <AxisLeft scale={yScale} />
+        {seriesList.map(({ timeseries, color }, tIndex) => (
+          <Group key={`group-${tIndex}`}>
+            {timeseries.points.map((p, pIndex) => (
+              <circle
+                key={`point-${pIndex}`}
+                r={
+                  isHoveringPoint &&
+                  pointIndex === pIndex &&
+                  tIndex === timeseriesIndex
+                    ? 5
+                    : 2
+                }
+                cx={xScale(p.date)}
+                cy={yScale(p.value)}
+                fill={color}
+              />
+            ))}
+          </Group>
+        ))}
+        {isHoveringPoint && (
+          <LineChart
+            timeseries={seriesList[timeseriesIndex].timeseries}
+            xScale={xScale}
+            yScale={yScale}
+            stroke={seriesList[timeseriesIndex].color}
+          />
+        )}
+        <ChartOverlayXY
+          timeseriesList={seriesList.map((s) => s.timeseries)}
+          yScale={yScale}
+          xScale={xScale}
+          width={innerWidth}
+          height={innerHeight}
+          onMouseMove={onMouseMove}
+          onMouseOut={onMouseOut}
+        />
+      </Group>
+    </svg>
+  );
+};

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
@@ -26,6 +26,9 @@ const dates = [
   new Date("2022-01-04"),
   new Date("2022-01-05"),
   new Date("2022-01-06"),
+  new Date("2022-01-07"),
+  new Date("2022-01-08"),
+  new Date("2022-01-09"),
 ];
 
 function generateSeries(dates: Date[], maxValue: number): Timeseries<number> {
@@ -35,12 +38,6 @@ function generateSeries(dates: Date[], maxValue: number): Timeseries<number> {
   }));
   return new Timeseries<number>(points);
 }
-
-const seriesList = [
-  { timeseries: generateSeries(dates, 10), color: "#2196f3" },
-  { timeseries: generateSeries(dates, 20), color: "#66bb6a" },
-  { timeseries: generateSeries(dates, 30), color: "#fb8c00" },
-];
 
 const xScale = scaleUtc({
   domain: [dates[0], dates[dates.length - 1]],
@@ -52,7 +49,21 @@ const yScale = scaleLinear({
   range: [innerHeight, 0],
 });
 
-export const Example = () => {
+const seriesList = [
+  { timeseries: generateSeries(dates, 10), color: "#2196f3" },
+  { timeseries: generateSeries(dates, 20), color: "#66bb6a" },
+  { timeseries: generateSeries(dates, 30), color: "#fb8c00" },
+];
+
+/**
+ * This chart is a demo of a simplified Trends chart. When the user hovers
+ * near a point on one of the series, the entire line is highlighted.
+ *
+ * When the user hovers near a point, the `ChartOverlayXY` component calls the
+ * onMouseMove handler passing the index of the point in the series, and
+ * the index of the series. We use that information to make the line thicker.
+ */
+export const ExampleTrendsChart = () => {
   const [pointIndex, setPointIndex] = useState<number | null>(null);
   const [timeseriesIndex, setTimeseriesIndex] = useState<number | null>(null);
 
@@ -77,31 +88,28 @@ export const Example = () => {
         <AxisLeft scale={yScale} />
         {seriesList.map(({ timeseries, color }, tIndex) => (
           <Group key={`group-${tIndex}`}>
-            {timeseries.points.map((p, pIndex) => (
-              <circle
-                key={`point-${pIndex}`}
-                r={
-                  isHoveringPoint &&
-                  pointIndex === pIndex &&
-                  tIndex === timeseriesIndex
-                    ? 5
-                    : 2
-                }
-                cx={xScale(p.date)}
-                cy={yScale(p.value)}
-                fill={color}
-              />
-            ))}
+            <LineChart
+              timeseries={timeseries}
+              xScale={xScale}
+              yScale={yScale}
+              stroke={color}
+              strokeWidth={
+                isHoveringPoint && tIndex === timeseriesIndex ? 3 : 1
+              }
+            />
+            <Group>
+              {timeseries.points.map((p, pIndex) => (
+                <circle
+                  key={`point-${pIndex}`}
+                  r={3}
+                  cx={xScale(p.date)}
+                  cy={yScale(p.value)}
+                  fill={color}
+                />
+              ))}
+            </Group>
           </Group>
         ))}
-        {isHoveringPoint && (
-          <LineChart
-            timeseries={seriesList[timeseriesIndex].timeseries}
-            xScale={xScale}
-            yScale={yScale}
-            stroke={seriesList[timeseriesIndex].color}
-          />
-        )}
         <ChartOverlayXY
           timeseriesList={seriesList.map((s) => s.timeseries)}
           yScale={yScale}

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.style.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.style.ts
@@ -1,3 +1,0 @@
-import { styled } from "../../styles";
-
-export const Container = styled("div")``;

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.style.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.style.ts
@@ -1,0 +1,3 @@
+import { styled } from "../../styles";
+
+export const Container = styled("div")``;

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -41,6 +41,10 @@ export interface PointInfo {
   pointIndex: number;
 }
 
+const noop = () => {
+  // Do nothing
+};
+
 /**
  * This component is an overlay that helps capture the information of the
  * point that is being hovered by the user. Given a list of timeseries,
@@ -56,10 +60,8 @@ export const ChartOverlayXY = ({
   xScale,
   yScale,
   timeseriesList,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onMouseMove = () => {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onMouseOut = () => {},
+  onMouseMove = noop,
+  onMouseOut = noop,
 }: ChartOverlayXYProps) => {
   // Put all the points together in one array. Each pointInfo includes
   // the index of the timeseries it belongs to, and its own index

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -6,26 +6,32 @@ import { voronoi, VoronoiPolygon } from "@visx/voronoi";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 
 export interface ChartOverlayXYProps {
-  /** List of timeseries */
+  /**
+   * List of timeseries objects that contain the hoverable points. The component
+   * receives a list of timeseries to make it easier to know which series was
+   * hovered (not only which point).
+   **/
   timeseriesList: Timeseries<number>[];
-  /** Width */
+  /** Width of the hoverable area. */
   width: number;
-  /** Height */
+  /** Height of the hoverable area. */
   height: number;
-  /** xScale */
+  /** d3-scale to convert between dates and pixel dimensions. */
   xScale: ScaleTime<number, number>;
-  /** yScale */
+  /** d3-scale to convert between data units on the y-axis and pixel dimensions. */
   yScale: ScaleLinear<number, number>;
+  /**
+   * Handler to call when a user hovers near a point. The point, timeseriesIndex
+   * and pointIndex are passed to the handler.
+   **/
   onMouseMove?: (pointInfo: PointInfo) => void;
+  /** Handler to call when the user moves out of the hoverable area. */
   onMouseOut?: () => void;
 }
 
-export interface HoverData {
-  timeseries: Timeseries<number>;
-  point: TimeseriesPoint<number>;
-}
-
-/** PointInfo */
+/**
+ * The PointInfo contains information about the point being hovered.
+ */
 export interface PointInfo {
   /** Hovered point */
   point: TimeseriesPoint<number>;
@@ -36,7 +42,13 @@ export interface PointInfo {
 }
 
 /**
- * Overlay to capture mouse over a point and the neighboring region
+ * This component is an overlay that helps capture the information of the
+ * point that is being hovered by the user. Given a list of timeseries,
+ * the `onMouseMove` handler will be called with the point, index of the
+ * timeseries (`timeseriesIndex`) and index of the point in the timeseries
+ * (`pointIndex`), which can be stored in a state by the parent component.
+ *
+ * See `ChartOverlayXY.stories.tsx` for usage examples.
  */
 export const ChartOverlayXY = ({
   width,
@@ -58,7 +70,8 @@ export const ChartOverlayXY = ({
   // and height. Each point has a corresponding polygon such that all the
   // points in the polygon are closer to its point than to any other
   // point.
-  // Each polygon has the pointInfo attached to it
+  // Each polygon has the pointInfo attached to it, so we can pass it to the
+  // handler when the user hovers it.
   const voronoiPolygons = useMemo(() => {
     const voroniLayout = voronoi<PointInfo>({
       x: ({ point }: PointInfo) => xScale(point.date),
@@ -84,7 +97,10 @@ export const ChartOverlayXY = ({
   );
 };
 
-// Generates identifiable points from a list of timeseries
+/**
+ * Given a list of timeseries, it returns a single list with the information
+ * of each point (point, timeseriesIndex and pointIndex in the timeseries).
+ */
 function getTimeseriesPoints(
   timeseriesList: Timeseries<number>[]
 ): PointInfo[] {

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -75,10 +75,7 @@ export const ChartOverlayXY = ({
         <VoronoiPolygon
           key={`polygon-${polygonIndex}`}
           polygon={polygon}
-          fill="#e3f2fd"
-          fillOpacity={0.5}
-          stroke="white"
-          strokeWidth={2}
+          fillOpacity={0}
           onMouseEnter={() => onMouseMove(polygon.data)}
           onMouseOut={onMouseOut}
         />

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -1,0 +1,103 @@
+import React, { useMemo } from "react";
+import concat from "lodash/concat";
+import { ScaleTime, ScaleLinear } from "d3-scale";
+import { Group } from "@visx/group";
+import { voronoi, VoronoiPolygon } from "@visx/voronoi";
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+
+export interface ChartOverlayXYProps {
+  /** List of timeseries */
+  timeseriesList: Timeseries<number>[];
+  /** Width */
+  width: number;
+  /** Height */
+  height: number;
+  /** xScale */
+  xScale: ScaleTime<number, number>;
+  /** yScale */
+  yScale: ScaleLinear<number, number>;
+  onMouseMove?: (pointInfo: PointInfo) => void;
+  onMouseOut?: () => void;
+}
+
+export interface HoverData {
+  timeseries: Timeseries<number>;
+  point: TimeseriesPoint<number>;
+}
+
+/** PointInfo */
+export interface PointInfo {
+  /** Hovered point */
+  point: TimeseriesPoint<number>;
+  /** Index of the hovered timeseries */
+  timeseriesIndex: number;
+  /** Index of the hovered point */
+  pointIndex: number;
+}
+
+/**
+ * Overlay to capture mouse over a point and the neighboring region
+ */
+export const ChartOverlayXY = ({
+  width,
+  height,
+  xScale,
+  yScale,
+  timeseriesList,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onMouseMove = () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onMouseOut = () => {},
+}: ChartOverlayXYProps) => {
+  // Put all the points together in one array. Each pointInfo includes
+  // the index of the timeseries it belongs to, and its own index
+  // on the corresponding timeseries
+  const points: PointInfo[] = getTimeseriesPoints(timeseriesList);
+
+  // The Voronoi polygons are generated from a set of points and a width
+  // and height. Each point has a corresponding polygon such that all the
+  // points in the polygon are closer to its point than to any other
+  // point.
+  // Each polygon has the pointInfo attached to it
+  const voronoiPolygons = useMemo(() => {
+    const voroniLayout = voronoi<PointInfo>({
+      x: ({ point }: PointInfo) => xScale(point.date),
+      y: ({ point }: PointInfo) => yScale(point.value),
+      width,
+      height,
+    });
+    return voroniLayout(points).polygons();
+  }, [points, width, height, xScale, yScale]);
+
+  return (
+    <Group>
+      {voronoiPolygons.map((polygon, polygonIndex) => (
+        <VoronoiPolygon
+          key={`polygon-${polygonIndex}`}
+          polygon={polygon}
+          fill="#e3f2fd"
+          fillOpacity={0.5}
+          stroke="white"
+          strokeWidth={2}
+          onMouseEnter={() => onMouseMove(polygon.data)}
+          onMouseOut={onMouseOut}
+        />
+      ))}
+    </Group>
+  );
+};
+
+// Generates identifiable points from a list of timeseries
+function getTimeseriesPoints(
+  timeseriesList: Timeseries<number>[]
+): PointInfo[] {
+  return timeseriesList.reduce<PointInfo[]>(
+    (acc, timeseries, timeseriesIndex) => {
+      const pointInfoList: PointInfo[] = timeseries.points.map(
+        (point, pointIndex) => ({ point, timeseriesIndex, pointIndex })
+      );
+      return concat(acc, pointInfoList);
+    },
+    []
+  );
+}

--- a/packages/ui-components/src/components/ChartOverlayXY/index.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/index.ts
@@ -1,0 +1,1 @@
+export * from "./ChartOverlayXY";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -106,3 +106,5 @@ export * from "./components/RectClipGroup";
 export * from "./components/RegionSearch";
 export * from "./components/ShareButton";
 export * from "./components/SparkLine";
+
+export * from "./components/ChartOverlayXY";

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -2690,6 +2690,11 @@
   resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-2.1.1.tgz#743fdc821c81f86537cbfece07093ac39b4bc342"
   integrity sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==
 
+"@types/d3-voronoi@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-voronoi/-/d3-voronoi-1.1.9.tgz#7bbc210818a3a5c5e0bafb051420df206617c9e5"
+  integrity sha512-DExNQkaHd1F3dFPvGA/Aw2NGyjMln6E9QzsiqOcBgnE+VInYnFBHBBySbZQts6z6xD+5jTfKCP7M4OqMyVjdwQ==
+
 "@types/d3-zoom@^1":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@types/d3-zoom/-/d3-zoom-1.8.3.tgz#00237900c6fdc2bb4fe82679ee4d74eb8fbe7b3c"
@@ -3129,6 +3134,17 @@
     lodash "^4.17.21"
     prop-types "^15.7.2"
     reduce-css-calc "^1.3.0"
+
+"@visx/voronoi@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@visx/voronoi/-/voronoi-2.10.0.tgz#2a81b7d00c1eb6c10e6537c107a3c49f625f1364"
+  integrity sha512-2GSosmQ25a9OctY4xPpPTwY6N4CW53Ssos8kzPHTo5Si/2h9AUNqVg7eGUb8lrEjakQYAAdX0J4U8D02tsQI+w==
+  dependencies:
+    "@types/d3-voronoi" "^1.1.9"
+    "@types/react" "*"
+    classnames "^2.3.1"
+    d3-voronoi "^1.1.2"
+    prop-types "^15.6.1"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -5015,6 +5031,11 @@ d3-transition@2:
     d3-ease "1 - 2"
     d3-interpolate "1 - 2"
     d3-timer "1 - 2"
+
+d3-voronoi@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
+  integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
 
 d3-zoom@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/287

Complex charts such as the Trends chart might have multiple time series, each one with multiple points. Normally we could attach a tooltip to each point in the series, but it will be difficult for the user to hover exactly the point they are interested in (the polygons are visible here, but normally they wouldn't be).

<img width="592" alt="image" src="https://user-images.githubusercontent.com/114084/194433221-225345af-2d8e-4fef-b79d-4984ee603699.png">

One technique to solve this problem is to generate a Voronoi partition, which, given a set of points, generates a set of polygons; one for each point in the original set; such that all the points inside the polygon are closer to its corresponding point than to any other point in the set, so if we add hover events on the polygon instead of the point, the user will have a larger area to target.

<img width="587" alt="image" src="https://user-images.githubusercontent.com/114084/194433277-a3f543d6-d057-4fbb-bf3e-79bc7962c34d.png">

The Trends chart has additional complexities that can also be solved with this component. For example, when hovering a point, we want to highlight the point and the line being hovered, as well as the location label. 

<img width="966" alt="image" src="https://user-images.githubusercontent.com/114084/194433332-328d0d71-30c9-4c18-b7ab-896c4d24f7f7.png">

To achieve that, the `onMouseMove` handler receives the point being hovered, the index of the time series and the index of the point in the time series, which allows us to highlight the line and the point, add labels, date markers, tooltips, etc.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/114084/195154148-5173eaa3-bb4c-4c7a-8a3e-6e88566b27d1.png">

