### PR TITLE
Improvements to MultiProgressBar (and metric-aware version)

### DIFF
--- a/.changeset/quiet-pandas-film.md
+++ b/.changeset/quiet-pandas-film.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Improvements to multi progress bar

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -1,27 +1,23 @@
 import React from "react";
 import { Region } from "@actnowcoalition/regions";
-import { Metric } from "@actnowcoalition/metrics";
+import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
 import {
   MultiProgressBar,
   BaseMultiProgressBarProps,
 } from "../MultiProgressBar";
 import { useDataForMetrics } from "../../common/hooks";
 
+type MetricProp = Metric | string;
+
 export interface MetricMultiProgressBarProps extends BaseMultiProgressBarProps {
   /* Region for which to chart */
   region: Region;
-  /* Metrics of which the progress bar will chart current values */
-  metrics: (Metric | string)[];
-  /* All props below - MultiProgressBar props to pass down */
-  width?: number;
-  height?: number;
-  bgColor?: string;
-  borderRadius?: number;
+  /* Metrics (2) of which the progress bar will chart current values */
+  metrics: [MetricProp, MetricProp];
 }
 
 interface MetricProgressBarItem {
   currentValue: number;
-  color: string;
   label: string;
 }
 
@@ -36,24 +32,26 @@ export const MetricMultiProgressBar = ({
     return null;
   }
 
-  const progressBarItems: MetricProgressBarItem[] = metrics.map(
-    (metric: Metric | string) => {
-      const metricData = data.metricData(metric);
-      return {
-        color: metricData.getColor(),
-        currentValue: metricData.currentValue as number, // improve this
-        label: metricData.formatValue(),
-      };
-    }
-  );
+  const [firstMetric, secondMetric] = metrics;
 
   return (
     <MultiProgressBar
-      items={progressBarItems}
+      firstItem={getItemFromMetricData(data, firstMetric)}
+      secondItem={getItemFromMetricData(data, secondMetric)}
       getItemValue={(item) => item.currentValue}
-      getItemColor={(item) => item.color}
       getItemLabel={(item) => item.label}
       {...otherProgressBarProps}
     />
   );
 };
+
+function getItemFromMetricData(
+  data: MultiMetricDataStore,
+  metric: Metric | string
+): MetricProgressBarItem {
+  const metricData = data.metricData(metric);
+  return {
+    currentValue: metricData.currentValue as number, // improve this
+    label: metricData.formatValue(),
+  };
+}

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -47,7 +47,7 @@ export const MetricMultiProgressBar = ({
 
 function getItemFromMetricData(
   data: MultiMetricDataStore,
-  metric: Metric | string
+  metric: MetricProp
 ): MetricProgressBarItem {
   const metricData = data.metricData(metric);
   return {

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -32,12 +32,11 @@ export const MetricMultiProgressBar = ({
     return null;
   }
 
-  const [firstMetric, secondMetric] = metrics;
+  const [firstItem, secondItem] = getProgressBarItems(data, metrics);
 
   return (
     <MultiProgressBar
-      firstItem={getItemFromMetricData(data, firstMetric)}
-      secondItem={getItemFromMetricData(data, secondMetric)}
+      items={[firstItem, secondItem]}
       getItemValue={(item) => item.currentValue}
       getItemLabel={(item) => item.label}
       {...otherProgressBarProps}
@@ -45,13 +44,14 @@ export const MetricMultiProgressBar = ({
   );
 };
 
-function getItemFromMetricData(
+function getProgressBarItems(
   data: MultiMetricDataStore,
-  metric: MetricProp
-): MetricProgressBarItem {
-  const metricData = data.metricData(metric);
-  return {
-    currentValue: metricData.currentValue as number, // improve this
-    label: metricData.formatValue(),
-  };
+  metrics: [MetricProp, MetricProp]
+): [MetricProgressBarItem, MetricProgressBarItem] {
+  const items = metrics.map((metric) => ({
+    currentValue: data.metricData(metric).currentValue as number,
+    label: data.metricData(metric).formatValue(),
+  }));
+
+  return [items[0], items[1]];
 }

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
@@ -45,14 +45,12 @@ const Template: Story<MultiProgressBarProps<Item>> = (args) => (
 
 export const DefaultColors = Template.bind({});
 DefaultColors.args = {
-  firstItem,
-  secondItem,
+  items: [firstItem, secondItem],
 };
 
 export const CustomColors = Template.bind({});
 CustomColors.args = {
-  firstItem,
-  secondItem,
+  items: [firstItem, secondItem],
   barColor: "#ff0303",
   bgColor: "#7d13bf",
 };

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
@@ -14,38 +14,17 @@ interface Item {
   value: number;
 }
 
-const sampleItems1 = [
-  {
-    color: "#5936B6",
-    label: "Label 1",
-    value: 0.4,
-  },
-];
+const firstItem = {
+  color: "#B292F9",
+  label: "Label 1",
+  value: 0.6,
+};
 
-const sampleItems2 = [
-  {
-    color: "#B292F9",
-    label: "Label 1",
-    value: 0.6,
-  },
-  {
-    color: "#5936B6",
-    label: "Label 2",
-    value: 0.4,
-  },
-];
-
-const sampleItems3 = [
-  {
-    color: "#5936B6",
-    label: "Label 1",
-    value: 0.01,
-  },
-];
-
-function getItemColor(item: Item): string {
-  return item.color;
-}
+const secondItem = {
+  color: "#5936B6",
+  label: "Label 2",
+  value: 0.4,
+};
 
 function getItemLabel(item: Item): string {
   return item.label;
@@ -58,24 +37,22 @@ function getItemValue(item: Item): number {
 const Template: Story<MultiProgressBarProps<Item>> = (args) => (
   <MultiProgressBar
     {...args}
-    getItemColor={getItemColor}
     getItemLabel={getItemLabel}
     getItemValue={getItemValue}
     maxValue={1}
   />
 );
 
-export const SingleItem = Template.bind({});
-SingleItem.args = {
-  items: sampleItems1,
+export const DefaultColors = Template.bind({});
+DefaultColors.args = {
+  firstItem,
+  secondItem,
 };
 
-export const TwoItems = Template.bind({});
-TwoItems.args = {
-  items: sampleItems2,
-};
-
-export const SmallItem = Template.bind({});
-SmallItem.args = {
-  items: sampleItems3,
+export const CustomColors = Template.bind({});
+CustomColors.args = {
+  firstItem,
+  secondItem,
+  barColor: "#ff0303",
+  bgColor: "#7d13bf",
 };

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
@@ -6,8 +6,7 @@ import { scaleLinear } from "@visx/scale";
 import { MultiProgressBarProps } from "./interfaces";
 
 export const MultiProgressBar = <T,>({
-  firstItem,
-  secondItem,
+  items,
   getItemValue,
   getItemLabel,
   maxValue,
@@ -32,7 +31,7 @@ export const MultiProgressBar = <T,>({
    * in the correct order in the progress bar.
    * */
   const [sortedFirstItem, sortedSecondItem] = sortBy(
-    [firstItem, secondItem],
+    items,
     (item) => getItemValue(item) * -1
   );
 

--- a/packages/ui-components/src/components/MultiProgressBar/interfaces.ts
+++ b/packages/ui-components/src/components/MultiProgressBar/interfaces.ts
@@ -1,6 +1,8 @@
 export interface BaseMultiProgressBarProps {
   maxValue: number;
+  /** Color of charted bars */
   barColor?: string;
+  /** Background color of progress bar */
   bgColor?: string;
   width?: number;
   height?: number;

--- a/packages/ui-components/src/components/MultiProgressBar/interfaces.ts
+++ b/packages/ui-components/src/components/MultiProgressBar/interfaces.ts
@@ -10,8 +10,7 @@ export interface BaseMultiProgressBarProps {
 }
 
 export interface MultiProgressBarProps<T> extends BaseMultiProgressBarProps {
-  firstItem: T;
-  secondItem: T;
+  items: [T, T];
   getItemLabel: (item: T) => string;
   getItemValue: (item: T) => number;
 }

--- a/packages/ui-components/src/components/MultiProgressBar/interfaces.ts
+++ b/packages/ui-components/src/components/MultiProgressBar/interfaces.ts
@@ -1,14 +1,15 @@
 export interface BaseMultiProgressBarProps {
   maxValue: number;
+  barColor?: string;
+  bgColor?: string;
   width?: number;
   height?: number;
-  bgColor?: string;
   borderRadius?: number;
 }
 
 export interface MultiProgressBarProps<T> extends BaseMultiProgressBarProps {
-  items: T[];
-  getItemColor: (item: T) => string;
+  firstItem: T;
+  secondItem: T;
   getItemLabel: (item: T) => string;
   getItemValue: (item: T) => number;
 }

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -7,13 +7,13 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-0.1.0.tgz#fa83caa21c419f20d7be7c10dafd70986613e6a0"
   integrity sha512-8dBa6CHFDuY/jAVtazVCDSl9796gaOLmsdMFX+uGBwQruEWpCq2jOkf/wvLypt9eoE+Dzi63Q5zbOIVXmlQRtQ==
 
-"@actnowcoalition/metrics@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.2.3.tgz#a56f529363543b2d65fe020bc7d59a75631694c2"
-  integrity sha512-TSwqn0aMFNLrmdqTMdGlf4MaCj5mfx3BBWX9Fq4eS4lA5bbT8YJVVDjX/WSl61VZNxXXYLUIJ21YXyxgJUUuIA==
+"@actnowcoalition/metrics@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.2.4.tgz#b65e506769bee33d64aac1593d705b6386f23291"
+  integrity sha512-h125oR5MLAv4kmN/qglxHdiZVxD40wKwCGz8Dft4Fb2DV4l9mBHnuHsCXjGq7U5QziiGZggADW4ZlC+v0Jc9sg==
   dependencies:
     "@actnowcoalition/assert" "^0.1.0"
-    "@actnowcoalition/number-format" "^0.1.0"
+    "@actnowcoalition/number-format" "^0.1.1"
     "@actnowcoalition/regions" "^0.1.1"
     "@actnowcoalition/time-utils" "^0.1.0"
     "@types/papaparse" "^5.3.3"
@@ -21,10 +21,10 @@
     node-fetch "^2.6.7"
     papaparse "^5.3.2"
 
-"@actnowcoalition/number-format@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/number-format/-/number-format-0.1.0.tgz#0d6bf419c6e9f5622fe8cde7940f68ea0fdb5320"
-  integrity sha512-BTdtEEqgV0zRk6sj2E/XU5j7tSiR/cE0sOVmISGW9pz58WNLVcFraIUH5XSArfzh7WLnWlsh5N+rJDgUoVsG/A==
+"@actnowcoalition/number-format@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/number-format/-/number-format-0.1.1.tgz#d80e6fc9d0223f7500af390e4812fbdecc966d8e"
+  integrity sha512-NgArNpGeHAE5uil+MEkkKjsCGfXi2sPosRkIDF6lodVjTzWzq1e+7yAw9VD7pmi2qPgJxPw25TrOH/UTuNHIkw==
 
 "@actnowcoalition/regions@^0.1.1":
   version "0.1.1"


### PR DESCRIPTION
[Default colors](https://act-now-packages--pr296-casulin-metric-multi-219p9pan.web.app/storybook/index.html?path=/story/charts-multiprogressbar--default-colors)
[Custom colors](https://act-now-packages--pr296-casulin-metric-multi-219p9pan.web.app/storybook/index.html?path=/story/charts-multiprogressbar--custom-colors)

- Simplifies `MultiProgressBar` to take only 2 items (`firstItem` and `secondItem`) instead of an array of any amount of items. This way, we could render one bar as solid and one bar as patterned/hatched.
- Adds a `barColor` prop that dictates the color of the progress bar's solid and hatched `rect`s (the coloring shouldn't be tied to the color associated with the metric/value/threshold)

Fixes #257 