### PR TITLE
Implement `AutoWidth` component

### DIFF
--- a/.changeset/spicy-owls-count.md
+++ b/.changeset/spicy-owls-count.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Implement AutoWidth component

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { Grid } from "@mui/material";
+import { states } from "@actnowcoalition/regions";
+import { ComponentMeta } from "@storybook/react";
+import { MetricId } from "../../stories/mockMetricCatalog";
+import { MetricSparklines } from "../MetricSparklines";
+import { AutoWidth } from ".";
+
+export default {
+  title: "Components/AutoWidth",
+  component: AutoWidth,
+} as ComponentMeta<typeof AutoWidth>;
+
+const Chart = ({ width, color }: { width?: number; color: string }) => (
+  <div
+    style={{
+      width,
+      height: 60,
+      backgroundColor: color,
+      display: "grid",
+      placeItems: "center",
+    }}
+  >
+    <div>{`width = ${width}px`}</div>
+  </div>
+);
+
+export const DefaultExample = () => (
+  <div style={{ width: 450, border: "solid 1px black" }}>
+    <AutoWidth>
+      <Chart color="#fff9c4" />
+    </AutoWidth>
+  </div>
+);
+
+export const ExampleSized = () => (
+  <div style={{ width: 450, border: "solid 1px black" }}>
+    <AutoWidth>
+      <Chart color="#fff9c4" width={120} />
+    </AutoWidth>
+  </div>
+);
+
+export const ExampleGrid = () => (
+  <Grid container spacing={2}>
+    <Grid item xs={4}></Grid>
+    <Grid item xs={4}></Grid>
+    <Grid item xs>
+      <AutoWidth>
+        <Chart color="#ffecb3" />
+      </AutoWidth>
+    </Grid>
+  </Grid>
+);
+
+const region = states.findByRegionIdStrict("12");
+
+export const ExampleSparklines = () => (
+  <Grid container spacing={2}>
+    <Grid item xs={4}>
+      <AutoWidth>
+        <MetricSparklines
+          height={90}
+          region={region}
+          metricBarChart={MetricId.MOCK_CASES}
+          metricLineChart={MetricId.MOCK_CASES}
+          numDays={30}
+        />
+      </AutoWidth>
+    </Grid>
+    <Grid item xs={4}>
+      <AutoWidth>
+        <MetricSparklines
+          height={90}
+          region={region}
+          metricBarChart={MetricId.MOCK_CASES}
+          metricLineChart={MetricId.MOCK_CASES}
+          numDays={30}
+        />
+      </AutoWidth>
+    </Grid>
+    <Grid item xs>
+      <AutoWidth>
+        <MetricSparklines
+          height={90}
+          region={region}
+          metricBarChart={MetricId.MOCK_CASES}
+          metricLineChart={MetricId.MOCK_CASES}
+          numDays={30}
+        />
+      </AutoWidth>
+    </Grid>
+  </Grid>
+);

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
@@ -1,11 +1,11 @@
 import React from "react";
+import { ComponentMeta } from "@storybook/react";
 import { Grid, Box, colors } from "@mui/material";
 import { states } from "@actnowcoalition/regions";
-import { ComponentMeta } from "@storybook/react";
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricSparklines } from "../MetricSparklines";
-import { AutoWidth } from ".";
 import { styled } from "../../styles";
+import { AutoWidth } from ".";
 
 export default {
   title: "Components/AutoWidth",
@@ -59,7 +59,7 @@ export const StaticWidth = () => (
  * This case just shows that AutoWidth will preserve the width of the child
  * component, if we explicitly pass it.
  */
-export const ExampleSizedChild = () => (
+export const SizedChild = () => (
   <StyledDiv>
     <AutoWidth>
       <MockChart color={chartColor} width={120} />
@@ -72,7 +72,7 @@ export const ExampleSizedChild = () => (
  * the chart. The AutoWidth component measures the width of the last Grid item
  * element and passes the value to the Chart component.
  */
-export const ExampleGrid = () => (
+export const UsingGrid = () => (
   <Grid container spacing={2}>
     <StyledGridItem item xs={4} />
     <StyledGridItem item xs={4} />
@@ -89,7 +89,7 @@ const region = states.findByRegionIdStrict("12");
 /**
  * Using a real chart this time, we create a Grid with 4 columns.
  */
-export const ExampleSparklines = () => (
+export const Sparklines = () => (
   <Grid container spacing={2}>
     {[1, 2, 3, 4].map((n) => (
       <StyledGridItem item xs={3} key={`grid-item-${n}`}>

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
@@ -1,94 +1,108 @@
 import React from "react";
-import { Grid } from "@mui/material";
+import { Grid, Box, colors } from "@mui/material";
 import { states } from "@actnowcoalition/regions";
 import { ComponentMeta } from "@storybook/react";
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricSparklines } from "../MetricSparklines";
 import { AutoWidth } from ".";
+import { styled } from "../../styles";
 
 export default {
   title: "Components/AutoWidth",
   component: AutoWidth,
 } as ComponentMeta<typeof AutoWidth>;
 
-const Chart = ({ width, color }: { width?: number; color: string }) => (
-  <div
-    style={{
-      width,
-      height: 60,
-      backgroundColor: color,
-      display: "grid",
-      placeItems: "center",
-    }}
-  >
+const height = 60;
+const chartColor = colors.purple[100];
+const borderColor = colors.blue[700];
+
+const StyledGridItem = styled(Grid)`
+  border: dashed 1px ${borderColor};
+`;
+
+const StyledDiv = styled("div")`
+  border: dashed 1px ${borderColor};
+  width: 450px;
+`;
+
+const StyledBox = styled(Box)`
+  display: grid;
+  place-items: center;
+  border: solid 1px ${colors.purple[300]};
+`;
+
+/**
+ * The AutoWidth component can be used to wrap any child elements that have
+ * an optional width property. In this case, we use a mock chart component
+ * just to demonstrate the concept and to show the width value.
+ */
+const MockChart = ({ width, color }: { width?: number; color: string }) => (
+  <StyledBox sx={{ width, height, backgroundColor: color }}>
     <div>{`width = ${width}px`}</div>
-  </div>
+  </StyledBox>
 );
 
-export const DefaultExample = () => (
-  <div style={{ width: 450, border: "solid 1px black" }}>
+/**
+ * A somewhat contrived example. If we do know the width of the parent
+ * component, we would just use it instead of wrapping the `Chart` inside
+ * `AutoWidth`.
+ */
+export const StaticWidth = () => (
+  <StyledDiv>
     <AutoWidth>
-      <Chart color="#fff9c4" />
+      <MockChart color={chartColor} />
     </AutoWidth>
-  </div>
+  </StyledDiv>
 );
 
-export const ExampleSized = () => (
-  <div style={{ width: 450, border: "solid 1px black" }}>
+/**
+ * This case just shows that AutoWidth will preserve the width of the child
+ * component, if we explicitly pass it.
+ */
+export const ExampleSizedChild = () => (
+  <StyledDiv>
     <AutoWidth>
-      <Chart color="#fff9c4" width={120} />
+      <MockChart color={chartColor} width={120} />
     </AutoWidth>
-  </div>
+  </StyledDiv>
 );
 
+/**
+ * When using grid, we don't know the width of each box, but we need it for
+ * the chart. The AutoWidth component measures the width of the last Grid item
+ * element and passes the value to the Chart component.
+ */
 export const ExampleGrid = () => (
   <Grid container spacing={2}>
-    <Grid item xs={4}></Grid>
-    <Grid item xs={4}></Grid>
-    <Grid item xs>
+    <StyledGridItem item xs={4} />
+    <StyledGridItem item xs={4} />
+    <StyledGridItem item xs={4}>
       <AutoWidth>
-        <Chart color="#ffecb3" />
+        <MockChart color={chartColor} />
       </AutoWidth>
-    </Grid>
+    </StyledGridItem>
   </Grid>
 );
 
 const region = states.findByRegionIdStrict("12");
 
+/**
+ * Using a real chart this time, we create a Grid with 4 columns.
+ */
 export const ExampleSparklines = () => (
   <Grid container spacing={2}>
-    <Grid item xs={4}>
-      <AutoWidth>
-        <MetricSparklines
-          height={90}
-          region={region}
-          metricBarChart={MetricId.MOCK_CASES}
-          metricLineChart={MetricId.MOCK_CASES}
-          numDays={30}
-        />
-      </AutoWidth>
-    </Grid>
-    <Grid item xs={4}>
-      <AutoWidth>
-        <MetricSparklines
-          height={90}
-          region={region}
-          metricBarChart={MetricId.MOCK_CASES}
-          metricLineChart={MetricId.MOCK_CASES}
-          numDays={30}
-        />
-      </AutoWidth>
-    </Grid>
-    <Grid item xs>
-      <AutoWidth>
-        <MetricSparklines
-          height={90}
-          region={region}
-          metricBarChart={MetricId.MOCK_CASES}
-          metricLineChart={MetricId.MOCK_CASES}
-          numDays={30}
-        />
-      </AutoWidth>
-    </Grid>
+    {[1, 2, 3, 4].map((n) => (
+      <StyledGridItem item xs={3} key={`grid-item-${n}`}>
+        <AutoWidth>
+          <MetricSparklines
+            height={height}
+            region={region}
+            metricBarChart={MetricId.MOCK_CASES}
+            metricLineChart={MetricId.MOCK_CASES}
+            numDays={30}
+          />
+        </AutoWidth>
+      </StyledGridItem>
+    ))}
   </Grid>
 );

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.style.ts
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.style.ts
@@ -1,3 +1,0 @@
-import { styled } from "../../styles";
-
-export const Container = styled("div")``;

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.style.ts
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.style.ts
@@ -1,0 +1,3 @@
+import { styled } from "../../styles";
+
+export const Container = styled("div")``;

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
@@ -1,6 +1,10 @@
 import React from "react";
+import isNumber from "lodash/isNumber";
 import { ParentSize } from "@visx/responsive";
 
+// TODO (Pablo): The intent here is to ensure that the children elements
+// have an optional, numeric `width` prop, but the validation doesn't
+// seem to be working.
 export interface AutoWidthProps {
   /** A single child element that receives an optional `width` prop. */
   children: React.ReactElement<{ width?: number }>;
@@ -15,12 +19,17 @@ export interface AutoWidthProps {
  * parent has been fully measured (width > 0) to prevent from rendering
  * the component too early.
  */
-export const AutoWidth = ({ children }: AutoWidthProps) => (
-  <ParentSize>
-    {({ width: parentWidth }) => {
-      const child = React.Children.only(children);
-      const width = child.props.width ?? parentWidth;
-      return width > 0 ? React.cloneElement(child, { width }) : null;
-    }}
-  </ParentSize>
-);
+export const AutoWidth = ({ children }: AutoWidthProps) => {
+  const child = React.Children.only(children);
+
+  // We return the child if it already has a numeric `width` prop.
+  if (isNumber(child.props.width)) {
+    return child;
+  }
+
+  return (
+    <ParentSize>
+      {({ width }) => (width > 0 ? React.cloneElement(child, { width }) : null)}
+    </ParentSize>
+  );
+};

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
@@ -15,7 +15,7 @@ export interface AutoWidthProps {
  * parent has been fully measured (width > 0) to prevent from rendering
  * the component too early.
  */
-export const AutoWidth: React.FC<AutoWidthProps> = ({ children }) => (
+export const AutoWidth = ({ children }: AutoWidthProps) => (
   <ParentSize>
     {({ width: parentWidth }) => {
       const child = React.Children.only(children);

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ParentSize } from "@visx/responsive";
+
+export interface AutoWidthProps {
+  /** A single child element that receives an optional `width` prop. */
+  children: React.ReactElement<{ width?: number }>;
+}
+
+/**
+ * The `AutoWidth` is a helper component that measures the width of the
+ * parent component and passes it down to the children element.
+ *
+ * If the child element already has a `width` property, the passed property
+ * will be preserved. The child component will only be rendered once the
+ * parent has been fully measured (width > 0) to prevent from rendering
+ * the component too early.
+ */
+export const AutoWidth: React.FC<AutoWidthProps> = ({ children }) => (
+  <ParentSize>
+    {({ width: parentWidth }) => {
+      const child = React.Children.only(children);
+      const width = child.props.width ?? parentWidth;
+      return width > 0 ? React.cloneElement(child, { width }) : null;
+    }}
+  </ParentSize>
+);

--- a/packages/ui-components/src/components/AutoWidth/index.ts
+++ b/packages/ui-components/src/components/AutoWidth/index.ts
@@ -1,0 +1,1 @@
+export * from "./AutoWidth";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -76,10 +76,12 @@ declare module "@mui/material/styles" {
 export * from "./common/hooks";
 
 /** UI Components and props */
+export * from "./components/AutoWidth";
 export * from "./components/Axes";
 export * from "./components/Axis";
 export * from "./components/BarChart";
 export * from "./components/ChartOverlayX";
+export * from "./components/ChartOverlayXY";
 export * from "./components/CompareTable";
 export * from "./components/Grid";
 export * from "./components/InfoTooltip";
@@ -106,5 +108,3 @@ export * from "./components/RectClipGroup";
 export * from "./components/RegionSearch";
 export * from "./components/ShareButton";
 export * from "./components/SparkLine";
-
-export * from "./components/ChartOverlayXY";


### PR DESCRIPTION
Implements a component that measures the width of its container and passes the width prop down to its children. This can be used to make charts adapt to the width of their containers more easily.

```tsx
<div style={{ width: 450, border: "solid 1px black" }}>
  <AutoWidth>
    <Chart color="#fff9c4" />
  </AutoWidth>
</div>
```

<img width="468" alt="image" src="https://user-images.githubusercontent.com/114084/195221756-a080378e-af4a-4d55-a024-32562449c069.png">
