### PR TITLE
Fix #322: Require passing provider ids to all metric data providers.

### DIFF
--- a/.changeset/chatty-frogs-wash.md
+++ b/.changeset/chatty-frogs-wash.md
@@ -1,0 +1,6 @@
+---
+"@actnowcoalition/metrics": patch
+"@actnowcoalition/ui-components": patch
+---
+
+Fix #322: Require passing provider ids to all metric data providers.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -72,7 +72,7 @@ More on data providers below.
 It consists of metric definitions and the data providers to fetch data for the metrics.
 
 ```
-const dataProviders = [new StaticValueDataProvider()];
+const dataProviders = [new StaticValueDataProvider("static")];
 const metrics = [
   {
     id: "the_answer",

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.ts
@@ -1,6 +1,5 @@
 import groupBy from "lodash/groupBy";
 import keyBy from "lodash/keyBy";
-import uniq from "lodash/uniq";
 
 import { Region } from "@actnowcoalition/regions";
 import { assert } from "@actnowcoalition/assert";
@@ -57,18 +56,15 @@ export class MetricCatalog {
     this.metricsById = keyBy(this.metrics, "id");
     this.dataProvidersById = keyBy(dataProviders, (p) => p.id);
 
-    const referencedDataProviderIds = metrics.map(
-      (m) => m.dataReference?.providerId
-    );
-    const missingDataProviderIds = referencedDataProviderIds.filter(
-      (id) => id && !this.dataProvidersById[id]
-    );
-    assert(
-      missingDataProviderIds.length === 0,
-      `Some metrics referenced data providers that do not exist: ${uniq(
-        missingDataProviderIds
-      ).join(", ")}`
-    );
+    for (const metric of this.metrics) {
+      const providerId = metric.dataReference?.providerId;
+      assert(
+        !providerId || this.dataProvidersById[providerId],
+        `${metric} has a dataReference.providerId of "${providerId}" which was not included in the provided dataProviders list: ${dataProviders.map(
+          (p) => p.id
+        )}.`
+      );
+    }
     this.options = options;
   }
 

--- a/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
+++ b/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
@@ -10,16 +10,20 @@ import { Metric } from "../Metric";
 import { StaticValueDataProvider } from "../data_providers";
 import { isoDateOnlyString } from "@actnowcoalition/time-utils";
 
+enum ProviderId {
+  STATIC = "static",
+}
+
 const testRegion = states.findByRegionIdStrict("12");
 const testMetric = new Metric({
   id: "cases_per_100k",
   dataReference: {
-    providerId: "static",
+    providerId: ProviderId.STATIC,
     value: 42,
   },
 });
 
-const testProvider = new StaticValueDataProvider();
+const testProvider = new StaticValueDataProvider(ProviderId.STATIC);
 
 // The snapshot JSON that corresponds to the data for `testRegion` and `testMetric`.
 const testSnapshot: SnapshotJSON = {

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.test.ts
@@ -7,6 +7,8 @@ const testNation = nations.findByRegionIdStrict("USA"); // USA.
 const testState = states.findByRegionIdStrict("25"); // Massachusetts.
 const testMetro = metros.findByRegionIdStrict("10420"); // Akron, OH.
 
+const PROVIDER_ID = "covid-act-now-api";
+
 enum MetricId {
   HOSPITAL_BEDS = "Current Hospital Bed Capacity",
   POPULATION = "Population",
@@ -17,21 +19,21 @@ const testMetrics = [
   {
     id: MetricId.HOSPITAL_BEDS,
     dataReference: {
-      providerId: "covid-act-now-api",
+      providerId: PROVIDER_ID,
       column: "actuals.hospitalBeds.capacity",
     },
   },
   {
     id: MetricId.POPULATION,
     dataReference: {
-      providerId: "covid-act-now-api",
+      providerId: PROVIDER_ID,
       column: "population",
     },
   },
   {
     id: MetricId.WEEKLY_ADMISSIONS,
     dataReference: {
-      providerId: "covid-act-now-api",
+      providerId: PROVIDER_ID,
       column: "metrics.weeklyCovidAdmissionsPer100k",
     },
   },
@@ -58,6 +60,7 @@ const testCacheData = {
 
 const dataProviders = [
   new CovidActNowDataProvider(
+    PROVIDER_ID,
     /*apiKey=*/ "placeholder", // These tests won't need to make any actual network calls.
     testCacheData
   ),

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
@@ -28,11 +28,19 @@ export class CovidActNowDataProvider extends CachingMetricDataProviderBase {
 
   /**
    * Constructs a new CovidActNowDataProvider instance.
+   *
+   * @param providerId A unique provider id to associate with the provider (e.g.
+   * "can-api"). This ID can be used from a {@link MetricDataReference} in a
+   * metric to reference the data from this provider.
    * @param apiKey Valid Covid Act Now API key to use in API calls.
    * @param data JSON data to put directly into the cache. Used primarily for testing.
    */
-  constructor(apiKey: string, data?: { [regionId: string]: DataRow }) {
-    super("covid-act-now-api");
+  constructor(
+    providerId: string,
+    apiKey: string,
+    data?: { [regionId: string]: DataRow }
+  ) {
+    super(providerId);
     this.apiKey = apiKey;
     this.apiJson = data ?? {};
   }

--- a/packages/metrics/src/data_providers/CsvDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.test.ts
@@ -2,6 +2,8 @@ import { CsvDataProvider } from "./CsvDataProvider";
 import { Metric } from "../Metric";
 import { states } from "@actnowcoalition/regions";
 
+const PROVIDER_ID = "csv-provider";
+
 const mockCsv = `region,cool_metric
 36,150
 12,`;
@@ -13,7 +15,7 @@ const csvTimeseries = `region,date,cool_metric
 const newYork = states.findByRegionIdStrict("36");
 const testMetric = new Metric({
   id: "metric",
-  dataReference: { providerId: "csv-provider", column: "cool_metric" },
+  dataReference: { providerId: PROVIDER_ID, column: "cool_metric" },
 });
 
 /**
@@ -29,7 +31,7 @@ const testFetchingCsvData = async (
   includeTimeseries: boolean,
   dateCol?: string
 ) => {
-  const provider = new CsvDataProvider("csv-provider", {
+  const provider = new CsvDataProvider(PROVIDER_ID, {
     regionColumn: "region",
     dateColumn: dateCol,
     csvText: data,
@@ -66,7 +68,7 @@ describe("CsvDataProvider", () => {
   });
 
   test("populateCache() fails if csv does not have at least one row.", async () => {
-    const provider = new CsvDataProvider("csv-provider", {
+    const provider = new CsvDataProvider("PROVIDER_ID", {
       regionColumn: "region",
       csvText: `region,cool_metric`,
     });
@@ -77,7 +79,7 @@ describe("CsvDataProvider", () => {
 
   test("Constructor fails if neither url or csv data is provided.", () => {
     expect(() => {
-      new CsvDataProvider("csv-provider", {
+      new CsvDataProvider("PROVIDER_ID", {
         regionColumn: "region",
       });
     }).toThrow("URL or CSV data must be provided");

--- a/packages/metrics/src/data_providers/CsvDataProvider.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.ts
@@ -46,6 +46,14 @@ export class CsvDataProvider extends CachingMetricDataProviderBase {
 
   private dataRowsByRegionId: { [regionId: string]: DataRow[] } = {};
 
+  /**
+   * Constructs a new CsvDataProvider instance.
+   *
+   * @param providerId A unique provider id to associate with the provider (e.g.
+   * "my-datasource-csv"). This ID can be used from a {@link MetricDataReference} in a
+   * metric to reference the data from this provider.
+   * @param options Options to configure the provider.
+   */
   constructor(providerId: string, options: CsvDataProviderOptions) {
     assert(
       options.url || options.csvText,

--- a/packages/metrics/src/data_providers/MockDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/MockDataProvider.test.ts
@@ -6,13 +6,15 @@ import { Metric } from "../Metric";
 
 const testRegion = states.findByRegionIdStrict("53"); // Washington.
 
+const PROVIDER_ID = "mock";
+
 describe("MockDataProvider", () => {
   test("generates data", () => {
-    const dataProvider = new MockDataProvider();
+    const dataProvider = new MockDataProvider(PROVIDER_ID);
     const metric = new Metric({
       id: "test",
       dataReference: {
-        providerId: "mock",
+        providerId: PROVIDER_ID,
         startDate: "2022-01-01",
         endDate: "2022-01-05",
       },
@@ -31,11 +33,11 @@ describe("MockDataProvider", () => {
   });
 
   test("uses default dates if omitted", () => {
-    const dataProvider = new MockDataProvider();
+    const dataProvider = new MockDataProvider(PROVIDER_ID);
     const metric = new Metric({
-      id: "test",
+      id: PROVIDER_ID,
       dataReference: {
-        providerId: "mock",
+        providerId: PROVIDER_ID,
       },
     });
     const data = dataProvider.getDataFromCache(testRegion, metric);

--- a/packages/metrics/src/data_providers/MockDataProvider.ts
+++ b/packages/metrics/src/data_providers/MockDataProvider.ts
@@ -34,8 +34,15 @@ export interface MockDataReferenceFields {
  * ```
  */
 export class MockDataProvider extends CachingMetricDataProviderBase {
-  constructor() {
-    super(/*providerId=*/ "mock");
+  /**
+   * Constructs a new MockDataProvider instance.
+   *
+   * @param providerId A unique provider id to associate with the provider (e.g.
+   * "mock"). This ID can be used from a {@link MetricDataReference} in a
+   * metric to reference the data from this provider.
+   */
+  constructor(providerId: string) {
+    super(providerId);
   }
 
   private cachedData: { [key: string]: MetricData<number> } = {};

--- a/packages/metrics/src/data_providers/StaticValueDataProvider.ts
+++ b/packages/metrics/src/data_providers/StaticValueDataProvider.ts
@@ -19,8 +19,15 @@ import { MetricData } from "../data";
  * ```
  */
 export class StaticValueDataProvider extends CachingMetricDataProviderBase {
-  constructor() {
-    super(/*providerId=*/ "static");
+  /**
+   * Constructs a new MockDataProvider instance.
+   *
+   * @param providerId A unique provider id to associate with the provider (e.g.
+   * "static"). This ID can be used from a {@link MetricDataReference} in a
+   * metric to reference the data from this provider.
+   */
+  constructor(providerId: string) {
+    super(providerId);
   }
 
   async populateCache(): Promise<void> {

--- a/packages/metrics/src/data_providers/TransformedMetricDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/TransformedMetricDataProvider.test.ts
@@ -8,10 +8,17 @@ import { StaticValueDataProvider } from "./StaticValueDataProvider";
 
 const testRegion = states.findByRegionIdStrict("53"); // Washington.
 
+enum ProviderId {
+  STATIC = "static",
+  INVERT_DATA = "invert-data",
+}
+
 // An implementation of TransformedMetricDataProvider that transforms numbers
 // into their additive inverses (e.g. 5 => -5).
 class InvertDataProvider extends TransformedMetricDataProvider {
-  id = "invert-data";
+  constructor(readonly id: string) {
+    super();
+  }
 
   transformData(
     sourceData: MetricData,
@@ -41,28 +48,28 @@ const testMetrics = [
   {
     id: MetricId.PI,
     dataReference: {
-      providerId: "static",
+      providerId: ProviderId.STATIC,
       value: Math.PI,
     },
   },
   {
     id: MetricId.ANSWER,
     dataReference: {
-      providerId: "static",
+      providerId: ProviderId.STATIC,
       value: 42,
     },
   },
   {
     id: MetricId.INVERTED_PI,
     dataReference: {
-      providerId: "invert-data",
+      providerId: ProviderId.INVERT_DATA,
       sourceMetric: MetricId.PI,
     },
   },
   {
     id: MetricId.INVERTED_ANSWER,
     dataReference: {
-      providerId: "invert-data",
+      providerId: ProviderId.INVERT_DATA,
       sourceMetric: MetricId.ANSWER,
     },
   },
@@ -71,8 +78,8 @@ const testMetrics = [
 describe("TransformedMetricDataProvider", () => {
   test("fetches and transforms data", async () => {
     const dataProviders = [
-      new StaticValueDataProvider(),
-      new InvertDataProvider(),
+      new StaticValueDataProvider(ProviderId.STATIC),
+      new InvertDataProvider(ProviderId.INVERT_DATA),
     ];
     const catalog = new MetricCatalog(testMetrics, dataProviders);
 

--- a/packages/ui-components/src/common/hooks/metric-data.test.tsx
+++ b/packages/ui-components/src/common/hooks/metric-data.test.tsx
@@ -19,23 +19,25 @@ enum MetricId {
   E = "e",
 }
 
+const STATIC_PROVIDER_ID = "static";
 const testMetricDefs = [
   {
     id: MetricId.PI,
     dataReference: {
-      providerId: "static",
+      providerId: STATIC_PROVIDER_ID,
       value: Math.PI,
     },
   },
   {
     id: MetricId.E,
     dataReference: {
-      providerId: "static",
+      providerId: STATIC_PROVIDER_ID,
       value: Math.E,
     },
   },
 ];
-const dataProviders = [new StaticValueDataProvider()];
+
+const dataProviders = [new StaticValueDataProvider(STATIC_PROVIDER_ID)];
 
 const testRegionWA = states.findByRegionIdStrict("53"); // Washington.
 const testRegionCA = states.findByRegionIdStrict("06"); // California

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -3,7 +3,11 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { states } from "@actnowcoalition/regions";
 import { MetricCatalog, MetricDefinition } from "@actnowcoalition/metrics";
 import { MetricCatalogProvider } from "./MetricCatalogContext";
-import { MetricId, dataProviders } from "../../stories/mockMetricCatalog";
+import {
+  MetricId,
+  dataProviders,
+  ProviderId,
+} from "../../stories/mockMetricCatalog";
 import MetricAwareDemo from "./MetricAwareDemo";
 
 export default {
@@ -20,7 +24,7 @@ const metricDefs: MetricDefinition[] = [
     extendedName:
       "Pi - The ratio of a circle's circumference to its diameter (should be formatted as 3.1)",
     dataReference: {
-      providerId: "static",
+      providerId: ProviderId.STATIC,
       value: Math.PI,
     },
     formatOptions: { maximumSignificantDigits: 2 },
@@ -30,7 +34,7 @@ const metricDefs: MetricDefinition[] = [
     name: "Cases Per 100k (mock)",
     extendedName: "Cases per 100k population (using mock data)",
     dataReference: {
-      providerId: "mock",
+      providerId: ProviderId.MOCK,
       startDate: "2020-01-01",
     },
   },

--- a/packages/ui-components/src/stories/MockAppleStockDataProvider.ts
+++ b/packages/ui-components/src/stories/MockAppleStockDataProvider.ts
@@ -20,8 +20,8 @@ import { appleStockTimeseries } from "./mockData";
  * ```
  */
 export class AppleStockDataProvider extends CachingMetricDataProviderBase {
-  constructor() {
-    super(/*providerId=*/ "apple_stock");
+  constructor(providerId: string) {
+    super(providerId);
   }
 
   private cachedData: { [key: string]: MetricData<number> } = {};

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -15,13 +15,19 @@ export enum MetricId {
   PASS_FAIL = "pass_fail",
 }
 
+export enum ProviderId {
+  MOCK = "mock",
+  STATIC = "static",
+  APPLE_STOCK = "apple_stock",
+}
+
 const testMetricDefs: MetricDefinition[] = [
   {
     id: MetricId.APPLE_STOCK,
     name: "AAPL",
     extendedName: "Apple Stock",
     dataReference: {
-      providerId: "apple_stock",
+      providerId: ProviderId.APPLE_STOCK,
     },
     categoryThresholds: [100, 200, 400, 800],
     categorySetId: "5_risk_categories",
@@ -31,7 +37,7 @@ const testMetricDefs: MetricDefinition[] = [
     name: "Pi",
     extendedName: "Pi - The ratio of a circle's circumference to its diameter",
     dataReference: {
-      providerId: "static",
+      providerId: ProviderId.STATIC,
       value: 3.141592653589793,
     },
   },
@@ -40,7 +46,7 @@ const testMetricDefs: MetricDefinition[] = [
     name: "Cases (mock)",
     extendedName: "Cases per 100k population (using mock data)",
     dataReference: {
-      providerId: "mock",
+      providerId: ProviderId.MOCK,
       startDate: "2020-01-01",
     },
     categoryThresholds: [40, 100],
@@ -51,7 +57,7 @@ const testMetricDefs: MetricDefinition[] = [
     name: "Cases (mock)",
     extendedName: "",
     dataReference: {
-      providerId: "mock",
+      providerId: ProviderId.MOCK,
       startDate: "2020-01-01",
     },
     categoryThresholds: [10, 100],
@@ -62,7 +68,7 @@ const testMetricDefs: MetricDefinition[] = [
     name: "Pass or Fail",
     extendedName: "Passing or Failing grade on an arbitrary test",
     dataReference: {
-      providerId: "static",
+      providerId: ProviderId.STATIC,
       value: 0,
     },
     categorySetId: "pass_fail",
@@ -71,9 +77,9 @@ const testMetricDefs: MetricDefinition[] = [
 ];
 
 export const dataProviders = [
-  new MockDataProvider(),
-  new StaticValueDataProvider(),
-  new AppleStockDataProvider(),
+  new MockDataProvider(ProviderId.MOCK),
+  new StaticValueDataProvider(ProviderId.STATIC),
+  new AppleStockDataProvider(ProviderId.APPLE_STOCK),
 ];
 
 const metricCategorySets = [
@@ -149,7 +155,7 @@ const metricDefsB: MetricDefinition[] = [
     name: "Pi",
     extendedName: "Pi - The ratio of a circle's circumference to its diameter",
     dataReference: {
-      providerId: "static",
+      providerId: ProviderId.STATIC,
       value: Math.PI,
     },
     formatOptions: { minimumFractionDigits: 2 },
@@ -159,7 +165,7 @@ const metricDefsB: MetricDefinition[] = [
     name: "Cases Per 100k (mock)",
     extendedName: "Cases per 100k population (using mock data)",
     dataReference: {
-      providerId: "mock",
+      providerId: ProviderId.MOCK,
       startDate: "2020-01-01",
     },
   },


### PR DESCRIPTION
Rather than having hardcoded provider ids for some data providers ("mock" for MockDataProvider, "static" for StaticValueDataProvider, etc.), we now require the user to always pass in their own provider IDs.  That way it's a bit more explicit and we don't have to document the IDs for the different providers.

Most of the changes in the PR are just updating tests / stories to use const / enums for provider ids instead of the hardcoded values.