### PR TITLE
Allow ripple in tabs

### DIFF
--- a/.changeset/quick-cherries-clean.md
+++ b/.changeset/quick-cherries-clean.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Allow ripple in tabs

--- a/.changeset/quick-cherries-clean.md
+++ b/.changeset/quick-cherries-clean.md
@@ -1,5 +1,0 @@
----
-"@actnowcoalition/ui-components": patch
----
-
-Allow ripple in tabs

--- a/packages/ui-components/src/stories/Tabs.stories.tsx
+++ b/packages/ui-components/src/stories/Tabs.stories.tsx
@@ -36,9 +36,9 @@ export const MultiTabsWithIndicator = () => {
   };
   return (
     <Tabs value={value} onChange={handleChange}>
-      <Tab value={1} label={<TabContent />} disableRipple />
-      <Tab value={2} label={<TabContent />} disableRipple />
-      <Tab value={3} label={<TabContent />} disableRipple />
+      <Tab value={1} label={<TabContent />} />
+      <Tab value={2} label={<TabContent />} />
+      <Tab value={3} label={<TabContent />} />
     </Tabs>
   );
 };


### PR DESCRIPTION
Disabling ripple made it challenging for users to tell which tab they're focusing on, particularly if they're not navigating with a mouse. This PR re-enables ripple, which highlights the tab the user focuses on.

Closes https://github.com/covid-projections/act-now-packages/issues/298