### PR TITLE
MetricLegendThreshold now support metrics with categories

### DIFF
--- a/.changeset/purple-trees-judge.md
+++ b/.changeset/purple-trees-judge.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+MetricLegendThreshold now supports metrics with categories

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -58,6 +58,12 @@ VerticalDefault.args = {
   metric: MetricId.MOCK_CASES,
 };
 
+export const VerticalCategories = Template.bind({});
+VerticalCategories.args = {
+  orientation: "vertical",
+  metric: MetricId.PASS_FAIL,
+};
+
 export const VerticalNoLabel = Template.bind({});
 VerticalNoLabel.args = {
   showLabels: false,

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -44,31 +44,18 @@ HorizontalOnlySideLabels.args = {
   endLabel: <Typography variant="paragraphSmall">higher</Typography>,
 };
 
-export const HorizontalRoundedNoLabels = Template.bind({});
-HorizontalRoundedNoLabels.args = {
-  ...HorizontalDefault.args,
+export const HorizontalCategories = Template.bind({});
+HorizontalCategories.args = {
+  orientation: "horizontal",
+  width: horizontalWidth,
   height: horizontalBarHeight,
-  borderRadius: horizontalBarHeight / 2,
-  showLabels: false,
-};
-
-export const HorizontalSquaredNoLabels = Template.bind({});
-HorizontalSquaredNoLabels.args = {
-  ...HorizontalDefault.args,
-  borderRadius: 0,
-  showLabels: false,
+  metric: MetricId.PASS_FAIL,
 };
 
 export const VerticalDefault = Template.bind({});
 VerticalDefault.args = {
   orientation: "vertical",
   metric: MetricId.MOCK_CASES,
-};
-
-export const VerticalRounded = Template.bind({});
-VerticalRounded.args = {
-  borderRadius: 8,
-  ...VerticalDefault.args,
 };
 
 export const VerticalNoLabel = Template.bind({});

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { Stack, Typography } from "@mui/material";
-import { Metric } from "@actnowcoalition/metrics";
-import { assert } from "@actnowcoalition/assert";
 import { LegendThreshold } from "../LegendThreshold";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { LevelItem, MetricLegendThresholdProps } from "./interfaces";
+import { getMetricLevelItems } from "./utils";
 
 const getItemColor = (item: LevelItem) => item.color;
 const getItemLabelHorizontal = (item: LevelItem) => item.endThreshold ?? "";
@@ -21,7 +20,7 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
   const metricCatalog = useMetricCatalog();
   metric = metricCatalog.getMetric(metric);
 
-  const items = getLevelItems(metric);
+  const items = getMetricLevelItems(metric);
 
   // Common props regardless of horizontal / vertical orientation
   const commonProps = { items, getItemColor, ...legendThresholdProps };
@@ -33,7 +32,7 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
   if (legendThresholdProps.orientation === "horizontal") {
     return (
       <Stack spacing={2} alignItems="center">
-        <Stack spacing={0.5}>
+        <Stack spacing={0.5} alignItems="center">
           <Typography variant="labelLarge">{metric.name}</Typography>
           <Typography variant="paragraphSmall">
             {metric.extendedName}
@@ -72,21 +71,3 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
     );
   }
 };
-
-function getLevelItems(metric: Metric): LevelItem[] {
-  const metricLevels = metric.levelSet?.levels;
-  const metricThresholds = metric.thresholds;
-  assert(
-    metricLevels,
-    "Metric must have levels and thresholds to use MetricLegendThreshold." +
-      `No levels found for metric ${metric}.`
-  );
-  return metricLevels.map((level, levelIndex) => ({
-    name: level.name ?? level.id,
-    color: level.color,
-    description: level.description,
-    endThreshold: metricThresholds
-      ? metric.formatValue(metricThresholds[levelIndex])
-      : undefined,
-  }));
-}

--- a/packages/ui-components/src/components/MetricLegendThreshold/utils.test.ts
+++ b/packages/ui-components/src/components/MetricLegendThreshold/utils.test.ts
@@ -1,0 +1,24 @@
+import { getMetricLevelItems } from "./utils";
+import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
+
+describe("MetricLegendThreshold", () => {
+  describe("getMetricLevelItems", () => {
+    test("returns expected levels for metrics with thresholds", () => {
+      const metricThresholds = metricCatalog.getMetric(MetricId.MOCK_CASES);
+      const legendLevels = getMetricLevelItems(metricThresholds);
+
+      expect(legendLevels).toHaveLength(3);
+      expect(legendLevels.map((d) => d.color)).toHaveLength(3);
+      expect(legendLevels.map((d) => d.name)).toHaveLength(3);
+    });
+
+    test("returns expected levels for metrics with categories", () => {
+      const metricCategories = metricCatalog.getMetric(MetricId.PASS_FAIL);
+      const legendLevels = getMetricLevelItems(metricCategories);
+
+      expect(legendLevels).toHaveLength(2);
+      expect(legendLevels.map((d) => d.color)).toHaveLength(2);
+      expect(legendLevels.map((d) => d.name)).toHaveLength(2);
+    });
+  });
+});

--- a/packages/ui-components/src/components/MetricLegendThreshold/utils.ts
+++ b/packages/ui-components/src/components/MetricLegendThreshold/utils.ts
@@ -1,0 +1,34 @@
+import { assert } from "@actnowcoalition/assert";
+import { Metric } from "@actnowcoalition/metrics";
+import { LevelItem } from "./interfaces";
+
+export function getMetricLevelItems(metric: Metric): LevelItem[] {
+  const metricLevels = metric.levelSet?.levels;
+  const metricCategories = metric.categories;
+
+  assert(
+    metricCategories || metricLevels,
+    `The metric needs to have either levels or categories`
+  );
+
+  if (metricCategories) {
+    return metric.categories.map((category) => ({
+      name: category.label,
+      color: category.color,
+      description: "",
+      endThreshold: undefined,
+    }));
+  }
+
+  assert(metricLevels, `The metric needs to have a defined levelSet`);
+
+  const metricThresholds = metric.thresholds;
+  return metricLevels.map((level, levelIndex) => ({
+    name: level.name ?? level.id,
+    color: level.color,
+    description: level.description,
+    endThreshold: metricThresholds
+      ? metric.formatValue(metricThresholds[levelIndex])
+      : undefined,
+  }));
+}

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -92,7 +92,7 @@ export const metricCatalog = new MetricCatalog(testMetricDefs, dataProviders, {
 });
 
 // Exporting a second metric catalog to confirm that the closest
-// MetricCatalocProvider instance is used
+// MetricCatalogProvider instance is used
 const metricDefsB: MetricDefinition[] = [
   {
     id: MetricId.PI,


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/300 - Update `MetricLegendThreshold` to support metrics with categories. I also fixed the alignment of the title and description on the horizontal case (it should be centered)

**Horizontal**

<img width="519" alt="image" src="https://user-images.githubusercontent.com/114084/195726025-e5e803cd-0882-49b6-aebb-1ed01aae7ff3.png">

**Vertical**

![image](https://user-images.githubusercontent.com/114084/195726468-b60b759b-43cb-4a18-9245-4f278607f089.png)
