### PR TITLE
Fix the state map for Alaska

### DIFF
--- a/.changeset/short-brooms-drum.md
+++ b/.changeset/short-brooms-drum.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix the state map for Alaska

--- a/packages/ui-components/src/components/MetricUSMaps/MetricUSStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSMaps/MetricUSStateMap/MetricUSStateMap.stories.tsx
@@ -32,6 +32,14 @@ MetricAwareNewYork.args = {
   regionDB,
 };
 
+export const MetricAwareAlaska = Template.bind({});
+MetricAwareAlaska.args = {
+  stateRegionId: "02",
+  renderTooltip,
+  metric: MetricId.MOCK_CASES,
+  regionDB,
+};
+
 export const MetricAwareNewYorkWithHighlightedCounty = Template.bind({});
 MetricAwareNewYorkWithHighlightedCounty.args = {
   stateRegionId: "36",

--- a/packages/ui-components/src/components/USMaps/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/USMaps/USStateMap/USStateMap.tsx
@@ -37,6 +37,7 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
     return null;
   }
 
+  const mapSize: [number, number] = [width, height];
   // The geoAlbersUsa projection is designed to show the entire US in a
   // rectangular area with aspect ratio 960x500. With this projection,
   // some states appear "rotated", so we use the Mercator projection to
@@ -46,14 +47,16 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
   // beyond the west edge of the projection, so the math to calculate the
   // parameters to make it fit won't work. We fall back to geoAlbersUsa
   // in this case.
-  const geoProjection = stateGeo.id === "02" ? geoAlbersUsa : geoMercator;
+  //
+  // Note: The geoAlbersUsa projection doesn't define `clipExtent`, so we
+  // can't use it for Alaska.
+  const projection =
+    stateGeo.id === "02"
+      ? geoAlbersUsa().fitSize(mapSize, stateGeo)
+      : geoMercator()
+          .fitSize(mapSize, stateGeo)
+          .clipExtent([[0, 0], mapSize]);
 
-  const projection = geoProjection()
-    .fitSize([width, height], stateGeo)
-    .clipExtent([
-      [0, 0],
-      [width, height],
-    ]);
   const geoPath = d3GeoPath().projection(projection);
 
   const regionsOfState = countiesGeographies.features.filter((geo) =>


### PR DESCRIPTION
In https://github.com/covid-projections/act-now-packages/pull/285, I added a small optimization to the way maps are projected. By adding .clipExtent, we only project map coordinates that will be visible in the map. 

https://github.com/covid-projections/act-now-packages/blob/06cd6e455c77290d8d1f2940e7f9e4afca50eeaf/packages/ui-components/src/components/USMaps/USStateMap/USStateMap.tsx#L51-L56

Unfortunately, the `geoAlbersUsa` projection (which we use for only for Alaska) doesn't implement the `clipExtent` method, so the Alaska map was crashing in the hackathon repo. This PR removes the call to `.clipExtent` for Alaska only (which was already a special case).

<img width="987" alt="image" src="https://user-images.githubusercontent.com/114084/198166731-bd4212f4-737d-406e-b568-4fcca9eef52b.png">
