### PR TITLE
Add keys to WorldMapInner

### DIFF
--- a/.changeset/perfect-ants-act.md
+++ b/.changeset/perfect-ants-act.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Resolve unique key warning in World Map component

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,8 @@
   "plugins": ["react", "@typescript-eslint", "lodash"],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
-    "lodash/import-scope": "warn"
+    "lodash/import-scope": "warn",
+    "react/jsx-key": "error"
   },
   "ignorePatterns": ["!.storybook", "**/dist", "**/lib", "public/**"]
 }

--- a/packages/metrics/src/data_providers/CsvDataProvider.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.ts
@@ -53,6 +53,9 @@ export class CsvDataProvider extends SimpleMetricDataProviderBase {
    * "my-datasource-csv"). This ID can be used from a {@link MetricDataReference} in a
    * metric to reference the data from this provider.
    * @param options Options to configure the provider.
+   * The regionColumn must match the region identifier in Act Now Coalition's regions package.
+   * (e.g. a nation's identifier in the regions package is the ISO 3 code.
+   * So data for a nation must have ISO 3 code as its identifier.)
    */
   constructor(providerId: string, options: CsvDataProviderOptions) {
     assert(

--- a/packages/ui-components/src/components/WorldMap/WorldMap.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.tsx
@@ -49,24 +49,21 @@ const WorldMapInner: React.FC<WorldMapProps> = ({
 
         {/* Style-able nation shapes (ie. colorable by metric) */}
         {countries.features.map((geo) => (
-          <>
-            <path
-              d={geoPath(geo) || ""}
-              fill={getFillColor(`${geo.id}`)}
-              fillOpacity={getFillOpacity(`${geo.id}`)}
-            />
-          </>
+          <path
+            key={geo.id}
+            d={geoPath(geo) || ""}
+            fill={getFillColor(`${geo.id}`)}
+            fillOpacity={getFillOpacity(`${geo.id}`)}
+          />
         ))}
 
         {/* Clickable region overlay */}
         {countries.features.map((geo) => (
-          <>
-            <Tooltip title={renderTooltip(`${geo.id}`) ?? ""}>
-              <Link href={getRegionUrl(`${geo.id}`)}>
-                <RegionOverlay d={geoPath(geo) ?? ""} />
-              </Link>
-            </Tooltip>
-          </>
+          <Tooltip key={geo.id} title={renderTooltip(`${geo.id}`) ?? ""}>
+            <Link href={getRegionUrl(`${geo.id}`)}>
+              <RegionOverlay d={geoPath(geo) ?? ""} />
+            </Link>
+          </Tooltip>
         ))}
 
         {/* Nation Borders */}


### PR DESCRIPTION
Add keys to `WorldMapInner` component to get rid of the following warning.

<img width="617" alt="image" src="https://user-images.githubusercontent.com/46338131/200418034-35fbaa44-228c-402e-bf3b-8de5c08b9bd0.png">

Closes https://github.com/covid-projections/act-now-packages/issues/361