### PR TITLE
AutoWidth in maps, responsive LegendThreshold

### DIFF
--- a/.changeset/hot-ads-suffer.md
+++ b/.changeset/hot-ads-suffer.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Improve responsiveness of maps and legend threshold

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
 import { LegendThreshold } from ".";
 import { LegendThresholdProps } from "./interfaces";
-import { Box } from "@mui/material";
 
 export default {
   title: "Components/LegendThreshold",
@@ -16,14 +15,11 @@ interface Item {
 }
 
 const Template: Story<LegendThresholdProps<Item>> = (args) => (
-  <Box border="1px solid red">
-    <LegendThreshold {...args} />
-  </Box>
+  <LegendThreshold {...args} />
 );
 
 // Horizontal legend threshold props
 const horizontalHeight = 20;
-// const horizontalWidth = 300;
 
 const items: Item[] = [
   { label: "10", sublabel: "Sublabel 1", color: "#90BE6D" },
@@ -43,7 +39,6 @@ const getItemSublabel = (item: Item, itemIndex: number) => item.sublabel;
 export const HorizontalDefault = Template.bind({});
 HorizontalDefault.args = {
   orientation: "horizontal",
-  // width: horizontalWidth,
   height: horizontalHeight,
   items,
   getItemColor,

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
 import { LegendThreshold } from ".";
 import { LegendThresholdProps } from "./interfaces";
+import { Box } from "@mui/material";
 
 export default {
   title: "Components/LegendThreshold",
@@ -15,12 +16,14 @@ interface Item {
 }
 
 const Template: Story<LegendThresholdProps<Item>> = (args) => (
-  <LegendThreshold {...args} />
+  <Box border="1px solid red">
+    <LegendThreshold {...args} />
+  </Box>
 );
 
 // Horizontal legend threshold props
 const horizontalHeight = 20;
-const horizontalWidth = 300;
+// const horizontalWidth = 300;
 
 const items: Item[] = [
   { label: "10", sublabel: "Sublabel 1", color: "#90BE6D" },
@@ -40,7 +43,7 @@ const getItemSublabel = (item: Item, itemIndex: number) => item.sublabel;
 export const HorizontalDefault = Template.bind({});
 HorizontalDefault.args = {
   orientation: "horizontal",
-  width: horizontalWidth,
+  // width: horizontalWidth,
   height: horizontalHeight,
   items,
   getItemColor,

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -4,13 +4,14 @@ import { scaleBand } from "@visx/scale";
 import { TickLabel, TickMark } from "./LegendThreshold.style";
 import { LegendThresholdProps } from "./interfaces";
 import { RectClipGroup } from "../RectClipGroup";
+import { AutoWidth } from "../AutoWidth";
 
 /**
  * `LegendThresholdHorizontal` represents a scale with thresholds that separate
  * a set of categories. By default, the labels between each category are shown.
  */
 
-export const LegendThresholdHorizontal = <T,>({
+export const LegendThresholdHorizontalInner = <T,>({
   height = 20,
   width = 300,
   borderRadius = 10,
@@ -69,3 +70,26 @@ export const LegendThresholdHorizontal = <T,>({
     </svg>
   );
 };
+
+export const LegendThresholdHorizontal = <T,>({
+  ...props
+}: LegendThresholdProps<T> &
+  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
+  return (
+    <AutoWidth>
+      <LegendThresholdHorizontalInner {...props} />
+    </AutoWidth>
+  );
+};
+
+// export const LegendThresholdHorizontal = <T,>({
+//   height = 20,
+//   ...otherSvgProps
+// }: LegendThresholdProps<T> &
+//   Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
+//   return (
+//     <AutoWidth>
+//       <LegendThresholdHorizontalInner height={height} {...otherSvgProps} />
+//     </AutoWidth>
+//   );
+// };

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -81,15 +81,3 @@ export const LegendThresholdHorizontal = <T,>({
     </AutoWidth>
   );
 };
-
-// export const LegendThresholdHorizontal = <T,>({
-//   height = 20,
-//   ...otherSvgProps
-// }: LegendThresholdProps<T> &
-//   Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>) => {
-//   return (
-//     <AutoWidth>
-//       <LegendThresholdHorizontalInner height={height} {...otherSvgProps} />
-//     </AutoWidth>
-//   );
-// };

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -12,19 +12,19 @@ export default {
 } as ComponentMeta<typeof MetricLegendThreshold>;
 
 const Template: Story<MetricLegendThresholdProps> = (args) => (
-  <Paper sx={{ width: 500, padding: 2 }}>
+  <Paper sx={{ p: 2 }}>
     <MetricLegendThreshold {...args} />
   </Paper>
 );
 
 // Horizontal legend threshold props
 const horizontalBarHeight = 20;
-const horizontalWidth = 300;
+// const horizontalWidth = 300;
 
 export const HorizontalDefault = Template.bind({});
 HorizontalDefault.args = {
   orientation: "horizontal",
-  width: horizontalWidth,
+  // width: horizontalWidth,
   height: horizontalBarHeight,
   metric: MetricId.MOCK_CASES,
 };
@@ -47,7 +47,7 @@ HorizontalOnlySideLabels.args = {
 export const HorizontalCategories = Template.bind({});
 HorizontalCategories.args = {
   orientation: "horizontal",
-  width: horizontalWidth,
+  // width: horizontalWidth,
   height: horizontalBarHeight,
   metric: MetricId.PASS_FAIL,
 };

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -19,12 +19,10 @@ const Template: Story<MetricLegendThresholdProps> = (args) => (
 
 // Horizontal legend threshold props
 const horizontalBarHeight = 20;
-// const horizontalWidth = 300;
 
 export const HorizontalDefault = Template.bind({});
 HorizontalDefault.args = {
   orientation: "horizontal",
-  // width: horizontalWidth,
   height: horizontalBarHeight,
   metric: MetricId.MOCK_CASES,
 };
@@ -47,7 +45,6 @@ HorizontalOnlySideLabels.args = {
 export const HorizontalCategories = Template.bind({});
 HorizontalCategories.args = {
   orientation: "horizontal",
-  // width: horizontalWidth,
   height: horizontalBarHeight,
   metric: MetricId.PASS_FAIL,
 };

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Stack, Typography } from "@mui/material";
+import { Stack, Typography, Box } from "@mui/material";
 import { LegendThreshold } from "../LegendThreshold";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { CategoryItem, MetricLegendThresholdProps } from "./interfaces";
@@ -31,20 +31,22 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
 
   if (legendThresholdProps.orientation === "horizontal") {
     return (
-      <Stack spacing={2} alignItems="center">
+      <Stack spacing={2}>
         <Stack spacing={0.5} alignItems="center">
           <Typography variant="labelLarge">{metric.name}</Typography>
           <Typography variant="paragraphSmall">
             {metric.extendedName}
           </Typography>
         </Stack>
-        <Stack direction="row" spacing={1} alignItems="center">
-          {startLabel}
-          <LegendThreshold<CategoryItem>
-            {...commonProps}
-            getItemLabel={getItemLabelHorizontal}
-          />
-          {endLabel}
+        <Stack direction="row" spacing={1}>
+          <Box>{startLabel}</Box>
+          <Box flex={1}>
+            <LegendThreshold<CategoryItem>
+              {...commonProps}
+              getItemLabel={getItemLabelHorizontal}
+            />
+          </Box>
+          <Box>{endLabel}</Box>
         </Stack>
       </Stack>
     );

--- a/packages/ui-components/src/components/USMaps/USNationalMap/USNationalMap.tsx
+++ b/packages/ui-components/src/components/USMaps/USNationalMap/USNationalMap.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ParentSize } from "@visx/responsive";
 import { geoPath as d3GeoPath, geoAlbersUsa } from "d3-geo";
 import {
   defaultHeight,
@@ -11,6 +10,7 @@ import { MapContainer, PositionAbsolute } from "../Maps.style";
 import StatesMap from "./StatesMap";
 import CountiesMap from "./CountiesMap";
 import { USNationalMapProps } from "../interfaces";
+import { AutoWidth } from "../../AutoWidth";
 
 const USNationalMapInner: React.FC<USNationalMapProps> = ({
   width = defaultWidth,
@@ -63,7 +63,7 @@ const USNationalMapInner: React.FC<USNationalMapProps> = ({
 };
 
 export const USNationalMap: React.FC<USNationalMapProps> = (props) => (
-  <ParentSize>
-    {({ width }) => <USNationalMapInner width={width} {...props} />}
-  </ParentSize>
+  <AutoWidth>
+    <USNationalMapInner {...props} />
+  </AutoWidth>
 );

--- a/packages/ui-components/src/components/USMaps/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/USMaps/USStateMap/USStateMap.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Tooltip } from "@mui/material";
-import { ParentSize } from "@visx/responsive";
 import { geoPath as d3GeoPath, geoAlbersUsa, geoMercator } from "d3-geo";
 import {
   statesGeographies,
@@ -16,6 +15,7 @@ import {
   RegionOverlay,
 } from "../Maps.style";
 import { USStateMapProps } from "../interfaces";
+import { AutoWidth } from "../../AutoWidth";
 
 const USStateMapInner: React.FC<USStateMapProps> = ({
   stateRegionId,
@@ -118,7 +118,7 @@ const USStateMapInner: React.FC<USStateMapProps> = ({
 };
 
 export const USStateMap: React.FC<USStateMapProps> = (props) => (
-  <ParentSize>
-    {({ width }) => <USStateMapInner width={width} {...props} />}
-  </ParentSize>
+  <AutoWidth>
+    <USStateMapInner {...props} />
+  </AutoWidth>
 );


### PR DESCRIPTION
- Replaces `ParentSize` with `AutoWidth` in maps
- Makes `LegendThresholdHorizontal` (+ `MetricLegendThresholdHorizontal`) responsive

[LegendThreshold before (non-responsive)](https://act-now-packages.web.app/storybook/?path=/story/components-legendthreshold--horizontal-default)
[LegendThreshold now (responsive, width dependent on parent)](https://act-now-packages--pr349-casulin-autosize-in-pbsrs0jm.web.app/storybook/index.html?path=/story/components-legendthreshold--horizontal-default)

[MetricLegendThresholdHorizontal before (non-responsive)](https://act-now-packages.web.app/storybook/?path=/story/metrics-metriclegendthreshold--horizontal-default)
[MetricLegendThresholdHorizontal now (responsive, width dependent on parent)](https://act-now-packages--pr349-casulin-autosize-in-pbsrs0jm.web.app/storybook/index.html?path=/story/metrics-metriclegendthreshold--horizontal-default)