### PR TITLE
Updates the MetricLineThresholdChart to show all the levels

### DIFF
--- a/.changeset/eight-lizards-warn.md
+++ b/.changeset/eight-lizards-warn.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+The `MetricLineThresholdChart` now shows all the levels

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { Group } from "@visx/group";
+import max from "lodash/max";
 
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
@@ -59,16 +60,6 @@ export const MetricLineThresholdChart = ({
 
   const { minDate, maxDate, maxValue } = timeseries;
 
-  const dateScale = scaleTime({
-    domain: [minDate, maxDate],
-    range: [0, chartWidth],
-  });
-
-  const yScale = scaleLinear({
-    domain: [0, maxValue],
-    range: [chartHeight, 0],
-  });
-
   const thresholds = metric.categoryThresholds;
   const categories = metric.categorySet?.categories;
   assert(
@@ -82,6 +73,18 @@ export const MetricLineThresholdChart = ({
     /*minValue=*/ 0,
     maxValue
   );
+
+  const dateScale = scaleTime({
+    domain: [minDate, maxDate],
+    range: [0, chartWidth],
+  });
+
+  const maxChartValue = max(intervals.map(({ upper }) => upper)) ?? maxValue;
+
+  const yScale = scaleLinear({
+    domain: [0, maxChartValue],
+    range: [chartHeight, 0],
+  });
 
   return (
     <svg width={width} height={height}>

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.test.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.test.ts
@@ -42,6 +42,7 @@ describe("calculateChartIntervals", () => {
     test("T1 < minValue < T2 < maxValue", () => {
       const intervals = calculateChartIntervals(categories, [10, 20], 15, 25);
       expect(intervals).toEqual([
+        { lower: 8, upper: 10, category: LOW },
         { lower: 10, upper: 20, category: MEDIUM },
         { lower: 20, upper: 25, category: HIGH },
       ]);
@@ -52,12 +53,17 @@ describe("calculateChartIntervals", () => {
       expect(intervals).toEqual([
         { lower: 5, upper: 10, category: LOW },
         { lower: 10, upper: 20, category: MEDIUM },
+        { lower: 20, upper: 22, category: HIGH },
       ]);
     });
 
     test("T1 < minValue < maxValue < T2", () => {
       const intervals = calculateChartIntervals(categories, [10, 20], 14, 18);
-      expect(intervals).toEqual([{ lower: 10, upper: 20, category: MEDIUM }]);
+      expect(intervals).toEqual([
+        { lower: 8, upper: 10, category: LOW },
+        { lower: 10, upper: 20, category: MEDIUM },
+        { lower: 20, upper: 22, category: HIGH },
+      ]);
     });
   });
 
@@ -77,12 +83,14 @@ describe("calculateChartIntervals", () => {
       expect(intervals).toEqual([
         { lower: 20, upper: 25, category: LOW },
         { lower: 10, upper: 20, category: MEDIUM },
+        { lower: 8, upper: 10, category: HIGH },
       ]);
     });
 
     test("minValue < T1 < maxValue < T2 ", () => {
       const intervals = calculateChartIntervals(categories, [20, 10], 5, 15);
       expect(intervals).toEqual([
+        { lower: 20, upper: 22, category: LOW },
         { lower: 10, upper: 20, category: MEDIUM },
         { lower: 5, upper: 10, category: HIGH },
       ]);
@@ -90,7 +98,11 @@ describe("calculateChartIntervals", () => {
 
     test("T1 < minValue < maxValue < T2 ", () => {
       const intervals = calculateChartIntervals(categories, [20, 10], 14, 18);
-      expect(intervals).toEqual([{ lower: 10, upper: 20, category: MEDIUM }]);
+      expect(intervals).toEqual([
+        { lower: 20, upper: 22, category: LOW },
+        { lower: 10, upper: 20, category: MEDIUM },
+        { lower: 8, upper: 10, category: HIGH },
+      ]);
     });
   });
 });

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.test.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.test.ts
@@ -19,12 +19,18 @@ describe("calculateChartIntervals", () => {
 
     test("minValue < maxValue < T", () => {
       const intervals = calculateChartIntervals(categories, [10], 0, 5);
-      expect(intervals).toEqual([{ lower: 0, upper: 10, category: LOW }]);
+      expect(intervals).toEqual([
+        { lower: 0, upper: 10, category: LOW },
+        { lower: 10, upper: 11, category: HIGH },
+      ]);
     });
 
     test("T < minValue < maxValue", () => {
       const intervals = calculateChartIntervals(categories, [10], 15, 25);
-      expect(intervals).toEqual([{ lower: 10, upper: 25, category: HIGH }]);
+      expect(intervals).toEqual([
+        { lower: 8, upper: 10, category: LOW },
+        { lower: 10, upper: 25, category: HIGH },
+      ]);
     });
   });
 

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -86,6 +86,7 @@ export function calculateChartIntervals(
 
   const firstThreshold = thresholds[0];
   const lastThreshold = thresholds[thresholds.length - 1];
+  const delta = 0.2 * (lastThreshold - firstThreshold);
 
   // Build the intervals in the same order as the categories, and then
   // filter out the intervals that are not relevant for the chart.
@@ -96,10 +97,10 @@ export function calculateChartIntervals(
       return {
         category,
         lower: isFirstCategory
-          ? Math.min(minVal, firstThreshold)
+          ? Math.min(minVal, firstThreshold - delta)
           : thresholds[categoryIndex - 1],
         upper: isLastCategory
-          ? Math.max(maxVal, lastThreshold)
+          ? Math.max(maxVal, lastThreshold + delta)
           : thresholds[categoryIndex],
       };
     })

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -12,44 +12,38 @@ export interface ChartInterval {
 
 /**
  * Given a set of metric categories, thresholds and a minValue, maxValue for
- * a metric, it returns a set of closed intervals that include minValue
- * and maxValue. These intervals are used in the chart to paint different
- * line segments according to their category.
+ * a metric, it returns a list of intervals that contain the thresholds and
+ * both minValue and maxValue. Examples:
  *
- * @example
- * ```ts
- * calculateChartIntervals(
- *   [LOW, MEDIUM, HIGH],
- *   [10, 20],
- *   5,  // minValue
- *   25  // maxValue
- * );
  *
- * [
- *   { lowerBound:  5, upperBound: 10, category: LOW },
- *   { lowerBound: 10, upperBound: 20, category: MEDIUM },
- *   { lowerBound: 20, upperBound: 60, category: HIGH },
- * ]
- * ```
+ *         minValue      T1                      T2        maxValue
+ *    --------|---------|-----------------------|------------|--------
  *
- * Note that categories that don't intersect with the interval [minValue, maxValue]
- * won't be returned, since we won't need them in the chart.
+ * In this case, we will have the following intervals:
  *
- * @example
- * ```ts
- * calculateChartIntervals(
- *   [LOW, MEDIUM, HIGH],
- *   [10, 20],
- *   5,  // minValue
- *   15  // maxValue
- * );
+ *   [
+ *     { lower: minValue, upper: T1, level: LOW},
+ *     { lower: T1, upper: T2, level: MEDIUM},
+ *     { lower: T2, upper: maxValue, level: HIGH},
+ *   ]
  *
- * // HIGH was filtered out since it's outside [minValue, maxValue]
- * [
- *   { lowerBound:  5, upperBound: 10, category: LOW },
- *   { lowerBound: 10, upperBound: 15, category: MEDIUM },
- * ]
- * ```
+ * In this situation, the first interval should be (-Infinity, T1], which
+ * we can't really use for the chart, so we calculate a padding amount
+ * and use that as the lower bound for the first interval
+ *
+ *                       T1      minValue        T2        maxValue
+ *    ----------*-------|-----------|-----------|------------|--------
+ *           T1 - padding
+ *
+ * In this case, the intervals will be
+ *
+ *   [
+ *     { lower: T1 - padding, upper: T1, level: LOW},
+ *     { lower: T1, upper: T2, level: MEDIUM},
+ *     { lower: T2, upper: maxValue, level: HIGH},
+ *   ]
+ *
+ * We adjust the upper bound of the last interval in the same way if necessary.
  *
  * @param metricCategories List of metric categories.
  * @param thresholds List of thresholds.
@@ -86,25 +80,31 @@ export function calculateChartIntervals(
 
   const firstThreshold = thresholds[0];
   const lastThreshold = thresholds[thresholds.length - 1];
-  const delta = 0.2 * (lastThreshold - firstThreshold);
 
-  // Build the intervals in the same order as the categories, and then
-  // filter out the intervals that are not relevant for the chart.
-  return metricCategories
-    .map((category, categoryIndex) => {
-      const isFirstCategory = categoryIndex === 0;
-      const isLastCategory = categoryIndex === metricCategories.length - 1;
-      return {
-        category,
-        lower: isFirstCategory
-          ? Math.min(minVal, firstThreshold - delta)
-          : thresholds[categoryIndex - 1],
-        upper: isLastCategory
-          ? Math.max(maxVal, lastThreshold + delta)
-          : thresholds[categoryIndex],
-      };
-    })
-    .filter((interval) => interval.lower < interval.upper);
+  // If `minValue` or `maxValue` are inside the thresholds, we calculate
+  // a padding to make sure that all the categories are visible in the
+  // chart. Here, we use 20% of the distance between the first and last
+  // threshold, or if we have only one threshold, we use 20% of the
+  // distance between `minValue` and `maxValue`.
+  const padding =
+    thresholds.length > 1
+      ? 0.2 * (lastThreshold - firstThreshold)
+      : 0.2 * (maxVal - minVal);
+
+  // Build the intervals in the same order as the categories.
+  return metricCategories.map((category, categoryIndex) => {
+    const isFirstCategory = categoryIndex === 0;
+    const isLastCategory = categoryIndex === metricCategories.length - 1;
+    return {
+      category,
+      lower: isFirstCategory
+        ? Math.min(minVal, firstThreshold - padding)
+        : thresholds[categoryIndex - 1],
+      upper: isLastCategory
+        ? Math.max(maxVal, lastThreshold + padding)
+        : thresholds[categoryIndex],
+    };
+  });
 }
 
 // Creates a copy of the input list and reverses its elements

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -81,11 +81,10 @@ export function calculateChartIntervals(
   const firstThreshold = thresholds[0];
   const lastThreshold = thresholds[thresholds.length - 1];
 
-  // If `minValue` or `maxValue` are inside the thresholds, we calculate
-  // a padding to make sure that all the categories are visible in the
-  // chart. Here, we use 20% of the distance between the first and last
-  // threshold, or if we have only one threshold, we use 20% of the
-  // distance between `minValue` and `maxValue`.
+  // Calculate a padding to make sure that each category has room for a label
+  // to be rendered inside the category. Here, we use 20% of the distance
+  // between the first and last threshold, or if we have only one threshold,
+  // we use 20% of the distance between `minValue` and `maxValue`.
   const padding =
     thresholds.length > 1
       ? 0.2 * (lastThreshold - firstThreshold)

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -23,7 +23,7 @@ const testMetricDefs: MetricDefinition[] = [
     dataReference: {
       providerId: "apple_stock",
     },
-    categoryThresholds: [100, 300, 400, 500],
+    categoryThresholds: [100, 200, 400, 800],
     categorySetId: "5_risk_categories",
   },
   {


### PR DESCRIPTION
Previously, the `MetricLineThresholdChart` chart will only show the intervals that intersected with the data. Here, we update how intervals are calculated (and the chart) to make sure that all the _categories_ are visible in the chart.

Note that I added the labels just to illustrate the change, but I don't want to add the labels yet (they are not in the mocks and don't look great, I think we need a better solution).

<img width="587" alt="image" src="https://user-images.githubusercontent.com/114084/197604127-8a4c7ef2-9882-4275-92aa-f9fe7b8166dd.png">

I'm going to update the `calculateChartIntervals` function to take a `metric` on a follow-up PR to keep this one focused on the logic.
