### PR TITLE
Implement `MetricSeries` chart

### DIFF
--- a/.changeset/bright-hats-clean.md
+++ b/.changeset/bright-hats-clean.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Implement MetricSeriesChart component

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { states } from "@actnowcoalition/regions";
+
+import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
+import { theme } from "../../styles";
+import { MetricSeriesChart, Series, SeriesType } from ".";
+
+export default {
+  title: "Charts/MetricSeriesChart",
+  component: MetricSeriesChart,
+} as ComponentMeta<typeof MetricSeriesChart>;
+
+const width = 800;
+const height = 600;
+
+const Template: ComponentStory<typeof MetricSeriesChart> = (args) => (
+  <MetricSeriesChart {...args} />
+);
+
+const vaccinationSeries: Series[] = [
+  {
+    region: states.findByRegionIdStrict("56"),
+    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+    type: SeriesType.LINE,
+    lineProps: {
+      stroke: theme.palette.gradient[100],
+    },
+  },
+  {
+    region: states.findByRegionIdStrict("53"),
+    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+    type: SeriesType.LINE,
+    lineProps: {
+      stroke: theme.palette.gradient[300],
+    },
+  },
+];
+
+export const Vaccination = Template.bind({});
+Vaccination.args = {
+  series: vaccinationSeries,
+  width,
+  height,
+};

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -5,7 +5,7 @@ import { states } from "@actnowcoalition/regions";
 
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 import { theme } from "../../styles";
-import { MetricSeriesChart, Series, SeriesType } from ".";
+import { MetricSeriesChart, SeriesType } from ".";
 
 export default {
   title: "Charts/MetricSeriesChart",
@@ -64,46 +64,31 @@ TrendsSingleLocation.args = {
   ],
 };
 
-const seriesTrendsMultipleLocations: Series[] = [
-  {
-    region: states.findByRegionIdStrict("36"),
-    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
-    type: SeriesType.LINE,
-    lineProps: {
-      stroke: schemeCategory10[0],
-    },
-  },
-  {
-    region: states.findByRegionIdStrict("56"),
-    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
-    type: SeriesType.LINE,
-    lineProps: {
-      stroke: schemeCategory10[1],
-    },
-  },
-  {
-    region: states.findByRegionIdStrict("18"),
-    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
-    type: SeriesType.LINE,
-    lineProps: {
-      stroke: schemeCategory10[2],
-    },
-  },
-  {
-    region: states.findByRegionIdStrict("32"),
-    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
-    type: SeriesType.LINE,
-    lineProps: {
-      stroke: schemeCategory10[3],
-      strokeDasharray: "4 8",
-      strokeWidth: 4,
-    },
-  },
-];
-
 export const TrendsMultipleLocations = Template.bind({});
 TrendsMultipleLocations.args = {
   width,
   height,
-  series: seriesTrendsMultipleLocations,
+  series: [
+    {
+      region: states.findByRegionIdStrict("36"),
+      metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+      type: SeriesType.LINE,
+      lineProps: { stroke: schemeCategory10[0] },
+    },
+    {
+      region: states.findByRegionIdStrict("56"),
+      metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+      type: SeriesType.LINE,
+      lineProps: { stroke: schemeCategory10[1] },
+    },
+    {
+      region: states.findByRegionIdStrict("18"),
+      metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+      type: SeriesType.LINE,
+      lineProps: {
+        stroke: schemeCategory10[2],
+        strokeDasharray: "4 4",
+      },
+    },
+  ],
 };

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -43,6 +43,21 @@ Vaccination.args = {
   ],
 };
 
+export const NegativeMinValue = Template.bind({});
+NegativeMinValue.args = {
+  width,
+  height,
+  minValue: -10,
+  series: [
+    {
+      region: states.findByRegionIdStrict("56"),
+      metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+      type: SeriesType.LINE,
+      lineProps: { stroke: "#000" },
+    },
+  ],
+};
+
 export const TrendsSingleLocation = Template.bind({});
 TrendsSingleLocation.args = {
   width,

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { schemeCategory10 } from "d3-scale-chromatic";
 import { states } from "@actnowcoalition/regions";
 
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
@@ -18,28 +19,91 @@ const Template: ComponentStory<typeof MetricSeriesChart> = (args) => (
   <MetricSeriesChart {...args} />
 );
 
-const vaccinationSeries: Series[] = [
+export const Vaccination = Template.bind({});
+Vaccination.args = {
+  width,
+  height,
+  series: [
+    {
+      region: states.findByRegionIdStrict("56"),
+      metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+      type: SeriesType.LINE,
+      lineProps: {
+        stroke: theme.palette.gradient[100],
+      },
+    },
+    {
+      region: states.findByRegionIdStrict("53"),
+      metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+      type: SeriesType.LINE,
+      lineProps: {
+        stroke: theme.palette.gradient[300],
+      },
+    },
+  ],
+};
+
+export const TrendsSingleLocation = Template.bind({});
+TrendsSingleLocation.args = {
+  width,
+  height,
+  series: [
+    {
+      region: states.findByRegionIdStrict("53"),
+      metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+      type: SeriesType.BAR,
+    },
+    {
+      region: states.findByRegionIdStrict("53"),
+      metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+      type: SeriesType.LINE,
+      lineProps: {
+        stroke: "black",
+      },
+    },
+  ],
+};
+
+const seriesTrendsMultipleLocations: Series[] = [
+  {
+    region: states.findByRegionIdStrict("36"),
+    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+    type: SeriesType.LINE,
+    lineProps: {
+      stroke: schemeCategory10[0],
+    },
+  },
   {
     region: states.findByRegionIdStrict("56"),
     metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
     type: SeriesType.LINE,
     lineProps: {
-      stroke: theme.palette.gradient[100],
+      stroke: schemeCategory10[1],
     },
   },
   {
-    region: states.findByRegionIdStrict("53"),
+    region: states.findByRegionIdStrict("18"),
     metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
     type: SeriesType.LINE,
     lineProps: {
-      stroke: theme.palette.gradient[300],
+      stroke: schemeCategory10[2],
+    },
+  },
+  {
+    region: states.findByRegionIdStrict("32"),
+    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
+    type: SeriesType.LINE,
+    lineProps: {
+      stroke: schemeCategory10[3],
+      strokeDasharray: "4 8",
+      strokeWidth: 4,
     },
   },
 ];
 
-export const Vaccination = Template.bind({});
-Vaccination.args = {
-  series: vaccinationSeries,
+export const TrendsMultipleLocations = Template.bind({});
+TrendsMultipleLocations.args = {
   width,
   height,
+  series: seriesTrendsMultipleLocations,
 };

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -92,7 +92,7 @@ export const MetricSeriesChart = ({
   });
 
   return (
-    <svg width={width} height={height} style={{ border: "solid 1px #ddd" }}>
+    <svg width={width} height={height}>
       <Group top={marginTop} left={marginLeft}>
         <AxesTimeseries
           yScale={yScale}

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -5,6 +5,7 @@ import { scaleLinear, scaleTime } from "@visx/scale";
 import uniq from "lodash/uniq";
 import min from "lodash/min";
 import max from "lodash/max";
+import isNumber from "lodash/isNumber";
 
 import { assert } from "@actnowcoalition/assert";
 import { Timeseries } from "@actnowcoalition/metrics";
@@ -21,6 +22,8 @@ import { SeriesChart } from "./SeriesChart";
 export interface MetricSeriesChartProps extends BaseChartProps {
   /** */
   series: Series[];
+  /** Minimum value for the y-axis. It defaults to 0. */
+  minValue?: number;
 }
 
 /**
@@ -41,6 +44,7 @@ export const MetricSeriesChart = ({
   marginBottom = 40,
   marginLeft = 70,
   marginRight = 20,
+  minValue = 0,
 }: MetricSeriesChartProps) => {
   // Deduplicate the regions and metrics if necessary
   const regions = uniq(series.map(({ region }) => region));
@@ -69,7 +73,10 @@ export const MetricSeriesChart = ({
   const timeseriesList = seriesList.map(({ timeseries }) => timeseries);
 
   const [minDate, maxDate] = getDateRange(timeseriesList);
-  const [minValue, maxValue] = getValueRange(timeseriesList);
+  const [minDataValue, maxValue] = getValueRange(timeseriesList);
+
+  // Note
+  const minYValue = isNumber(minValue) ? minValue : Math.min(0, minDataValue);
 
   const chartWidth = width - marginLeft - marginRight;
   const chartHeight = height - marginTop - marginBottom;
@@ -80,7 +87,7 @@ export const MetricSeriesChart = ({
   });
 
   const yScale = scaleLinear({
-    domain: [minValue, maxValue],
+    domain: [minYValue, maxValue],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -172,7 +172,7 @@ function getValueRange(timeseriesList: Timeseries<number>[]): [number, number] {
 
   assert(
     typeof minValue === "number" && typeof maxValue === "number",
-    "min and max value"
+    "At least one of the provided timeseries shouldn't be empty"
   );
 
   return [minValue, maxValue];

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -16,11 +16,8 @@ import { BaseChartProps } from "../MetricLineChart";
 import { Series } from "./interfaces";
 import { SeriesChart } from "./SeriesChart";
 
-/**
- *
- */
 export interface MetricSeriesChartProps extends BaseChartProps {
-  /** */
+  /** List of series to be rendered */
   series: Series[];
   /** Minimum value for the y-axis. It defaults to 0. */
   minValue?: number;
@@ -75,7 +72,9 @@ export const MetricSeriesChart = ({
   const [minDate, maxDate] = getDateRange(timeseriesList);
   const [minDataValue, maxValue] = getValueRange(timeseriesList);
 
-  // Note
+  // Note: We use minValue if provided. If not, we default to start from zero,
+  // which is best in most cases, unless minDataValue is negative, in which
+  // case we use that value instead.
   const minYValue = isNumber(minValue) ? minValue : Math.min(0, minDataValue);
 
   const chartWidth = width - marginLeft - marginRight;
@@ -113,17 +112,30 @@ export const MetricSeriesChart = ({
   );
 };
 
+/**
+ * Returns the date range that covers the provided timeseries.
+ *
+ * @param timeseriesList List of timeseries.
+ * @returns [minDate, maxDate]
+ */
 function getDateRange(timeseriesList: Timeseries<unknown>[]): [Date, Date] {
   const minDate = min(timeseriesList.map(({ minDate }) => minDate));
   const maxDate = max(timeseriesList.map(({ maxDate }) => maxDate));
 
   assert(
     minDate instanceof Date && maxDate instanceof Date,
-    "minDate and maxDate should be date"
+    "At least one of the provided timeseries shouldn't be empty"
   );
 
   return [minDate, maxDate];
 }
+
+/**
+ * Returns the range of values that covers the provided timeseries.
+ *
+ * @param timeseriesList List of timeseries.
+ * @returns [minValue, maxValue]
+ */
 function getValueRange(timeseriesList: Timeseries<number>[]): [number, number] {
   const minValue = min(timeseriesList.map(({ minValue }) => minValue));
   const maxValue = max(timeseriesList.map(({ maxValue }) => maxValue));

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { Skeleton } from "@mui/material";
+import { Group } from "@visx/group";
+import { scaleLinear, scaleTime } from "@visx/scale";
+import uniq from "lodash/uniq";
+import min from "lodash/min";
+import max from "lodash/max";
+
+import { assert } from "@actnowcoalition/assert";
+import { Timeseries } from "@actnowcoalition/metrics";
+
+import { useDataForRegionsAndMetrics } from "../../common/hooks";
+import { AxesTimeseries } from "../AxesTimeseries";
+import { BaseChartProps } from "../MetricLineChart";
+import { Series } from "./interfaces";
+import { SeriesChart } from "./SeriesChart";
+
+/**
+ *
+ */
+export interface MetricSeriesChartProps extends BaseChartProps {
+  /** */
+  series: Series[];
+}
+
+/**
+ * Chart that represent multiple (region, metric) combinations in the same
+ * chart. The timeseries will normally share the date span and the units
+ * on the y-axis, they should be comparable. Examples.
+ *
+ * The axis will be calculated from the data. The appearance of each series
+ * depends on its type and other properties passed when creating the series.
+ *
+ * @returns SVG element with the chart.
+ */
+export const MetricSeriesChart = ({
+  series,
+  width,
+  height,
+  marginTop = 10,
+  marginBottom = 40,
+  marginLeft = 70,
+  marginRight = 20,
+}: MetricSeriesChartProps) => {
+  // Deduplicate the regions and metrics if necessary
+  const regions = uniq(series.map(({ region }) => region));
+  const metrics = uniq(series.map(({ metric }) => metric));
+
+  const { data } = useDataForRegionsAndMetrics(
+    regions,
+    metrics,
+    /*includeTimeseries=*/ true
+  );
+
+  if (!data) {
+    return <Skeleton variant="rectangular" width={width} height={height} />;
+  }
+
+  const seriesList = series
+    .filter(({ metric, region }) => data.hasMetricData(region, metric))
+    .map((seriesItem) => ({
+      series: seriesItem,
+      timeseries: data
+        .metricData(seriesItem.region, seriesItem.metric)
+        .timeseries.assertFiniteNumbers(),
+    }))
+    .filter(({ timeseries }) => timeseries.hasData());
+
+  const timeseriesList = seriesList.map(({ timeseries }) => timeseries);
+
+  const [minDate, maxDate] = getDateRange(timeseriesList);
+  const [minValue, maxValue] = getValueRange(timeseriesList);
+
+  const chartWidth = width - marginLeft - marginRight;
+  const chartHeight = height - marginTop - marginBottom;
+
+  const dateScale = scaleTime({
+    domain: [minDate, maxDate],
+    range: [0, chartWidth],
+  });
+
+  const yScale = scaleLinear({
+    domain: [minValue, maxValue],
+    range: [chartHeight, 0],
+  });
+
+  return (
+    <svg width={width} height={height} style={{ border: "solid 1px #ddd" }}>
+      <Group top={marginTop} left={marginLeft}>
+        <AxesTimeseries
+          yScale={yScale}
+          dateScale={dateScale}
+          height={chartHeight}
+        />
+        {seriesList.map((item, itemIndex) => (
+          <SeriesChart
+            key={`series-${itemIndex}`}
+            series={item.series}
+            timeseries={item.timeseries}
+            dateScale={dateScale}
+            yScale={yScale}
+          />
+        ))}
+      </Group>
+    </svg>
+  );
+};
+
+function getDateRange(timeseriesList: Timeseries<unknown>[]): [Date, Date] {
+  const minDate = min(timeseriesList.map(({ minDate }) => minDate));
+  const maxDate = max(timeseriesList.map(({ maxDate }) => maxDate));
+
+  assert(
+    minDate instanceof Date && maxDate instanceof Date,
+    "minDate and maxDate should be date"
+  );
+
+  return [minDate, maxDate];
+}
+function getValueRange(timeseriesList: Timeseries<number>[]): [number, number] {
+  const minValue = min(timeseriesList.map(({ minValue }) => minValue));
+  const maxValue = max(timeseriesList.map(({ maxValue }) => maxValue));
+
+  assert(
+    typeof minValue === "number" && typeof maxValue === "number",
+    "min and max value"
+  );
+
+  return [minValue, maxValue];
+}

--- a/packages/ui-components/src/components/MetricSeriesChart/SeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/SeriesChart.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 import { ScaleTime, ScaleLinear } from "d3-scale";
 import { Timeseries } from "@actnowcoalition/metrics";
-
-import { LineChart } from "../LineChart";
 import { BarChart } from "../BarChart";
+import { LineChart } from "../LineChart";
 import { Series, SeriesType } from "./interfaces";
 
 export interface SeriesChartProps {
+  /** Series to render */
   series: Series;
+  /** Timeseries corresponding to the series */
   timeseries: Timeseries<number>;
+  /** d3-scale to transform point dates to pixel positions on the x-axis */
   dateScale: ScaleTime<number, number>;
+  /** d3-scale to transform point values to pixel positions on the y-axis */
   yScale: ScaleLinear<number, number>;
 }
 
@@ -29,6 +32,7 @@ export const SeriesChart = ({
           {...series.lineProps}
         />
       );
+
     case SeriesType.BAR:
       return (
         <BarChart

--- a/packages/ui-components/src/components/MetricSeriesChart/SeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/SeriesChart.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { ScaleTime, ScaleLinear } from "d3-scale";
+import { Timeseries } from "@actnowcoalition/metrics";
+
+import { LineChart } from "../LineChart";
+import { BarChart } from "../BarChart";
+import { Series, SeriesType } from "./interfaces";
+
+export interface SeriesChartProps {
+  series: Series;
+  timeseries: Timeseries<number>;
+  dateScale: ScaleTime<number, number>;
+  yScale: ScaleLinear<number, number>;
+}
+
+export const SeriesChart = ({
+  series,
+  timeseries,
+  dateScale,
+  yScale,
+}: SeriesChartProps) => {
+  switch (series.type) {
+    case SeriesType.LINE:
+      return (
+        <LineChart
+          timeseries={timeseries}
+          xScale={dateScale}
+          yScale={yScale}
+          {...series.lineProps}
+        />
+      );
+    case SeriesType.BAR:
+      return (
+        <BarChart
+          timeseries={timeseries}
+          xScale={dateScale}
+          yScale={yScale}
+          barWidth={0.5}
+          fill="#ddd"
+        />
+      );
+    default:
+      return <></>;
+  }
+};

--- a/packages/ui-components/src/components/MetricSeriesChart/index.ts
+++ b/packages/ui-components/src/components/MetricSeriesChart/index.ts
@@ -1,0 +1,2 @@
+export * from "./interfaces";
+export * from "./MetricSeriesChart";

--- a/packages/ui-components/src/components/MetricSeriesChart/interfaces.ts
+++ b/packages/ui-components/src/components/MetricSeriesChart/interfaces.ts
@@ -1,0 +1,47 @@
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+import React from "react";
+
+/**
+ *
+ */
+export enum SeriesType {
+  LINE = "LINE",
+  THRESHOLDS = "THRESHOLDS",
+  BAR = "BAR",
+}
+
+interface SeriesBase {
+  metric: Metric;
+  region: Region;
+}
+
+/**
+ *
+ */
+export interface SeriesLine extends SeriesBase {
+  type: SeriesType.LINE;
+  lineProps: Pick<
+    React.SVGProps<SVGPathElement>,
+    "stroke" | "strokeDasharray" | "strokeWidth"
+  >;
+}
+
+/**
+ *
+ */
+export interface SeriesThresholds extends SeriesBase {
+  type: SeriesType.THRESHOLDS;
+}
+
+/**
+ *
+ */
+export interface SeriesBar extends SeriesBase {
+  type: SeriesType.BAR;
+}
+
+/**
+ *
+ */
+export type Series = SeriesLine | SeriesThresholds | SeriesBar;

--- a/packages/ui-components/src/components/MetricSeriesChart/interfaces.ts
+++ b/packages/ui-components/src/components/MetricSeriesChart/interfaces.ts
@@ -1,13 +1,12 @@
+import React from "react";
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import React from "react";
 
 /**
- *
+ * Enum with the types of Series
  */
 export enum SeriesType {
   LINE = "LINE",
-  THRESHOLDS = "THRESHOLDS",
   BAR = "BAR",
 }
 
@@ -17,7 +16,8 @@ interface SeriesBase {
 }
 
 /**
- *
+ * The SeriesLine object will be represented as a line chart. It allows
+ * to customize the line by passing the `lineProps` object.
  */
 export interface SeriesLine extends SeriesBase {
   type: SeriesType.LINE;
@@ -28,20 +28,13 @@ export interface SeriesLine extends SeriesBase {
 }
 
 /**
- *
- */
-export interface SeriesThresholds extends SeriesBase {
-  type: SeriesType.THRESHOLDS;
-}
-
-/**
- *
+ * The SeriesBar object will be represented as a BarChart.
  */
 export interface SeriesBar extends SeriesBase {
   type: SeriesType.BAR;
 }
 
 /**
- *
+ * Series to visually represent timeseries.
  */
-export type Series = SeriesLine | SeriesThresholds | SeriesBar;
+export type Series = SeriesLine | SeriesBar;

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -101,6 +101,7 @@ export * from "./components/MetricLineThresholdChart";
 export * from "./components/MetricMultiProgressBar";
 export * from "./components/MetricOverview";
 export * from "./components/MetricScoreOverview";
+export * from "./components/MetricSeriesChart";
 export * from "./components/MetricSparklines";
 export * from "./components/MetricTooltip";
 export * from "./components/MetricUSMaps";


### PR DESCRIPTION
The MetricSeries component allows to show multiple time series in the same chart. This is only appropriate for time series that share the units on the y-axis (for % of vaccinations, or for normalized metrics such as weekly cases per 100k). A Series object has a type (LINE or BAR), the metric, region and optional props to customize the underlying chart.

**Example** If we want to show a single metric as both a bar chart and a line chart, we can do:

```tsx
const series = [
  {
    region: states.findByRegionIdStrict("53"),
    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
    type: SeriesType.BAR,
  },
  {
    region: states.findByRegionIdStrict("53"),
    metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
    type: SeriesType.LINE,
    lineProps: {
      stroke: "black",
    },
  },
];

// Render the chart
<MetricSeriesChart
  series={series}
  width={width}
  height={height}
/>
```

More examples in storybook.

**Vaccination** 

<img width="769" alt="image" src="https://user-images.githubusercontent.com/114084/199324801-e8d85938-b906-412d-a717-4d0548280669.png">

**Trends Multiple Locations**

<img width="766" alt="image" src="https://user-images.githubusercontent.com/114084/199324741-15ce7cfe-1b08-40a5-9e04-44538a2b8a1f.png">

**Trends Single Locations**

<img width="761" alt="image" src="https://user-images.githubusercontent.com/114084/199324861-7742e47c-4986-4573-b8cf-d60093f6d6a6.png">
