### PR TITLE
Implement `useHoveredPoint` hook

### DIFF
--- a/.changeset/warm-elephants-yawn.md
+++ b/.changeset/warm-elephants-yawn.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Implement useHoveredPoint hook to use on multi-timeseries charts

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
@@ -1,12 +1,11 @@
-import React, { useState } from "react";
-import isNumber from "lodash/isNumber";
+import React from "react";
 import { ComponentMeta } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleUtc, scaleLinear } from "@visx/scale";
 import { Timeseries } from "@actnowcoalition/metrics";
 import { AxisBottom, AxisLeft } from "../Axis";
 import { LineChart } from "../LineChart";
-import { ChartOverlayXY, PointInfo } from ".";
+import { ChartOverlayXY, useHoveredPoint } from ".";
 
 export default {
   title: "Charts/ChartOverlayXY",
@@ -64,37 +63,24 @@ const seriesList = [
  * the index of the series. We use that information to make the line thicker.
  */
 export const ExampleTrendsChart = () => {
-  const [pointIndex, setPointIndex] = useState<number | null>(null);
-  const [timeseriesIndex, setTimeseriesIndex] = useState<number | null>(null);
-
-  const isHoveringPoint = isNumber(pointIndex) && isNumber(timeseriesIndex);
-
-  const onMouseMove = ({ pointIndex, timeseriesIndex }: PointInfo) => {
-    if (isNumber(pointIndex) && isNumber(timeseriesIndex)) {
-      setPointIndex(pointIndex);
-      setTimeseriesIndex(timeseriesIndex);
-    }
-  };
-
-  const onMouseOut = () => {
-    setPointIndex(null);
-    setTimeseriesIndex(null);
-  };
+  const timeseriesList = seriesList.map((s) => s.timeseries);
+  const { pointInfo, onMouseMove, onMouseLeave } =
+    useHoveredPoint<number>(timeseriesList);
 
   return (
     <svg width={width} height={height} style={{ border: "solid 1px #ddd" }}>
       <Group left={padding} top={padding}>
         <AxisBottom top={innerHeight} scale={xScale} />
         <AxisLeft scale={yScale} />
-        {seriesList.map(({ timeseries, color }, tIndex) => (
-          <Group key={`group-${tIndex}`}>
+        {seriesList.map(({ timeseries, color }, index) => (
+          <Group key={`group-${index}`}>
             <LineChart
               timeseries={timeseries}
               xScale={xScale}
               yScale={yScale}
               stroke={color}
               strokeWidth={
-                isHoveringPoint && tIndex === timeseriesIndex ? 3 : 1
+                pointInfo && index === pointInfo.timeseriesIndex ? 3 : 1
               }
             />
             <Group>
@@ -117,7 +103,7 @@ export const ExampleTrendsChart = () => {
           width={innerWidth}
           height={innerHeight}
           onMouseMove={onMouseMove}
-          onMouseOut={onMouseOut}
+          onMouseOut={onMouseLeave}
         />
       </Group>
     </svg>

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -24,16 +24,16 @@ export interface ChartOverlayXYProps {
    * Handler to call when a user hovers near a point. The point, timeseriesIndex
    * and pointIndex are passed to the handler.
    **/
-  onMouseMove?: (pointInfo: PointInfo) => void;
+  onMouseMove?: (pointInfo: HoveredPointInfo) => void;
   /** Handler to call when the user moves out of the hoverable area. */
   onMouseOut?: () => void;
 }
 
 /**
- * The PointInfo contains information about the point being hovered.
+ * Information about the point being hovered.
  */
-export interface PointInfo {
-  /** Hovered point */
+export interface HoveredPointInfo {
+  /**  */
   point: TimeseriesPoint<number>;
   /** Index of the hovered timeseries */
   timeseriesIndex: number;
@@ -66,7 +66,7 @@ export const ChartOverlayXY = ({
   // Put all the points together in one array. Each pointInfo includes
   // the index of the timeseries it belongs to, and its own index
   // on the corresponding timeseries
-  const points: PointInfo[] = getTimeseriesPoints(timeseriesList);
+  const points: HoveredPointInfo[] = getTimeseriesPoints(timeseriesList);
 
   // The Voronoi polygons are generated from a set of points and a width
   // and height. Each point has a corresponding polygon such that all the
@@ -75,9 +75,9 @@ export const ChartOverlayXY = ({
   // Each polygon has the pointInfo attached to it, so we can pass it to the
   // handler when the user hovers it.
   const voronoiPolygons = useMemo(() => {
-    const voroniLayout = voronoi<PointInfo>({
-      x: ({ point }: PointInfo) => xScale(point.date),
-      y: ({ point }: PointInfo) => yScale(point.value),
+    const voroniLayout = voronoi<HoveredPointInfo>({
+      x: ({ point }: HoveredPointInfo) => xScale(point.date),
+      y: ({ point }: HoveredPointInfo) => yScale(point.value),
       width,
       height,
     });
@@ -105,10 +105,10 @@ export const ChartOverlayXY = ({
  */
 function getTimeseriesPoints(
   timeseriesList: Timeseries<number>[]
-): PointInfo[] {
-  return timeseriesList.reduce<PointInfo[]>(
+): HoveredPointInfo[] {
+  return timeseriesList.reduce<HoveredPointInfo[]>(
     (acc, timeseries, timeseriesIndex) => {
-      const pointInfoList: PointInfo[] = timeseries.points.map(
+      const pointInfoList: HoveredPointInfo[] = timeseries.points.map(
         (point, pointIndex) => ({ point, timeseriesIndex, pointIndex })
       );
       return concat(acc, pointInfoList);

--- a/packages/ui-components/src/components/ChartOverlayXY/index.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/index.ts
@@ -1,1 +1,2 @@
 export * from "./ChartOverlayXY";
+export * from "./useHoveredPoint";

--- a/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import isNumber from "lodash/isNumber";
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+import { ChartOverlayXYProps, PointInfo } from "./ChartOverlayXY";
+
+/**
+ * React hook that keeps track of the point being hovered in a chart. This hook
+ * is normally used with ChartOverlayXY. Given a list of timeseries, it returns
+ * the handlers onMouseMove, onMouseLeave and `pointInfo`, an object containing
+ * `timeseriesIndex`, `pointIndex` and `point`, which represent the index of
+ * the timeseries being hovered, the index in the timeseries of the point being
+ * hovered, and the point being hovered itself.
+ *
+ * @example
+ * ```tsx
+ * const { pointInfo, onMouseMove, onMouseLeave } = useHoveredPoint(timeseriesList);
+ *
+ * return (
+ *   <svg width={width} height={height}>
+ *     {timeseriesList.map(timeseries => (
+ *       <LineChart timeseries={timeseries} {...} />
+ *     ))}
+ *     {pointInfo?.point && (
+ *       <Tooltip point={pointInfo?.point}>
+ *         <CircleMarker />
+ *       </Tooltip>
+ *     )}
+ *     {pointInfo && (
+ *       <LineChart
+ *         timeseries={timeseriesList[timeseriesIndex]}
+ *         strokeWidth={4}
+ *       />
+ *     )}
+ *     <ChartOverlayX
+ *       onMouseMove={onMouseMove}
+ *       onMouseLeave={onMouseLeave}
+ *       {...otherProps}
+ *     />
+ *   </svg>
+ * );
+ * ```
+ *
+ * @param timeseriesList
+ * @returns the hovered point information and the onMouseMove and onMouseLeave handlers.
+ */
+export function useHoveredPoint<T>(
+  timeseriesList: Timeseries<T>[] | undefined
+) {
+  const [pointIndex, setPointIndex] = useState<number | null>(null);
+  const [timeseriesIndex, setTimeseriesIndex] = useState<number | null>(null);
+  const [point, setPoint] = useState<TimeseriesPoint<T> | null>(null);
+
+  const onMouseLeave = () => {
+    setPointIndex(null);
+    setTimeseriesIndex(null);
+    setPoint(null);
+  };
+
+  const onMouseMove: ChartOverlayXYProps["onMouseMove"] = ({
+    pointIndex,
+    timeseriesIndex,
+  }: PointInfo) => {
+    if (timeseriesList && isNumber(pointIndex) && isNumber(timeseriesIndex)) {
+      setPointIndex(pointIndex);
+      setTimeseriesIndex(timeseriesIndex);
+      setPoint(timeseriesList[timeseriesIndex].points[pointIndex]);
+    }
+  };
+  const pointInfo = { timeseriesIndex, pointIndex, point };
+
+  return { pointInfo, onMouseMove, onMouseLeave };
+}

--- a/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
@@ -1,15 +1,12 @@
 import { useState } from "react";
 import isNumber from "lodash/isNumber";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
-import { ChartOverlayXYProps, PointInfo } from "./ChartOverlayXY";
+import { ChartOverlayXYProps, HoveredPointInfo } from "./ChartOverlayXY";
 
 /**
  * React hook that keeps track of the point being hovered in a chart. This hook
  * is normally used with ChartOverlayXY. Given a list of timeseries, it returns
- * the handlers onMouseMove, onMouseLeave and `pointInfo`, an object containing
- * `timeseriesIndex`, `pointIndex` and `point`, which represent the index of
- * the timeseries being hovered, the index in the timeseries of the point being
- * hovered, and the point being hovered itself.
+ * the handlers onMouseMove, onMouseLeave and `pointInfo`.
  *
  * @example
  * ```tsx
@@ -41,7 +38,7 @@ import { ChartOverlayXYProps, PointInfo } from "./ChartOverlayXY";
  * ```
  *
  * @param timeseriesList
- * @returns the hovered point information and the onMouseMove and onMouseLeave handlers.
+ * @returns The hovered point information and the onMouseMove and onMouseLeave handlers.
  */
 export function useHoveredPoint<T>(
   timeseriesList: Timeseries<T>[] | undefined
@@ -59,7 +56,7 @@ export function useHoveredPoint<T>(
   const onMouseMove: ChartOverlayXYProps["onMouseMove"] = ({
     pointIndex,
     timeseriesIndex,
-  }: PointInfo) => {
+  }: HoveredPointInfo) => {
     if (timeseriesList && isNumber(pointIndex) && isNumber(timeseriesIndex)) {
       setPointIndex(pointIndex);
       setTimeseriesIndex(timeseriesIndex);


### PR DESCRIPTION
Similar to `useHoveredDate`, this hook makes it easy to get the point being hovered for charts with multiple lines (doing this in preparation for Trends)