### PR TITLE
Update the min-width of MuiTooltip

### DIFF
--- a/.changeset/ninety-cows-fix.md
+++ b/.changeset/ninety-cows-fix.md
@@ -2,4 +2,4 @@
 "@actnowcoalition/ui-components": patch
 ---
 
-Set the minimum width of tooltips to 180px
+Set the minimum width of tooltips to 200px

--- a/.changeset/ninety-cows-fix.md
+++ b/.changeset/ninety-cows-fix.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Set the minimum width of tooltips to 180px

--- a/packages/ui-components/src/styles/theme/components.tsx
+++ b/packages/ui-components/src/styles/theme/components.tsx
@@ -167,6 +167,7 @@ const components: ThemeOptions["components"] = {
   MuiTooltip: {
     styleOverrides: {
       tooltip: ({ theme }) => ({
+        minWidth: 200,
         backgroundColor: "black",
         color: "white",
         fontSize: theme.typography.paragraphLarge.fontSize,


### PR DESCRIPTION
Close #284  - This makes the tooltips keep their width when their content changes (at least in most cases).