### PR TITLE
Fix #249: Use p-limit for throttling requests more elegantly.

### DIFF
--- a/.changeset/hot-moons-battle.md
+++ b/.changeset/hot-moons-battle.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/metrics": patch
+---
+
+Use p-limit for throttling CAN API requests more elegantly.

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -36,6 +36,7 @@
     "@types/papaparse": "^5.3.3",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
+    "p-limit": "^3.1.0",
     "p-retry": "^4.6.2",
     "papaparse": "^5.3.2"
   }

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
@@ -53,7 +53,7 @@ export class CovidActNowDataProvider extends CachingMetricDataProviderBase {
     metrics: Metric[],
     includeTimeseries: boolean
   ) {
-    const fetchRegion = async (region: Region) => {
+    const fetchAndCacheRegion = async (region: Region) => {
       const cacheKey = `${region.regionId}-${includeTimeseries}`;
       // If timeseries data exists in the cache, skip the fetch no matter what,
       // as the timeseries endpoints also contain all of the non-timeseries data,
@@ -70,7 +70,7 @@ export class CovidActNowDataProvider extends CachingMetricDataProviderBase {
 
     const limiter = pLimit(MAX_CONCURRENT_REQUESTS);
     await Promise.all(
-      regions.map((region) => limiter(() => fetchRegion(region)))
+      regions.map((region) => limiter(() => fetchAndCacheRegion(region)))
     );
   }
 

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
@@ -1,3 +1,4 @@
+import pLimit from "p-limit";
 import { CachingMetricDataProviderBase } from "./CachingMetricDataProviderBase";
 import { Region } from "@actnowcoalition/regions";
 import { Metric } from "../Metric";
@@ -7,9 +8,11 @@ import {
   dataRowToMetricData,
 } from "./data_provider_utils";
 import { DataRow } from "./data_provider_utils";
-import chunk from "lodash/chunk";
 import { MetricData } from "../data/MetricData";
 import { fetchJson } from "./utils";
+
+// Limit having too many outstanding requests at once, to avoid timeouts, etc.
+const MAX_CONCURRENT_REQUESTS = 50;
 
 /**
  * Data provider to ingest data from the Covid Act Now API.
@@ -50,28 +53,25 @@ export class CovidActNowDataProvider extends CachingMetricDataProviderBase {
     metrics: Metric[],
     includeTimeseries: boolean
   ) {
-    // TODO(#249): This parallelization and retry logic is very crude and should be
-    // cleaned up and generalized, or better yet replaced with some sort of
-    // networking library that handles it for us.
-    const chunks = chunk(regions, 50);
-    for (const chunk of chunks) {
-      await Promise.all(
-        chunk.map(async (region) => {
-          const cacheKey = `${region.regionId}-${includeTimeseries}`;
-          // If timeseries data exists in the cache, skip the fetch no matter what,
-          // as the timeseries endpoints also contain all of the non-timeseries data,
-          // and we will use this data if necessary via the getCachedData method.
-          if (!this.getCachedData(region, includeTimeseries)) {
-            const url = this.buildFetchUrl(region, includeTimeseries);
-            try {
-              this.apiJson[cacheKey] = await fetchJson(url);
-            } catch (e) {
-              console.error(`Failed to fetch data for ${region}: ${e}`);
-            }
-          }
-        })
-      );
-    }
+    const fetchRegion = async (region: Region) => {
+      const cacheKey = `${region.regionId}-${includeTimeseries}`;
+      // If timeseries data exists in the cache, skip the fetch no matter what,
+      // as the timeseries endpoints also contain all of the non-timeseries data,
+      // and we will use this data if necessary via the getCachedData method.
+      if (!this.getCachedData(region, includeTimeseries)) {
+        const url = this.buildFetchUrl(region, includeTimeseries);
+        try {
+          this.apiJson[cacheKey] = await fetchJson(url);
+        } catch (e) {
+          console.error(`Failed to fetch data for ${region}: ${e}`);
+        }
+      }
+    };
+
+    const limiter = pLimit(MAX_CONCURRENT_REQUESTS);
+    await Promise.all(
+      regions.map((region) => limiter(() => fetchRegion(region)))
+    );
   }
 
   getDataFromCache(region: Region, metric: Metric, includeTimeseries: boolean) {

--- a/packages/metrics/yarn.lock
+++ b/packages/metrics/yarn.lock
@@ -73,7 +73,14 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-p-retry@4:
+p-limit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-retry@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
   integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
@@ -113,3 +120,8 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11252,7 +11252,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==


### PR DESCRIPTION
Switch to using the "p-limit" npm module for parallelizing requests to the CAN API, which I think is a bit more elegant and slightly more efficient (we don't wait for all 50 to complete before starting the next batch of 50).

Tested via running `yarn generate-data-snapshot` in hackathon repo.

Fixes #249.