### PR TITLE
Legend threshold improvements 

### DIFF
--- a/.changeset/strong-eagles-end.md
+++ b/.changeset/strong-eagles-end.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Improvements to LegendThreshold components

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import { LegendThreshold, LegendThresholdProps } from ".";
+import { LegendThreshold } from ".";
+import { LegendThresholdProps } from "./interfaces";
 
 export default {
   title: "Components/LegendThreshold",

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -43,7 +43,6 @@ HorizontalDefault.args = {
   height: horizontalHeight,
   width: horizontalWidth,
   barHeight: horizontalBarHeight,
-  showLabels: true,
   items,
   getItemColor,
   getItemLabel,
@@ -68,7 +67,6 @@ export const HorizontalSquared = Template.bind({});
 HorizontalSquared.args = {
   ...HorizontalDefault.args,
   borderRadius: 0,
-  showLabels: true,
 };
 
 export const VerticalDefault = Template.bind({});

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -19,8 +19,7 @@ const Template: Story<LegendThresholdProps<Item>> = (args) => (
 );
 
 // Horizontal legend threshold props
-const horizontalHeight = 40;
-const horizontalBarHeight = 20;
+const horizontalHeight = 20;
 const horizontalWidth = 300;
 
 const items: Item[] = [
@@ -41,9 +40,8 @@ const getItemSublabel = (item: Item, itemIndex: number) => item.sublabel;
 export const HorizontalDefault = Template.bind({});
 HorizontalDefault.args = {
   orientation: "horizontal",
-  height: horizontalHeight,
   width: horizontalWidth,
-  barHeight: horizontalBarHeight,
+  height: horizontalHeight,
   items,
   getItemColor,
   getItemLabel,
@@ -52,15 +50,15 @@ HorizontalDefault.args = {
 export const HorizontalWithoutLabels = Template.bind({});
 HorizontalWithoutLabels.args = {
   ...HorizontalDefault.args,
-  height: horizontalBarHeight,
+  height: horizontalHeight,
   showLabels: false,
 };
 
 export const HorizontalRounded = Template.bind({});
 HorizontalRounded.args = {
   ...HorizontalDefault.args,
-  height: horizontalBarHeight,
-  borderRadius: horizontalBarHeight / 2,
+  height: horizontalHeight,
+  borderRadius: horizontalHeight / 2,
   showLabels: false,
 };
 

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -1,21 +1,13 @@
 import React from "react";
-import {
-  LegendThresholdHorizontal,
-  LegendThresholdHorizontalProps,
-} from "./LegendThresholdHorizontal";
-import {
-  LegendThresholdVertical,
-  LegendThresholdVerticalProps,
-} from "./LegendThresholdVertical";
-
-export type LegendThresholdProps<T> =
-  | LegendThresholdHorizontalProps<T>
-  | LegendThresholdVerticalProps<T>;
+import { LegendThresholdHorizontal } from "./LegendThresholdHorizontal";
+import { LegendThresholdVertical } from "./LegendThresholdVertical";
+import { LegendThresholdProps } from "./interfaces";
 
 /**
  * `LegendThreshold` represents a scale with thresholds that separate
  * a set of levels. By default, the labels between each level are shown.
  */
+
 export const LegendThreshold = <T,>(props: LegendThresholdProps<T>) => {
   return props.orientation === "horizontal" ? (
     <LegendThresholdHorizontal {...props} />

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -2,29 +2,16 @@ import React from "react";
 import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
 import { TickLabel, TickMark } from "./LegendThreshold.style";
-import { CommonLegendThresholdProps } from "./interfaces";
+import { LegendThresholdHorizontalProps } from "./interfaces";
 import { RectClipGroup } from "../RectClipGroup";
-
-export interface LegendThresholdHorizontalProps<T>
-  extends CommonLegendThresholdProps<T> {
-  /** Orientation of the bars */
-  orientation: "horizontal";
-  /** Width of the component */
-  width?: number;
-  /**
-   * Height of the colored bars. When not adding the bars, make sure that
-   * `barHeight` is set to the same value as `height`.
-   */
-  barHeight?: number;
-}
 
 /**
  * `LegendThresholdHorizontal` represents a scale with thresholds that separate
  * a set of levels. By default, the labels between each level are shown.
  */
+
 export const LegendThresholdHorizontal = <T,>({
-  height = 40,
-  barHeight = 20,
+  height = 20,
   width = 300,
   borderRadius = 10,
   items,
@@ -44,11 +31,15 @@ export const LegendThresholdHorizontal = <T,>({
   const labelTickHeight = 4;
   const tickLabelPadding = 2;
 
+  const heightWithLabels =
+    height + 20; /* An additional 20px accounts for the height of labels */
+  const totalHeight = showLabels ? heightWithLabels : height;
+
   return (
-    <svg width={width} height={height} {...otherSvgProps}>
+    <svg width={width} height={totalHeight} {...otherSvgProps}>
       <RectClipGroup
         width={width}
-        height={showLabels ? barHeight : height}
+        height={height}
         rx={borderRadius}
         ry={borderRadius}
       >
@@ -56,7 +47,7 @@ export const LegendThresholdHorizontal = <T,>({
           <rect
             key={`item-${itemIndex}`}
             x={scaleRect(itemIndex) ?? 0}
-            height={barHeight}
+            height={height}
             width={rectWidth}
             fill={getItemColor(item, itemIndex)}
           />
@@ -68,7 +59,7 @@ export const LegendThresholdHorizontal = <T,>({
           itemIndex !== items.length - 1 && (
             <Group
               key={`item-${itemIndex}`}
-              top={barHeight}
+              top={height}
               left={(scaleRect(itemIndex) ?? 0) + rectWidth}
             >
               <TickMark y1={0} y2={labelTickHeight} />

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
 import { TickLabel, TickMark } from "./LegendThreshold.style";
-import { LegendThresholdHorizontalProps } from "./interfaces";
+import { LegendThresholdProps } from "./interfaces";
 import { RectClipGroup } from "../RectClipGroup";
 
 /**
@@ -19,11 +19,8 @@ export const LegendThresholdHorizontal = <T,>({
   getItemLabel,
   showLabels = true,
   ...otherSvgProps
-}: LegendThresholdHorizontalProps<T> &
-  Omit<
-    React.SVGProps<SVGSVGElement>,
-    keyof LegendThresholdHorizontalProps<T>
-  >) => {
+}: LegendThresholdProps<T> &
+  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
   const indexList = items.map((item, itemIndex) => itemIndex);
   const scaleRect = scaleBand({ domain: indexList, range: [0, width] });
   const rectWidth = scaleRect.bandwidth();

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CommonLegendThresholdProps } from "./interfaces";
+import { LegendThresholdVerticalProps } from "./interfaces";
 import {
   LegendThresholdVerticalWrapper,
   LegendContainer,
@@ -8,23 +8,13 @@ import {
 } from "./LegendThreshold.style";
 import { Typography } from "@mui/material";
 
-export interface LegendThresholdVerticalProps<T>
-  extends CommonLegendThresholdProps<T> {
-  /** Orientation of the bars */
-  orientation: "vertical";
-  /** Width of the bars (12 by default) */
-  barWidth?: number;
-  /** Secondary labels for each item */
-  getItemSublabel?: (item: T, itemIndex: number) => string;
-}
-
 /**
  * `LegendThresholdVertical` represents a scale with thresholds that separate
  * a set of levels. By default, the labels between each level are shown.
  */
 export const LegendThresholdVertical = <T,>({
   height = 265,
-  barWidth = 12,
+  width = 12,
   borderRadius = 6,
   showLabels = true,
   items,
@@ -42,7 +32,7 @@ export const LegendThresholdVertical = <T,>({
         <LegendContainer key={itemIndex} style={{ height: legendColorHeight }}>
           <LegendColor
             style={{
-              width: barWidth,
+              width,
               backgroundColor: getItemColor(item, itemIndex),
             }}
             roundTop={itemIndex === 0 ? borderRadius : 0}

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LegendThresholdVerticalProps } from "./interfaces";
+import { LegendThresholdProps } from "./interfaces";
 import {
   LegendThresholdVerticalWrapper,
   LegendContainer,
@@ -21,7 +21,7 @@ export const LegendThresholdVertical = <T,>({
   getItemColor,
   getItemLabel,
   getItemSublabel,
-}: LegendThresholdVerticalProps<T>) => {
+}: LegendThresholdProps<T>) => {
   const numberOfItems = items.length;
   const legendColorHeight = height / numberOfItems;
   // Reverse the order of the items so that the lowest levels are rendered at the bottom.

--- a/packages/ui-components/src/components/LegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/LegendThreshold/interfaces.ts
@@ -1,6 +1,8 @@
 interface CommonLegendThresholdProps<T> {
   /** Height of the thermometer */
   height?: number;
+  /** Width of the thermometer */
+  width?: number;
   /** Border radius of the thermometer bar */
   borderRadius?: number;
   /** List of items representing the labels */
@@ -19,16 +21,12 @@ interface LegendThresholdHorizontalProps<T>
   extends CommonLegendThresholdProps<T> {
   /** Orientation of the bars */
   orientation: "horizontal";
-  /** Width of the thermometer */
-  width?: number;
 }
 
 interface LegendThresholdVerticalProps<T>
   extends CommonLegendThresholdProps<T> {
   /** Orientation of the bars */
   orientation: "vertical";
-  /** Width of the thermometer */
-  width?: number;
   /** Function that returns the item's secondary label */
   getItemSublabel?: (item: T, itemIndex: number) => string;
 }

--- a/packages/ui-components/src/components/LegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/LegendThreshold/interfaces.ts
@@ -1,16 +1,38 @@
-export interface CommonLegendThresholdProps<T> {
-  /** Height of the component, including the colored bars and labels. */
+interface CommonLegendThresholdProps<T> {
+  /** Height of the thermometer */
   height?: number;
-  /** Border radius of the colored bars */
+  /** Border radius of the thermometer bar */
   borderRadius?: number;
   /** List of items representing the labels */
   items: T[];
-  /** Function that returns the color of each level */
+  /** Function that returns the color of each item */
   getItemColor: (item: T, itemIndex: number) => string;
-  /**
-   * Whether to show the labels or not (true by default). Make sure to set
-   * `barHeight` to `height` when not including the labels.
-   */
+  /** Whether to show the labels or not */
   showLabels?: boolean;
+  /** Function that returns the label of each item */
   getItemLabel?: (item: T, itemIndex: number) => string;
 }
+
+// TODO (chelsi) - can you have showLabels without getItemLabel?
+
+interface LegendThresholdHorizontalProps<T>
+  extends CommonLegendThresholdProps<T> {
+  /** Orientation of the bars */
+  orientation: "horizontal";
+  /** Width of the thermometer */
+  width?: number;
+}
+
+interface LegendThresholdVerticalProps<T>
+  extends CommonLegendThresholdProps<T> {
+  /** Orientation of the bars */
+  orientation: "vertical";
+  /** Width of the thermometer */
+  width?: number;
+  /** Function that returns the item's secondary label */
+  getItemSublabel?: (item: T, itemIndex: number) => string;
+}
+
+export type LegendThresholdProps<T> =
+  | LegendThresholdHorizontalProps<T>
+  | LegendThresholdVerticalProps<T>;

--- a/packages/ui-components/src/components/LegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/LegendThreshold/interfaces.ts
@@ -1,4 +1,6 @@
-interface CommonLegendThresholdProps<T> {
+export interface LegendThresholdProps<T> {
+  /** Orientation of the bars */
+  orientation: "horizontal" | "vertical";
   /** Height of the thermometer */
   height?: number;
   /** Width of the thermometer */
@@ -13,24 +15,8 @@ interface CommonLegendThresholdProps<T> {
   showLabels?: boolean;
   /** Function that returns the label of each item */
   getItemLabel?: (item: T, itemIndex: number) => string;
-}
-
-// TODO (chelsi) - can you have showLabels without getItemLabel?
-
-interface LegendThresholdHorizontalProps<T>
-  extends CommonLegendThresholdProps<T> {
-  /** Orientation of the bars */
-  orientation: "horizontal";
-}
-
-interface LegendThresholdVerticalProps<T>
-  extends CommonLegendThresholdProps<T> {
-  /** Orientation of the bars */
-  orientation: "vertical";
-  /** Function that returns the item's secondary label */
+  /** Function that returns the sublabel of each item */
   getItemSublabel?: (item: T, itemIndex: number) => string;
 }
 
-export type LegendThresholdProps<T> =
-  | LegendThresholdHorizontalProps<T>
-  | LegendThresholdVerticalProps<T>;
+// TODO (chelsi) - can you have showLabels without getItemLabel?

--- a/packages/ui-components/src/components/LegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/LegendThreshold/interfaces.ts
@@ -18,5 +18,3 @@ export interface LegendThresholdProps<T> {
   /** Function that returns the sublabel of each item */
   getItemSublabel?: (item: T, itemIndex: number) => string;
 }
-
-// TODO (chelsi) - can you have showLabels without getItemLabel?

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -25,7 +25,7 @@ export const HorizontalDefault = Template.bind({});
 HorizontalDefault.args = {
   orientation: "horizontal",
   width: horizontalWidth,
-  barHeight: horizontalBarHeight,
+  height: horizontalBarHeight,
   metric: MetricId.MOCK_CASES,
 };
 

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -30,7 +30,6 @@ HorizontalDefault.args = {
   height: horizontalHeight,
   width: horizontalWidth,
   barHeight: horizontalBarHeight,
-  showLabels: true,
   metric: MetricId.MOCK_CASES,
 };
 
@@ -46,8 +45,8 @@ HorizontalOnlySideLabels.args = {
   ...HorizontalDefault.args,
   height: horizontalBarHeight,
   showLabels: false,
-  startLabel: <Typography>lower</Typography>,
-  endLabel: <Typography>higher</Typography>,
+  startLabel: <Typography variant="paragraphSmall">lower</Typography>,
+  endLabel: <Typography variant="paragraphSmall">higher</Typography>,
 };
 
 export const HorizontalRounded = Template.bind({});
@@ -62,7 +61,6 @@ export const HorizontalSquared = Template.bind({});
 HorizontalSquared.args = {
   ...HorizontalDefault.args,
   borderRadius: 0,
-  showLabels: true,
 };
 
 export const VerticalDefault = Template.bind({});

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -2,10 +2,8 @@ import React from "react";
 import { Typography, Paper } from "@mui/material";
 import { ComponentMeta } from "@storybook/react";
 import { MetricId } from "../../stories/mockMetricCatalog";
-import {
-  MetricLegendThreshold,
-  MetricLegendThresholdProps,
-} from "./MetricLegendThreshold";
+import { MetricLegendThreshold } from "./MetricLegendThreshold";
+import { MetricLegendThresholdProps } from "./interfaces";
 import { Story } from "@storybook/react";
 
 export default {
@@ -20,23 +18,20 @@ const Template: Story<MetricLegendThresholdProps> = (args) => (
 );
 
 // Horizontal legend threshold props
-const horizontalHeight = 40;
 const horizontalBarHeight = 20;
 const horizontalWidth = 300;
 
 export const HorizontalDefault = Template.bind({});
 HorizontalDefault.args = {
   orientation: "horizontal",
-  height: horizontalHeight,
   width: horizontalWidth,
   barHeight: horizontalBarHeight,
   metric: MetricId.MOCK_CASES,
 };
 
-export const HorizontalWithoutLabels = Template.bind({});
-HorizontalWithoutLabels.args = {
+export const HorizontalNoLabels = Template.bind({});
+HorizontalNoLabels.args = {
   ...HorizontalDefault.args,
-  height: horizontalBarHeight,
   showLabels: false,
 };
 
@@ -49,18 +44,19 @@ HorizontalOnlySideLabels.args = {
   endLabel: <Typography variant="paragraphSmall">higher</Typography>,
 };
 
-export const HorizontalRounded = Template.bind({});
-HorizontalRounded.args = {
+export const HorizontalRoundedNoLabels = Template.bind({});
+HorizontalRoundedNoLabels.args = {
   ...HorizontalDefault.args,
   height: horizontalBarHeight,
   borderRadius: horizontalBarHeight / 2,
   showLabels: false,
 };
 
-export const HorizontalSquared = Template.bind({});
-HorizontalSquared.args = {
+export const HorizontalSquaredNoLabels = Template.bind({});
+HorizontalSquaredNoLabels.args = {
   ...HorizontalDefault.args,
   borderRadius: 0,
+  showLabels: false,
 };
 
 export const VerticalDefault = Template.bind({});

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -4,69 +4,12 @@ import { Metric } from "@actnowcoalition/metrics";
 import { assert } from "@actnowcoalition/assert";
 import { LegendThreshold } from "../LegendThreshold";
 import { useMetricCatalog } from "../MetricCatalogContext";
-
-interface LevelItem {
-  /** Level name (e.g. "High") */
-  name: string;
-  /** Level color */
-  color: string;
-  /** Description of the level */
-  description: string | undefined;
-  /** Formatted value of the threshold at the end of the current level */
-  endThreshold?: string;
-}
+import { LevelItem, MetricLegendThresholdProps } from "./interfaces";
 
 const getItemColor = (item: LevelItem) => item.color;
 const getItemLabelHorizontal = (item: LevelItem) => item.endThreshold ?? "";
 const getItemLabelVertical = (item: LevelItem) => item.name;
 const getItemSublabel = (item: LevelItem) => item.description ?? "";
-
-interface CommonMetricLegendThresholdProps {
-  /** Metric to display thresholds for. */
-  metric: Metric | string;
-  /** Whether to show level labels. Does not affect start/endLabels */
-  showLabels?: boolean;
-  /** Optional label for the left or top side of the thermometer. */
-  startLabel?: React.ReactNode;
-  /** Optional label for the right or bottom side of the thermometer. */
-  endLabel?: React.ReactNode;
-  /** Whether or not to display metric name and info. If false, only thermometer is displayed. */
-  includeOverview?: boolean;
-  /** Height of the component, including the colored bars and labels. */
-  height?: number;
-  /** Border radius of the bars */
-  borderRadius?: number;
-  /** Optional other props. */
-  otherSvgProps?: Omit<
-    React.SVGProps<SVGSVGElement>,
-    keyof MetricLegendThresholdVerticalProps
-  >;
-}
-
-export interface MetricLegendThresholdHorizontalProps
-  extends CommonMetricLegendThresholdProps {
-  /** Orientation of the bars. */
-  orientation: "horizontal";
-  /** Width of the component. */
-  width?: number;
-  /**
-   * Height of the bars. When not adding the labels, make sure that
-   * `barHeight` is set to the same value as `height`.
-   */
-  barHeight?: number;
-}
-
-export interface MetricLegendThresholdVerticalProps
-  extends CommonMetricLegendThresholdProps {
-  /** Orientation of the bars. */
-  orientation: "vertical";
-  /** Width of the bars. */
-  barWidth?: number;
-}
-
-export type MetricLegendThresholdProps =
-  | MetricLegendThresholdHorizontalProps
-  | MetricLegendThresholdVerticalProps;
 
 export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
   metric,

--- a/packages/ui-components/src/components/MetricLegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/MetricLegendThreshold/interfaces.ts
@@ -1,0 +1,56 @@
+import { Metric } from "@actnowcoalition/metrics";
+
+export interface LevelItem {
+  /** Level name (e.g. "High") */
+  name: string;
+  /** Level color */
+  color: string;
+  /** Description of the level */
+  description: string | undefined;
+  /** Formatted value of the threshold at the end of the current level */
+  endThreshold?: string;
+}
+
+interface CommonMetricLegendThresholdProps {
+  /** Metric to display thresholds for. */
+  metric: Metric | string;
+  /** Whether to show level labels. Does not affect start/endLabels */
+  showLabels?: boolean;
+  /** Optional label for the left or top side of the thermometer. */
+  startLabel?: React.ReactNode;
+  /** Optional label for the right or bottom side of the thermometer. */
+  endLabel?: React.ReactNode;
+  /** Whether or not to display metric name and info. If false, only thermometer is displayed. */
+  includeOverview?: boolean;
+  /** Border radius of the bars */
+  borderRadius?: number;
+  /** Optional other props. */
+  otherSvgProps?: Omit<
+    React.SVGProps<SVGSVGElement>,
+    keyof MetricLegendThresholdVerticalProps
+  >;
+}
+
+interface MetricLegendThresholdHorizontalProps
+  extends CommonMetricLegendThresholdProps {
+  /** Orientation of the bars. */
+  orientation: "horizontal";
+  /** Width of the component. */
+  width?: number;
+  /** Height of the bars. */
+  height?: number;
+}
+
+interface MetricLegendThresholdVerticalProps
+  extends CommonMetricLegendThresholdProps {
+  /** Orientation of the bars. */
+  orientation: "vertical";
+  /** Width of the bars. */
+  width?: number;
+  /** Height of the bars. */
+  height?: number;
+}
+
+export type MetricLegendThresholdProps =
+  | MetricLegendThresholdHorizontalProps
+  | MetricLegendThresholdVerticalProps;

--- a/packages/ui-components/src/components/MetricLegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/MetricLegendThreshold/interfaces.ts
@@ -1,6 +1,8 @@
 import { Metric } from "@actnowcoalition/metrics";
 
-interface CommonMetricLegendThresholdProps {
+export interface MetricLegendThresholdProps {
+  /** Orientation of the bars. */
+  orientation: "horizontal" | "vertical";
   /** Metric to display thresholds for. */
   metric: Metric | string;
   /** Whether to show level labels. Does not affect start/endLabels */
@@ -20,25 +22,9 @@ interface CommonMetricLegendThresholdProps {
   /** Optional other props. */
   otherSvgProps?: Omit<
     React.SVGProps<SVGSVGElement>,
-    keyof MetricLegendThresholdVerticalProps
+    keyof MetricLegendThresholdProps
   >;
 }
-
-interface MetricLegendThresholdHorizontalProps
-  extends CommonMetricLegendThresholdProps {
-  /** Orientation of the bars. */
-  orientation: "horizontal";
-}
-
-interface MetricLegendThresholdVerticalProps
-  extends CommonMetricLegendThresholdProps {
-  /** Orientation of the bars. */
-  orientation: "vertical";
-}
-
-export type MetricLegendThresholdProps =
-  | MetricLegendThresholdHorizontalProps
-  | MetricLegendThresholdVerticalProps;
 
 export interface LevelItem {
   /** Level name (e.g. "High") */

--- a/packages/ui-components/src/components/MetricLegendThreshold/interfaces.ts
+++ b/packages/ui-components/src/components/MetricLegendThreshold/interfaces.ts
@@ -1,16 +1,5 @@
 import { Metric } from "@actnowcoalition/metrics";
 
-export interface LevelItem {
-  /** Level name (e.g. "High") */
-  name: string;
-  /** Level color */
-  color: string;
-  /** Description of the level */
-  description: string | undefined;
-  /** Formatted value of the threshold at the end of the current level */
-  endThreshold?: string;
-}
-
 interface CommonMetricLegendThresholdProps {
   /** Metric to display thresholds for. */
   metric: Metric | string;
@@ -24,6 +13,10 @@ interface CommonMetricLegendThresholdProps {
   includeOverview?: boolean;
   /** Border radius of the bars */
   borderRadius?: number;
+  /** Width of the bars */
+  width?: number;
+  /** Height of the bars */
+  height?: number;
   /** Optional other props. */
   otherSvgProps?: Omit<
     React.SVGProps<SVGSVGElement>,
@@ -35,22 +28,25 @@ interface MetricLegendThresholdHorizontalProps
   extends CommonMetricLegendThresholdProps {
   /** Orientation of the bars. */
   orientation: "horizontal";
-  /** Width of the component. */
-  width?: number;
-  /** Height of the bars. */
-  height?: number;
 }
 
 interface MetricLegendThresholdVerticalProps
   extends CommonMetricLegendThresholdProps {
   /** Orientation of the bars. */
   orientation: "vertical";
-  /** Width of the bars. */
-  width?: number;
-  /** Height of the bars. */
-  height?: number;
 }
 
 export type MetricLegendThresholdProps =
   | MetricLegendThresholdHorizontalProps
   | MetricLegendThresholdVerticalProps;
+
+export interface LevelItem {
+  /** Level name (e.g. "High") */
+  name: string;
+  /** Level color */
+  color: string;
+  /** Description of the level */
+  description: string | undefined;
+  /** Formatted value of the threshold at the end of the current level */
+  endThreshold?: string;
+}

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
@@ -35,7 +35,7 @@ export const MetricScoreOverview: React.FC<MetricScoreOverviewProps> = ({
       includeOverview={false}
       height={72}
       borderRadius={6}
-      barWidth={12}
+      width={12}
     />
   );
   const metricValue = <MetricValue region={region} metric={resolvedMetric} />;


### PR DESCRIPTION
Fixes #255 

Having `barHeight` and `height` props was making it difficult to have sane default UI on all variations (with labels, without labels). This streamlines the horizontal legend's height by getting rid of the `barHeight` prop and just using `height`, adding an extra 20px of height to the horizontal legend when labels render (labels rendering below the horizontal legend shouldn't be longer than short numeric value, a percentage, etc. so 20px should suffice).

This PR also consolidates the props for `LegendThreshold` and `MetricLegendThreshold`. The props overlap enough that we don't need a `common` version, a `vertical` version, and a `horizontal` version for legend props, especially now that we've gotten rid of the `barHeight` prop, and all legends now just take an optional `height` and `width` (with sane defaults)