### PR TITLE
Fix the Metric constructor to properly compare categoryThresholds

### DIFF
--- a/.changeset/twenty-shoes-relax.md
+++ b/.changeset/twenty-shoes-relax.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/metrics": patch
+---
+
+Fix a bug that caused correctly sorted thresholds to be incorrectly detected as unsorted

--- a/packages/metrics/src/Metric/Metric.ts
+++ b/packages/metrics/src/Metric/Metric.ts
@@ -123,8 +123,9 @@ export class Metric {
         `${this} defines ${this.categoryThresholds.length} thresholds in categoryThresholds but the referenced ${this.categorySetId} category set has ${this.categorySet.categories.length} categories. There should be 1 fewer thresholds than there are categories. Add or remove thresholds as necessary.`
       );
 
-      // Verify they're sorted.
-      const sorted = this.categoryThresholds.slice().sort();
+      // Verify they're sorted. We need to pass a comparator function to `sort`,
+      // otherwise the values are converted to string before sorting.
+      const sorted = this.categoryThresholds.slice().sort((a, b) => a - b);
       const sortedReverse = sorted.slice().reverse();
       assert(
         isEqual(sorted, this.categoryThresholds) ||


### PR DESCRIPTION
Fixes a small bug on the Metric constructor - In order to determine if the thresholds are sorted, we compare the thresholds to sorted thresholds (both ascending and descending). 

https://github.com/covid-projections/act-now-packages/blob/00a645b7c6e10258464f52af3ed26706b73c389d/packages/metrics/src/Metric/Metric.ts#L126-L133


The problem in the original code is that [`Array.prototype.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) converts numbers to strings before sorting. Passing a comparator function solves the issue. I added more test cases to confirm that it only throws when it should.

