### PR TITLE
Update `RegionSearch` API to use `MuiLink` and other improvements

### DIFF
--- a/.changeset/grumpy-icons-yell.md
+++ b/.changeset/grumpy-icons-yell.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": minor
+---
+
+Update RegionSearch to use MuiLink and regionDB

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
@@ -3,10 +3,14 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { TextField, InputAdornment } from "@mui/material";
 import MapIcon from "@mui/icons-material/Map";
 import sortBy from "lodash/sortBy";
-import { states, counties, metros } from "@actnowcoalition/regions";
+import {
+  states,
+  counties,
+  metros,
+  RegionDB,
+  Region,
+} from "@actnowcoalition/regions";
 import { RegionSearch } from ".";
-import { RegionDB, Region } from "@actnowcoalition/regions";
-import { assert } from "@actnowcoalition/assert";
 
 export default {
   title: "Components/RegionSearch",
@@ -17,40 +21,22 @@ const regionDB = new RegionDB([...states.all, ...counties.all], {
   getRegionUrl: (region: Region): string => `/us/${region.slug}`,
 });
 
-const getRegionUrl = (regionId: string): string => {
-  const region = regionDB.findByRegionIdStrict(regionId);
-  const url = regionDB.getRegionUrl(region);
-  assert(typeof url === "string", "RegionDB.getRegionUrl must be configured");
-  return url;
-};
-
 const Template: ComponentStory<typeof RegionSearch> = (args) => (
   <RegionSearch {...args} />
 );
 
-const AnchorLinkComponent: React.FC<{
-  children: React.ReactElement;
-  targetUrl: string;
-}> = ({ children, targetUrl }) => (
-  <a href={targetUrl} style={{ textDecoration: "none" }}>
-    {children}
-  </a>
-);
-
 export const StatesOnly = Template.bind({});
 StatesOnly.args = {
+  regionDB,
   options: states.all,
   inputLabel: "States",
-  LinkComponent: AnchorLinkComponent,
-  getRegionUrl: getRegionUrl,
 };
 
 export const CustomRenderInput = Template.bind({});
 CustomRenderInput.args = {
+  regionDB,
   options: states.all,
   inputLabel: "States",
-  LinkComponent: AnchorLinkComponent,
-  getRegionUrl: getRegionUrl,
   renderInput: (params) => (
     <TextField
       {...params}
@@ -70,16 +56,14 @@ CustomRenderInput.args = {
 
 export const CountiesOnly = Template.bind({});
 CountiesOnly.args = {
+  regionDB,
   options: sortBy(counties.all, (county) => county.population * -1),
   inputLabel: "Counties",
-  LinkComponent: AnchorLinkComponent,
-  getRegionUrl: getRegionUrl,
 };
 
 const allRegions = [...states.all, ...counties.all, ...metros.all];
 export const AllRegions = Template.bind({});
 AllRegions.args = {
+  regionDB,
   options: allRegions,
-  LinkComponent: AnchorLinkComponent,
-  getRegionUrl: getRegionUrl,
 };

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.style.ts
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.style.ts
@@ -1,0 +1,6 @@
+import { Link } from "@mui/material";
+import { styled } from "../../styles";
+
+export const StyledLink = styled(Link)`
+  text-decoration: none;
+`;

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -62,31 +62,26 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
   );
 
   return (
-    <div>
-      <Autocomplete
-        options={options}
-        onChange={(e, item: Region | null) => onChange(item)}
-        clearIcon={<></>}
-        renderInput={customRenderInput ?? defaultRenderInput}
-        renderOption={(
-          props: HTMLAttributes<HTMLLIElement>,
-          option: Region
-        ) => (
-          <StyledLink href={regionDB.getRegionUrl(option)}>
-            <SearchItem
-              itemLabel={option.shortName}
-              itemSublabel={`${formatPopulation(option.population)} population`}
-              {...props}
-            />
-          </StyledLink>
-        )}
-        getOptionLabel={stringifyOption}
-        filterOptions={createFilterOptions({
-          limit: 30,
-          stringify: stringifyOption,
-        })}
-        {...otherAutocompleteProps}
-      />
-    </div>
+    <Autocomplete
+      options={options}
+      onChange={(e, item: Region | null) => onChange(item)}
+      clearIcon={<></>}
+      renderInput={customRenderInput ?? defaultRenderInput}
+      renderOption={(props: HTMLAttributes<HTMLLIElement>, option: Region) => (
+        <StyledLink href={regionDB.getRegionUrl(option)}>
+          <SearchItem
+            itemLabel={option.shortName}
+            itemSublabel={`${formatPopulation(option.population)} population`}
+            {...props}
+          />
+        </StyledLink>
+      )}
+      getOptionLabel={stringifyOption}
+      filterOptions={createFilterOptions({
+        limit: 30,
+        stringify: stringifyOption,
+      })}
+      {...otherAutocompleteProps}
+    />
   );
 };

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -1,10 +1,17 @@
 import React, { HTMLAttributes } from "react";
-import { Region } from "@actnowcoalition/regions";
-import { Autocomplete, AutocompleteProps, TextField } from "@mui/material";
+import {
+  Autocomplete,
+  AutocompleteProps,
+  TextField,
+  createFilterOptions,
+  Link,
+} from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
-import { createFilterOptions } from "@mui/material/useAutocomplete";
-import { SearchItem } from "./SearchItem/SearchItem";
+
+import { Region, RegionDB } from "@actnowcoalition/regions";
+
 import { formatPopulation } from "../../common/utils";
+import { SearchItem } from "./SearchItem/SearchItem";
 
 function stringifyOption(region: Region) {
   return region.fullName;
@@ -26,12 +33,7 @@ export type CustomAutocompleteProps = AutocompleteProps<
 
 export interface RegionSearchProps
   extends Omit<CustomAutocompleteProps, "renderInput"> {
-  /** Link component in which to wrap the search item. */
-  LinkComponent: React.FC<{
-    children: React.ReactElement;
-    targetUrl: string;
-  }>;
-  getRegionUrl: (regionId: string) => string;
+  regionDB: RegionDB;
   /** Placeholder text to show in the inner text field  */
   inputLabel?: string;
   /** Optional renderInput function. See https://mui.com/material-ui/api/autocomplete/ */
@@ -39,11 +41,10 @@ export interface RegionSearchProps
 }
 
 export const RegionSearch: React.FC<RegionSearchProps> = ({
+  regionDB,
   options,
   inputLabel = "City, county, state, or district",
   renderInput: customRenderInput,
-  LinkComponent,
-  getRegionUrl,
   ...otherAutocompleteProps
 }) => {
   const defaultRenderInput: CustomAutocompleteProps["renderInput"] = (
@@ -69,19 +70,15 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
         renderOption={(
           props: HTMLAttributes<HTMLLIElement>,
           option: Region
-        ) => {
-          return (
-            <LinkComponent targetUrl={getRegionUrl(option.regionId)}>
-              <SearchItem
-                itemLabel={option.shortName}
-                itemSublabel={`${formatPopulation(
-                  option.population
-                )} population`}
-                {...props}
-              />
-            </LinkComponent>
-          );
-        }}
+        ) => (
+          <Link href={regionDB.getRegionUrl(option)}>
+            <SearchItem
+              itemLabel={option.shortName}
+              itemSublabel={`${formatPopulation(option.population)} population`}
+              {...props}
+            />
+          </Link>
+        )}
         getOptionLabel={stringifyOption}
         filterOptions={createFilterOptions({
           limit: 30,

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -4,7 +4,6 @@ import {
   AutocompleteProps,
   TextField,
   createFilterOptions,
-  Link,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 
@@ -12,6 +11,7 @@ import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { formatPopulation } from "../../common/utils";
 import { SearchItem } from "./SearchItem/SearchItem";
+import { StyledLink } from "./RegionSearch.style";
 
 function stringifyOption(region: Region) {
   return region.fullName;
@@ -33,6 +33,7 @@ export type CustomAutocompleteProps = AutocompleteProps<
 
 export interface RegionSearchProps
   extends Omit<CustomAutocompleteProps, "renderInput"> {
+  /** RegionDB instance for the application */
   regionDB: RegionDB;
   /** Placeholder text to show in the inner text field  */
   inputLabel?: string;
@@ -71,13 +72,13 @@ export const RegionSearch: React.FC<RegionSearchProps> = ({
           props: HTMLAttributes<HTMLLIElement>,
           option: Region
         ) => (
-          <Link href={regionDB.getRegionUrl(option)}>
+          <StyledLink href={regionDB.getRegionUrl(option)}>
             <SearchItem
               itemLabel={option.shortName}
               itemSublabel={`${formatPopulation(option.population)} population`}
               {...props}
             />
-          </Link>
+          </StyledLink>
         )}
         getOptionLabel={stringifyOption}
         filterOptions={createFilterOptions({

--- a/packages/ui-components/src/styles/theme/components.tsx
+++ b/packages/ui-components/src/styles/theme/components.tsx
@@ -1,6 +1,6 @@
 /** MUI theme components */
 import React from "react";
-import { ThemeOptions, createTheme, textFieldClasses } from "@mui/material";
+import { ThemeOptions, createTheme } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 const referenceTheme = createTheme();
@@ -11,16 +11,6 @@ const components: ThemeOptions["components"] = {
       filterSelectedOptions: true,
       disableClearable: true,
       popupIcon: <KeyboardArrowDownIcon />,
-    },
-    styleOverrides: {
-      root: {
-        // TODO (Pablo): The MuiTextField component has margins set globally -
-        // we should only add the margins in context where that's needed
-        // Select
-        [`& .${textFieldClasses.root}`]: {
-          margin: 0,
-        },
-      },
     },
   },
 
@@ -108,9 +98,6 @@ const components: ThemeOptions["components"] = {
     styleOverrides: {
       root: ({ theme }) => ({
         backgroundColor: theme.palette.common.white,
-        // TODO (Pablo): We should remove the margin on this component and add
-        // it only in the context that needs it (select)
-        margin: theme.spacing(1, 2),
         "& .MuiFilledInput-root": {
           backgroundColor: theme.palette.common.white,
           border: `1px solid ${theme.palette.border.default}`,

--- a/packages/ui-components/src/styles/theme/components.tsx
+++ b/packages/ui-components/src/styles/theme/components.tsx
@@ -1,6 +1,6 @@
 /** MUI theme components */
 import React from "react";
-import { ThemeOptions, createTheme } from "@mui/material";
+import { ThemeOptions, createTheme, textFieldClasses } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 const referenceTheme = createTheme();
@@ -11,6 +11,13 @@ const components: ThemeOptions["components"] = {
       filterSelectedOptions: true,
       disableClearable: true,
       popupIcon: <KeyboardArrowDownIcon />,
+    },
+    styleOverrides: {
+      root: {
+        [`& .${textFieldClasses.root}`]: {
+          margin: 0,
+        },
+      },
     },
   },
 

--- a/packages/ui-components/src/styles/theme/components.tsx
+++ b/packages/ui-components/src/styles/theme/components.tsx
@@ -14,6 +14,9 @@ const components: ThemeOptions["components"] = {
     },
     styleOverrides: {
       root: {
+        // TODO (Pablo): The MuiTextField component has margins set globally -
+        // we should only add the margins in context where that's needed
+        // Select
         [`& .${textFieldClasses.root}`]: {
           margin: 0,
         },
@@ -105,6 +108,8 @@ const components: ThemeOptions["components"] = {
     styleOverrides: {
       root: ({ theme }) => ({
         backgroundColor: theme.palette.common.white,
+        // TODO (Pablo): We should remove the margin on this component and add
+        // it only in the context that needs it (select)
         margin: theme.spacing(1, 2),
         "& .MuiFilledInput-root": {
           backgroundColor: theme.palette.common.white,


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/333 

<img width="561" alt="image" src="https://user-images.githubusercontent.com/114084/197892356-10b08359-d84f-45b6-8b29-65dd16ae8492.png">

## Changes

- Update the API of `RegionSearch` to use `MuiLink` and `regionDB` instead of the props `LinkComponent` and `getRegionUrl`
- Update the styles of `MuiAutocomplete` to remove the margins of `MuiTextField`, which were causing the component to be wider than its container. 

**Before** (I added a container with a fixed width and a black border to show the difference)

<img width="466" alt="image" src="https://user-images.githubusercontent.com/114084/197893273-71568339-c443-4d89-ab1b-8d004cfa546d.png">

**After**

<img width="422" alt="image" src="https://user-images.githubusercontent.com/114084/197893418-67ca61d1-0757-47d5-b7f9-b5d62e2bf6d1.png">

