### PR TITLE
Fix #316: Disallow null and undefined in timeseries.

### DIFF
--- a/.changeset/kind-parrots-develop.md
+++ b/.changeset/kind-parrots-develop.md
@@ -1,0 +1,6 @@
+---
+"@actnowcoalition/metrics": patch
+"@actnowcoalition/ui-components": patch
+---
+
+Fix #316: Disallow null and undefined in timeseries.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,5 +28,5 @@
     "@typescript-eslint/no-explicit-any": "off",
     "lodash/import-scope": "warn"
   },
-  "ignorePatterns": ["!.storybook", "**/dist", "**/lib"]
+  "ignorePatterns": ["!.storybook", "**/dist", "**/lib", "public/**"]
 }

--- a/packages/metrics/src/Timeseries/Timeseries.test.ts
+++ b/packages/metrics/src/Timeseries/Timeseries.test.ts
@@ -28,6 +28,16 @@ describe("Timeseries", () => {
     ).toThrowError("Dates in a timeseries must not have a (non-zero) time.");
   });
 
+  test("constructor requires points to not be null or undefined", () => {
+    const verifyValueThrowsError = (value: unknown) => {
+      expect(
+        () => new Timeseries([{ date: new Date("2021-02-03"), value }])
+      ).toThrowError("Timeseries may not contain null or undefined values.");
+    };
+    verifyValueThrowsError(null);
+    verifyValueThrowsError(undefined);
+  });
+
   test("constructor sorts dates", () => {
     const points = [
       {
@@ -102,24 +112,8 @@ describe("Timeseries", () => {
       ).toThrowError("Found non-numeric (or non-finite) value in timeseries");
     };
     verifyValueThrowsError("string");
-    verifyValueThrowsError(null);
-    verifyValueThrowsError(undefined);
     verifyValueThrowsError(new Date());
     verifyValueThrowsError(Number.NaN);
-  });
-
-  test("removeNulls() removes nulls and undefined", () => {
-    const date = new Date("2021-01-01");
-    const ts = new Timeseries<number | null | undefined>([
-      { date, value: 1 },
-      { date, value: null },
-      { date, value: 2 },
-      { date, value: undefined },
-      { date, value: 3 },
-    ]);
-    const tsWithoutNulls: Timeseries<number> = ts.removeNils();
-    expect(tsWithoutNulls.length).toBe(3);
-    expect(tsWithoutNulls.values).toEqual([1, 2, 3]);
   });
 
   test(`hasData() can be used as a type guard for NonEmptyTimeseries`, () => {
@@ -188,9 +182,7 @@ describe("Timeseries", () => {
     };
     verifyValueThrowsError("true");
     verifyValueThrowsError("string");
-    verifyValueThrowsError(undefined);
     verifyValueThrowsError(Number.NaN);
-    verifyValueThrowsError(null);
   });
 
   test("assertBoolean() accepts boolean values", () => {
@@ -213,7 +205,7 @@ describe("Timeseries", () => {
         ]).assertStrings()
       ).toThrowError("Found non-string value in timeseries");
     };
-    const notStrings = [100, {}, undefined, Number.NaN, true, null];
+    const notStrings = [100, {}, Number.NaN, true];
     for (const value of notStrings) {
       verifyValueThrowsError(value);
     }

--- a/packages/metrics/src/data/MetricData.ts
+++ b/packages/metrics/src/data/MetricData.ts
@@ -71,7 +71,7 @@ export class MetricData<T = unknown> {
    * @returns The timeseries cast to `Timeseries<number>`.
    */
   numericTimeseries(): Timeseries<number> {
-    return this.timeseries.removeNils().assertFiniteNumbers();
+    return this.timeseries.assertFiniteNumbers();
   }
 
   /**

--- a/packages/metrics/src/data_providers/data_provider_utils.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.ts
@@ -4,6 +4,7 @@ import { Metric } from "../Metric";
 import { MetricData } from "../data";
 import { Timeseries } from "../Timeseries";
 import get from "lodash/get";
+import isNil from "lodash/isNil";
 
 export type DataRow = { [key: string]: unknown };
 
@@ -61,21 +62,23 @@ export function dataRowsToMetricData(
 ) {
   const rows = dataRowsByRegionId[region.regionId] ?? [];
   const timeseries = new Timeseries(
-    rows.map((row) => {
-      const value = get(row, metricKey);
-      if (strict) {
-        assert(value !== undefined, `Metric key ${metricKey} missing.`);
-      }
-      assert(
-        typeof row[dateKey] === "string",
-        `Date column must be a string. ${typeof row[dateKey]} found.`
-      );
-      return {
-        date: new Date(row[dateKey] as string),
-        value: value as unknown,
-      };
-    })
-  ).removeNils();
+    rows
+      .map((row) => {
+        const value = get(row, metricKey);
+        if (strict) {
+          assert(value !== undefined, `Metric key ${metricKey} missing.`);
+        }
+        assert(
+          typeof row[dateKey] === "string",
+          `Date column must be a string. ${typeof row[dateKey]} found.`
+        );
+        return {
+          date: new Date(row[dateKey] as string),
+          value: value as unknown,
+        };
+      })
+      .filter((row) => !isNil(row.value))
+  );
   return new MetricData(
     metric,
     region,

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -63,10 +63,9 @@ export const LineChart: React.FC<LineChartProps> = ({
   strokeLinejoin = "round",
   ...otherLineProps
 }) => {
-  const data = timeseries.removeNils();
   return (
     <LinePath
-      data={data.points}
+      data={timeseries.points}
       x={(d) => xScale(d.date)}
       y={(d) => yScale(d.value)}
       curve={curveMonotoneX}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,11 +7685,6 @@ gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-geo-albers-usa-territories@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/geo-albers-usa-territories/-/geo-albers-usa-territories-0.1.0.tgz#4d674629fc28feee709ec8e1b1f250ebd16f5df2"
-  integrity sha512-mmYOFbMcDbO/EP/bs01huipWEVGN8J6kz2zasMCx1CI1nAQyAAmfXQhpIROleDm4/RoOiaql5qO81eW+tPs9og==
-
 get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
Assert in constructor and remove no longer needed `remvoeNils()` method.