### PR TITLE
Create story for select dropdown (with multiple inputs)

### DIFF
--- a/.changeset/new-birds-drum.md
+++ b/.changeset/new-birds-drum.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Style select multiple component

--- a/packages/ui-components/src/stories/SelectMultiple.stories.tsx
+++ b/packages/ui-components/src/stories/SelectMultiple.stories.tsx
@@ -7,7 +7,6 @@ import {
   TextFieldProps,
   Typography,
 } from "@mui/material";
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 export default {
   title: "Design System/SelectMultiple",
@@ -31,6 +30,12 @@ const textFieldProps: TextFieldProps = {
   fullWidth: true,
   label: <Typography variant="paragraphSmall">Locations</Typography>,
   InputLabelProps: { shrink: true },
+  sx: {
+    "& .MuiFilledInput-root": {
+      paddingTop: 3,
+      paddingBottom: 1,
+    },
+  },
 };
 
 export const ShortMultiSelect = () => {
@@ -38,7 +43,6 @@ export const ShortMultiSelect = () => {
     <Box width={320}>
       <Autocomplete
         multiple
-        popupIcon={<KeyboardArrowDownIcon />}
         options={cities.map((option) => option.name)}
         defaultValue={[cities[0].name]}
         renderTags={(location, getTagProps) =>
@@ -68,7 +72,6 @@ export const LongMultiSelect = () => {
     <Box width={600}>
       <Autocomplete
         multiple
-        popupIcon={<KeyboardArrowDownIcon />}
         options={cities.map((option) =>
           option.name.concat(", ", option.country)
         )}

--- a/packages/ui-components/src/stories/SelectMultiple.stories.tsx
+++ b/packages/ui-components/src/stories/SelectMultiple.stories.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Box, TextField, TextFieldProps, Typography } from "@mui/material";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import Chip from "@mui/material/Chip";
+import Autocomplete from "@mui/material/Autocomplete";
+
+export default {
+  title: "Design System/SelectMultiple",
+};
+
+const cities = [
+  { name: "Beijing", country: "China" },
+  { name: "Tokyo", country: "Japan" },
+  { name: "Kinshasa", country: "DR Congo" },
+  { name: "Moscow", country: "Russia" },
+  { name: "Jakarta", country: "Indonesia" },
+  { name: "Cairo", country: "Egypt" },
+  { name: "Seoul", country: "South Korea" },
+  { name: "Mexico City", country: "Mexico" },
+  { name: "London", country: "United Kingdom" },
+  { name: "Dhaka", country: "Bangladesh" },
+];
+
+const textFieldProps: TextFieldProps = {
+  variant: "filled",
+  fullWidth: true,
+  label: <Typography variant="paragraphSmall">Locations</Typography>,
+  InputLabelProps: { shrink: true },
+};
+
+export const ShortMultiSelect = () => {
+  return (
+    <Box width={320}>
+      <Autocomplete
+        multiple
+        popupIcon={<KeyboardArrowDownIcon />}
+        options={cities.map((option) => option.name)}
+        defaultValue={[cities[0].name]}
+        renderTags={(location, getTagProps) =>
+          location.map((locationName, index) => (
+            <Chip
+              {...getTagProps({ index })}
+              key={locationName}
+              variant="outlined"
+              label={locationName}
+            />
+          ))
+        }
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            {...textFieldProps}
+            InputProps={{ ...params.InputProps, disableUnderline: true }}
+          />
+        )}
+      />
+    </Box>
+  );
+};
+
+export const LongMultiSelect = () => {
+  return (
+    <Box width={600}>
+      <Autocomplete
+        multiple
+        popupIcon={<KeyboardArrowDownIcon />}
+        options={cities.map((option) =>
+          option.name.concat(", ", option.country)
+        )}
+        defaultValue={[cities[0].name.concat(", ", cities[0].country)]}
+        renderTags={(location, getTagProps) =>
+          location.map((locationName, index) => (
+            <Chip
+              {...getTagProps({ index })}
+              key={locationName}
+              variant="outlined"
+              label={locationName}
+            />
+          ))
+        }
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            {...textFieldProps}
+            InputProps={{ ...params.InputProps, disableUnderline: true }}
+          />
+        )}
+      />
+    </Box>
+  );
+};

--- a/packages/ui-components/src/stories/SelectMultiple.stories.tsx
+++ b/packages/ui-components/src/stories/SelectMultiple.stories.tsx
@@ -1,8 +1,13 @@
 import React from "react";
-import { Box, TextField, TextFieldProps, Typography } from "@mui/material";
+import {
+  Autocomplete,
+  Box,
+  Chip,
+  TextField,
+  TextFieldProps,
+  Typography,
+} from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
-import Chip from "@mui/material/Chip";
-import Autocomplete from "@mui/material/Autocomplete";
 
 export default {
   title: "Design System/SelectMultiple",

--- a/packages/ui-components/src/styles/theme/components.ts
+++ b/packages/ui-components/src/styles/theme/components.ts
@@ -5,6 +5,20 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 const referenceTheme = createTheme();
 
 const components: ThemeOptions["components"] = {
+  MuiAutocomplete: {
+    defaultProps: {
+      filterSelectedOptions: true,
+      disableClearable: true,
+    },
+    styleOverrides: {
+      root: ({ theme }) => ({
+        "& .MuiFilledInput-root": {
+          paddingTop: theme.spacing(3),
+          paddingBottom: theme.spacing(1),
+        },
+      }),
+    },
+  },
   MuiTextField: {
     defaultProps: {
       SelectProps: {

--- a/packages/ui-components/src/styles/theme/components.tsx
+++ b/packages/ui-components/src/styles/theme/components.tsx
@@ -1,4 +1,5 @@
 /** MUI theme components */
+import React from "react";
 import { ThemeOptions, createTheme } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
@@ -9,14 +10,7 @@ const components: ThemeOptions["components"] = {
     defaultProps: {
       filterSelectedOptions: true,
       disableClearable: true,
-    },
-    styleOverrides: {
-      root: ({ theme }) => ({
-        "& .MuiFilledInput-root": {
-          paddingTop: theme.spacing(3),
-          paddingBottom: theme.spacing(1),
-        },
-      }),
+      popupIcon: <KeyboardArrowDownIcon />,
     },
   },
 


### PR DESCRIPTION
Evolved from https://github.com/covid-projections/act-now-packages/pull/279. Just renaming the branch since we're no longer necessarily doing style overrides.

This PR creates a MUI autocomplete component to match the multi-select component in our [mocks](https://www.figma.com/file/YN7x6bJmSfRHaovP5ABKu2/ActNow-Design-System?node-id=41%3A1555).

![image](https://user-images.githubusercontent.com/46338131/195220726-77da5dec-bbdd-4f68-bb24-f0e8fe0983b2.png)
