### PR TITLE
Several fixes to MetricSeriesChart

### DIFF
--- a/.changeset/real-brooms-retire.md
+++ b/.changeset/real-brooms-retire.md
@@ -1,0 +1,7 @@
+---
+"@actnowcoalition/ui-components": minor
+---
+
+- `MetricSeriesChart` takes `Metric` or `MetricId`
+- The y-axis on `MetricSeriesChart` takes the format of the metrics in the series list
+- The `SeriesLine.lineProps` attribute is now optional

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -53,7 +53,6 @@ NegativeMinValue.args = {
       region: states.findByRegionIdStrict("56"),
       metric: metricCatalog.getMetric(MetricId.MOCK_CASES),
       type: SeriesType.LINE,
-      lineProps: { stroke: "#000" },
     },
   ],
 };

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -50,8 +50,8 @@ export const MetricSeriesChart = ({
 
   // Deduplicate the regions and metrics if necessary
   const regions = uniq(series.map(({ region }) => region));
-  const metrics = uniq(series.map(({ metric }) => metric)).map((metric) =>
-    metricCatalog.getMetric(metric)
+  const metrics = uniq(
+    series.map(({ metric }) => metricCatalog.getMetric(metric))
   );
 
   assert(

--- a/packages/ui-components/src/components/MetricSeriesChart/interfaces.ts
+++ b/packages/ui-components/src/components/MetricSeriesChart/interfaces.ts
@@ -11,7 +11,7 @@ export enum SeriesType {
 }
 
 interface SeriesBase {
-  metric: Metric;
+  metric: Metric | string;
   region: Region;
 }
 

--- a/packages/ui-components/src/components/MetricSeriesChart/interfaces.ts
+++ b/packages/ui-components/src/components/MetricSeriesChart/interfaces.ts
@@ -21,7 +21,7 @@ interface SeriesBase {
  */
 export interface SeriesLine extends SeriesBase {
   type: SeriesType.LINE;
-  lineProps: Pick<
+  lineProps?: Pick<
     React.SVGProps<SVGPathElement>,
     "stroke" | "strokeDasharray" | "strokeWidth"
   >;

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -3,6 +3,7 @@ import { Stack, Typography, Tooltip, TooltipProps } from "@mui/material";
 import { Metric, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 import { formatDateTime, DateFormat } from "@actnowcoalition/time-utils";
+import { useMetricCatalog } from "../MetricCatalogContext";
 
 export interface MetricTooltipProps extends MetricTooltipContentProps {
   /** Children is the component that, when hovered, should open the tooltip */
@@ -14,21 +15,23 @@ export const MetricTooltip = ({
   region,
   point,
   ...tooltipProps
-}: MetricTooltipProps & Omit<TooltipProps, "title">) => (
-  <Tooltip
-    arrow
-    placement="top"
-    disableInteractive
-    title={
-      <MetricTooltipContent metric={metric} region={region} point={point} />
-    }
-    {...tooltipProps}
-  />
-);
+}: MetricTooltipProps & Omit<TooltipProps, "title">) => {
+  return (
+    <Tooltip
+      arrow
+      placement="top"
+      disableInteractive
+      title={
+        <MetricTooltipContent metric={metric} region={region} point={point} />
+      }
+      {...tooltipProps}
+    />
+  );
+};
 
 export interface MetricTooltipContentProps {
-  /** Metric to use to render the tooltip */
-  metric: Metric;
+  /** Metric or MetricId to use to render the tooltip */
+  metric: Metric | string;
   /** Region to use to render the tooltip */
   region: Region;
   /**
@@ -40,10 +43,12 @@ export interface MetricTooltipContentProps {
 }
 
 export const MetricTooltipContent = ({
-  metric,
+  metric: metricOrId,
   region,
   point,
 }: MetricTooltipContentProps) => {
+  const metricCatalog = useMetricCatalog();
+  const metric = metricCatalog.getMetric(metricOrId);
   return (
     <Stack spacing={0.5}>
       <Typography variant="overline" color="inherit">


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/360

- Update the `Series` interface to take either `Metric` or `MetricId`
- Format the y-axis tick labels on MetricSeriesChart to match the metrics in the series
- Make the `SeriesLine.lineProps` attribute optional 