### PR TITLE
MetricScoreOverview style improvements

### DIFF
--- a/.changeset/great-crabs-sort.md
+++ b/.changeset/great-crabs-sort.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Cleanup for MetricScoreOverview and LegendThreshold

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.style.ts
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.style.ts
@@ -16,14 +16,6 @@ export const TickMark = styled("line")`
   stroke: ${({ theme }) => theme.palette.border.default};
 `;
 
-export const LegendThresholdVerticalWrapper = styled("div")`
-  width: fit-content;
-`;
-
-export const LegendContainer = styled("div")`
-  display: flex;
-`;
-
 const getTopRadius = ($roundTop: number) => css`
   border-top-left-radius: ${$roundTop}px;
   border-top-right-radius: ${$roundTop}px;
@@ -40,11 +32,4 @@ export const LegendColor = styled("div", { shouldForwardProp: isValidProp })<{
 }>`
   ${(props) => getTopRadius(props.roundTop)}
   ${(props) => getBottomRadius(props.roundBottom)}
-`;
-
-export const LegendLabelContainer = styled("div")`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  white-space: nowrap;
 `;

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.style.ts
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.style.ts
@@ -38,7 +38,6 @@ export const LegendColor = styled("div", { shouldForwardProp: isValidProp })<{
   roundTop: number;
   roundBottom: number;
 }>`
-  margin-right: ${(props) => props.theme.spacing(2)};
   ${(props) => getTopRadius(props.roundTop)}
   ${(props) => getBottomRadius(props.roundBottom)}
 `;

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { LegendThresholdProps } from "./interfaces";
-import {
-  LegendThresholdVerticalWrapper,
-  LegendContainer,
-  LegendColor,
-  LegendLabelContainer,
-} from "./LegendThreshold.style";
-import { Typography } from "@mui/material";
+import { LegendColor } from "./LegendThreshold.style";
+import { Typography, Box, Stack } from "@mui/material";
 
 /**
  * `LegendThresholdVertical` represents a scale with thresholds that separate
@@ -27,9 +22,9 @@ export const LegendThresholdVertical = <T,>({
   // Reverse the order of the items so that the lowest levels are rendered at the bottom.
   const orderedItems = items.slice().reverse();
   return (
-    <LegendThresholdVerticalWrapper>
+    <Box width="fit-content">
       {orderedItems.map((item, itemIndex) => (
-        <LegendContainer key={itemIndex} style={{ height: legendColorHeight }}>
+        <Box key={itemIndex} height={legendColorHeight} display="flex">
           <LegendColor
             style={{
               width,
@@ -39,7 +34,7 @@ export const LegendThresholdVertical = <T,>({
             roundBottom={itemIndex === numberOfItems - 1 ? borderRadius : 0}
           />
           {showLabels && (
-            <LegendLabelContainer>
+            <Stack ml={2} spacing={0.25} justifyContent="center">
               {getItemLabel && (
                 <>
                   <Typography variant="labelSmall">
@@ -52,10 +47,10 @@ export const LegendThresholdVertical = <T,>({
                   )}
                 </>
               )}
-            </LegendLabelContainer>
+            </Stack>
           )}
-        </LegendContainer>
+        </Box>
       ))}
-    </LegendThresholdVerticalWrapper>
+    </Box>
   );
 };

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
@@ -27,43 +27,31 @@ export const MetricScoreOverview: React.FC<MetricScoreOverviewProps> = ({
   const metricCatalog = useMetricCatalog();
   const resolvedMetric = metricCatalog.getMetric(metric);
 
-  const metricLegendThreshold = (
-    <MetricLegendThreshold
-      orientation="vertical"
-      metric={resolvedMetric}
-      showLabels={false}
-      includeOverview={false}
-      height={72}
-      borderRadius={6}
-      width={12}
-    />
-  );
-  const metricValue = <MetricValue region={region} metric={resolvedMetric} />;
-
   return (
-    <Stack direction={"column"} spacing={2}>
-      <Stack
-        direction={"row"}
-        spacing={1}
-        alignItems={"center"}
-        {...otherStackProps}
-      >
-        {metricLegendThreshold}
-        <Stack direction={"column"} spacing={1}>
-          <Typography variant="paragraphSmall" color="secondary.light">
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <span>{resolvedMetric.name}</span>
-              {tooltipTitle && (
-                <InfoTooltip title={tooltipTitle}>
-                  <IconButton>
-                    <InfoOutlinedIcon color="inherit" fontSize="small" />
-                  </IconButton>
-                </InfoTooltip>
-              )}
-            </Stack>
+    <Stack direction="row" spacing={2} alignItems="center" {...otherStackProps}>
+      <MetricLegendThreshold
+        orientation="vertical"
+        metric={resolvedMetric}
+        showLabels={false}
+        includeOverview={false}
+        height={72}
+        borderRadius={6}
+        width={12}
+      />
+      <Stack spacing={1}>
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Typography variant="paragraphSmall">
+            {resolvedMetric.name}
           </Typography>
-          {metricValue}
+          {tooltipTitle && (
+            <InfoTooltip title={tooltipTitle}>
+              <IconButton color="inherit" disableRipple={true} sx={{ p: 0 }}>
+                <InfoOutlinedIcon fontSize="small" />
+              </IconButton>
+            </InfoTooltip>
+          )}
         </Stack>
+        <MetricValue region={region} metric={resolvedMetric} />
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
Fixes styling of `MetricScoreOverview` component to closer match the mocks and cleans up the code a bit

[MetricScoreOverview in storybook](https://act-now-packages--pr308-casulin-metric-score-d198ztez.web.app/storybook/index.html?path=/story/metrics-metricscoreoverview--default)
[MetricScoreOverview in Figma](https://www.figma.com/file/YN7x6bJmSfRHaovP5ABKu2/ActNow-Design-System?node-id=13%3A948)

[MetricLegendThreshold (vertical) in storybook](https://act-now-packages--pr308-casulin-metric-score-d198ztez.web.app/storybook/index.html?path=/story/metrics-metriclegendthreshold--vertical-default)
[LegendThreshold (vertical) in storybook](https://act-now-packages--pr308-casulin-metric-score-d198ztez.web.app/storybook/index.html?path=/story/components-legendthreshold--vertical-default)