### PR TITLE
Add links to regions in MetricCompareTable

### DIFF
--- a/.changeset/thirty-kiwis-approve.md
+++ b/.changeset/thirty-kiwis-approve.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": minor
+---
+
+Add links to region pages on `MetricCompareTable`

--- a/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
@@ -5,6 +5,8 @@ import {
   TableRow as MuiTableRow,
   TableCell as MuiTableCell,
   tableCellClasses,
+  typographyClasses,
+  linkClasses,
   TableContainer as MuiTableContainer,
 } from "@mui/material";
 import React from "react";
@@ -12,7 +14,10 @@ import { styled } from "../../styles";
 
 export const TableContainer = MuiTableContainer;
 
+// The table needs to have a height to allow us to set height: 100% on children
+// of TableCell.
 export const Table = styled(MuiTable)`
+  height: 100%;
   border-collapse: separate;
 `;
 
@@ -27,6 +32,11 @@ export const TableRow = styled(MuiTableRow)(({ theme }) => ({
   },
   "&:nth-of-type(even)": {
     backgroundColor: theme.palette.common.white,
+  },
+  "&:hover": {
+    [`.${linkClasses.root} .${typographyClasses.root}`]: {
+      color: theme.palette.primary.dark,
+    },
   },
 }));
 

--- a/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
@@ -69,7 +69,7 @@ export const TableCell = styled(MuiTableCell, {
       ...getStickyRowAndColumnProps(stickyRow, stickyColumn),
     },
     [`&.${tableCellClasses.body}`]: {
-      // backgroundColor: "inherit",
+      backgroundColor: "inherit",
       ...getStickyColumnProps(stickyColumn),
     },
   })

--- a/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
@@ -10,15 +10,15 @@ import {
 import React from "react";
 import { styled } from "../../styles";
 
-export const TableContainer = styled(MuiTableContainer)``;
+export const TableContainer = MuiTableContainer;
 
 export const Table = styled(MuiTable)`
   border-collapse: separate;
 `;
 
-export const TableHead = styled(MuiTableHead)``;
+export const TableHead = MuiTableHead;
 
-export const TableBody = styled(MuiTableBody)``;
+export const TableBody = MuiTableBody;
 
 // Alternate white and light grey background for table rows
 export const TableRow = styled(MuiTableRow)(({ theme }) => ({
@@ -59,7 +59,7 @@ export const TableCell = styled(MuiTableCell, {
       ...getStickyRowAndColumnProps(stickyRow, stickyColumn),
     },
     [`&.${tableCellClasses.body}`]: {
-      backgroundColor: "inherit",
+      // backgroundColor: "inherit",
       ...getStickyColumnProps(stickyColumn),
     },
   })

--- a/packages/ui-components/src/components/CompareTable/CompareTable.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.tsx
@@ -36,7 +36,7 @@ export const CompareTable = <R extends CompareTableRowBase>({
       </TableHead>
       <TableBody>
         {sortedRows.map((row, rowIndex) => (
-          <TableRow key={`table-row-${row.rowId}`}>
+          <TableRow key={`table-row-${row.rowId}`} hover>
             {columns.map((column, columnIndex) => (
               <Fragment key={`cell-${row.rowId}-${column.columnId}`}>
                 {column.renderCell({ row, rowIndex, columnIndex })}

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { states } from "@actnowcoalition/regions";
+import { states, Region, RegionDB } from "@actnowcoalition/regions";
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { TableContainer } from "../CompareTable";
 import { MetricCompareTable } from ".";
+
+const regionDB = new RegionDB(states.all, {
+  getRegionUrl: (region: Region) => `/us/${region.slug}`,
+});
 
 export default {
   title: "Metrics/MetricCompareTable",
@@ -18,6 +22,7 @@ const Template: ComponentStory<typeof MetricCompareTable> = (args) => (
 
 export const Example = Template.bind({});
 Example.args = {
-  regions: states.all,
+  regionDB,
+  regions: regionDB.all,
   metrics: [MetricId.PI, MetricId.MOCK_CASES, MetricId.PASS_FAIL],
 };

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
@@ -1,0 +1,18 @@
+import { styled } from "../../styles";
+import { Link as MuiLink } from "@mui/material";
+import { TableCell } from "../CompareTable";
+
+// We remove the padding on the table cells to ensure that the link they
+// contain covers the entire cell.
+export const StyledTableCell = styled(TableCell)`
+  padding: 0;
+`;
+
+export const StyledLink = styled(MuiLink)`
+  display: flex;
+  padding: ${({ theme }) => theme.spacing(2)};
+  text-decoration: none;
+
+  width: 100%;
+  height: 100%;
+`;

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -11,6 +11,7 @@ import { Row, MetricCompareTableProps } from "./interfaces";
 import { createMetricColumn, createLocationColumn } from "./utils";
 
 export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
+  regionDB,
   regions,
   metrics: metricOrIds,
   ...otherCompareTableProps
@@ -45,9 +46,15 @@ export const MetricCompareTable: React.FC<MetricCompareTableProps> = ({
   }));
 
   const columns: ColumnDefinition<Row>[] = [
-    createLocationColumn(sortDirection, sortColumnId, onClickSort),
+    createLocationColumn(regionDB, sortDirection, sortColumnId, onClickSort),
     ...metrics.map((metric) =>
-      createMetricColumn(metric, sortDirection, sortColumnId, onClickSort)
+      createMetricColumn(
+        regionDB,
+        metric,
+        sortDirection,
+        sortColumnId,
+        onClickSort
+      )
     ),
   ];
 

--- a/packages/ui-components/src/components/MetricCompareTable/interfaces.ts
+++ b/packages/ui-components/src/components/MetricCompareTable/interfaces.ts
@@ -1,4 +1,4 @@
-import { Region } from "@actnowcoalition/regions";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
 import { CompareTableProps } from "../CompareTable";
 
@@ -13,6 +13,8 @@ export interface Row {
 
 export interface MetricCompareTableProps
   extends Omit<CompareTableProps<Row>, "rows" | "columns"> {
+  /** Region DB instance to use  */
+  regionDB: RegionDB;
   /** List of regions (first column)  */
   regions: Region[];
   /** List of metrics or metricID - order of the columns will match */

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -1,19 +1,23 @@
 import React from "react";
 import isNumber from "lodash/isNumber";
+import { Stack, Typography } from "@mui/material";
+
 import { Metric } from "@actnowcoalition/metrics";
+import { RegionDB } from "@actnowcoalition/regions";
+
+import { formatPopulation } from "../../common/utils";
 import { MetricValue } from "../MetricValue";
 import {
   ColumnDefinition,
   ColumnHeader,
-  TableCell,
   SortDirection,
   getAriaSort,
 } from "../CompareTable";
+import { StyledTableCell, StyledLink } from "./MetricCompareTable.style";
 import { Row } from "./interfaces";
-import { Stack, Typography } from "@mui/material";
-import { formatPopulation } from "../../common/utils";
 
 export function createMetricColumn(
+  regionDB: RegionDB,
   metric: Metric,
   sortDirection: SortDirection,
   sortColumnId: string,
@@ -39,14 +43,19 @@ export function createMetricColumn(
       );
     },
     renderCell: ({ row }) => (
-      <TableCell>
-        <MetricValue
-          metric={metric}
-          region={row.region}
-          variant="dataTabular"
-          justifyContent="end"
-        />
-      </TableCell>
+      <StyledTableCell>
+        <StyledLink
+          href={regionDB.getRegionUrl(row.region)}
+          sx={{ justifyContent: "end" }}
+        >
+          <MetricValue
+            metric={metric}
+            region={row.region}
+            variant="dataTabular"
+            justifyContent="end"
+          />
+        </StyledLink>
+      </StyledTableCell>
     ),
     sorterAsc: (rowA, rowB) => {
       const { currentValue: valueA } =
@@ -70,6 +79,7 @@ export function createMetricColumn(
 }
 
 export function createLocationColumn(
+  regionDB: RegionDB,
   sortDirection: SortDirection,
   sortColumnId: string,
   onClickSort: (direction: SortDirection, columnId: string) => void
@@ -91,14 +101,16 @@ export function createLocationColumn(
       );
     },
     renderCell: ({ row }) => (
-      <TableCell stickyColumn>
-        <Stack spacing={0.5}>
-          <Typography variant="labelSmall">{row.region.fullName}</Typography>
-          <Typography variant="paragraphSmall">
-            {formatPopulation(row.region.population)}
-          </Typography>
-        </Stack>
-      </TableCell>
+      <StyledTableCell stickyColumn>
+        <StyledLink href={regionDB.getRegionUrl(row.region)}>
+          <Stack spacing={0.5}>
+            <Typography variant="labelSmall">{row.region.fullName}</Typography>
+            <Typography variant="paragraphSmall">
+              {formatPopulation(row.region.population)}
+            </Typography>
+          </Stack>
+        </StyledLink>
+      </StyledTableCell>
     ),
     sorterAsc: (rowA, rowB) =>
       rowA.region.fullName < rowB.region.fullName ? -1 : 1,


### PR DESCRIPTION
Close #277 - Add links to `MetricCompareTable` rows

<img width="617" alt="image" src="https://user-images.githubusercontent.com/114084/197647395-5d46555a-2ce9-49de-88db-152d8f5716ff.png">

## Changes

- Updated the styles to highlight rows on hover (default hover overlay, if the table cell has a link inside, the text will have `primary.dark` color on hover)
- Add links to regions on the `MetricCompareTable` (this required restyling the table cells to remove the padding. It also required passing the `RegionDB` to the `MetricCompareTable` (we only need the function to get the URL, but this way the API is consistent with the metric-aware maps)