### PR TITLE
Theme defaults

### DIFF
--- a/.changeset/spicy-cheetahs-vanish.md
+++ b/.changeset/spicy-cheetahs-vanish.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Improve implementations of theme colors

--- a/packages/ui-components/src/components/Axis/Axis.style.tsx
+++ b/packages/ui-components/src/components/Axis/Axis.style.tsx
@@ -31,7 +31,7 @@ export const AxisLeft = styled((props: AxisLeftProps) => (
       dx: "-.25em",
       ...baseTickLabelProps,
     })}
-    stroke={theme.palette.border.default}
+    stroke={theme.palette.chart.axis}
     {...props}
   />
 ))``;
@@ -46,7 +46,7 @@ export const AxisBottom = styled((props: AxisBottomProps) => (
       verticalAnchor: "start",
       ...baseTickLabelProps,
     })}
-    stroke={theme.palette.border.default}
+    stroke={theme.palette.chart.axis}
     {...props}
   />
 ))``;

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import { Group } from "@visx/group";
 import { Timeseries } from "@actnowcoalition/metrics";
+import { useTheme } from "@mui/material";
 
 export interface BarChartOwnProps {
   /** Timeseries used to draw the bar chart */
@@ -56,6 +57,7 @@ export const BarChart: React.FC<BarChartProps> = ({
   barWidth = 2,
   ...rectProps
 }) => {
+  const theme = useTheme();
   const [yStart] = yScale.range();
   return (
     <Group>
@@ -68,7 +70,7 @@ export const BarChart: React.FC<BarChartProps> = ({
             y={Math.min(rectY, yStart)}
             width={barWidth}
             height={Math.abs(rectY - yStart)}
-            fill="#000"
+            fill={theme.palette.chart.main}
             {...rectProps}
           />
         );

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -4,6 +4,7 @@ import { curveMonotoneX } from "@visx/curve";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
+import { useTheme } from "@mui/material";
 
 export interface LineChartOwnProps {
   /** Timeseries used to draw the line chart */
@@ -57,12 +58,13 @@ export const LineChart: React.FC<LineChartProps> = ({
   timeseries,
   xScale,
   yScale,
-  stroke = "#000",
+  stroke,
   strokeWidth = 2,
   shapeRendering = "geometricPrecision",
   strokeLinejoin = "round",
   ...otherLineProps
 }) => {
+  const theme = useTheme();
   return (
     <LinePath
       data={timeseries.points}
@@ -71,7 +73,7 @@ export const LineChart: React.FC<LineChartProps> = ({
       curve={curveMonotoneX}
       shapeRendering={shapeRendering}
       strokeLinejoin={strokeLinejoin}
-      stroke={stroke}
+      stroke={stroke ?? theme.palette.chart.main}
       strokeWidth={strokeWidth}
       {...otherLineProps}
     />

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -69,6 +69,10 @@ declare module "@mui/material/styles" {
       400: string;
       500: string;
     };
+    chart: {
+      main: string;
+      axis: string;
+    };
   }
 }
 

--- a/packages/ui-components/src/styles/theme/palette.ts
+++ b/packages/ui-components/src/styles/theme/palette.ts
@@ -32,6 +32,10 @@ const colors = {
     400: "#794DF3",
     500: "#5936B6",
   },
+  common: {
+    black: "black",
+    white: "white",
+  },
 };
 
 const palette = {
@@ -46,8 +50,8 @@ const palette = {
     contrastText: colors.text.light,
   },
   common: {
-    black: "black",
-    white: "white",
+    black: colors.common.black,
+    white: colors.common.white,
   },
   border: {
     default: colors.border.default,
@@ -72,6 +76,10 @@ const palette = {
     300: colors.gradient[300],
     400: colors.gradient[400],
     500: colors.gradient[500],
+  },
+  chart: {
+    main: colors.common.black,
+    axis: colors.border.default,
   },
 };
 

--- a/packages/ui-components/src/styles/theme/palette.ts
+++ b/packages/ui-components/src/styles/theme/palette.ts
@@ -56,7 +56,7 @@ const palette = {
     main: colors.severity[100],
   },
   text: {
-    primary: colors.text.default,
+    primary: colors.text.emphasized,
     secondary: colors.text.deemphasized,
   },
   severity: {

--- a/packages/ui-components/src/styles/theme/typography.ts
+++ b/packages/ui-components/src/styles/theme/typography.ts
@@ -41,21 +41,21 @@ const typography: ExtendedTypographyOptions = {
     fontSize: typographyConstants.fontSizeH1,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   h2: {
     fontSize: typographyConstants.fontSizeH2,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   h3: {
     fontSize: typographyConstants.fontSizeH3,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   /**
@@ -66,21 +66,21 @@ const typography: ExtendedTypographyOptions = {
     fontSize: typographyConstants.fontSizeBase,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   h5: {
     fontSize: typographyConstants.fontSizeBase,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   h6: {
     fontSize: typographyConstants.fontSizeBase,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   labelSmall: {
@@ -88,7 +88,7 @@ const typography: ExtendedTypographyOptions = {
     fontSize: typographyConstants.fontSizePSmall,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightBase,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   labelLarge: {
@@ -96,20 +96,21 @@ const typography: ExtendedTypographyOptions = {
     fontSize: typographyConstants.fontSizeBase,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightBase,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   paragraphSmall: {
     fontFamily: typographyConstants.fontFamily,
     fontSize: typographyConstants.fontSizePSmall,
     lineHeight: typographyConstants.lineHeightSmall,
-    color: palette.secondary.light,
+    color: palette.text.secondary,
   },
 
   paragraphLarge: {
     fontFamily: typographyConstants.fontFamily,
     fontSize: typographyConstants.fontSizeBase,
     lineHeight: typographyConstants.lineHeightBase,
+    color: palette.text.primary,
   },
 
   dataEmphasizedSmall: {
@@ -117,7 +118,7 @@ const typography: ExtendedTypographyOptions = {
     fontSize: typographyConstants.fontSizeDSmall,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   dataEmphasizedLarge: {
@@ -125,7 +126,7 @@ const typography: ExtendedTypographyOptions = {
     fontSize: typographyConstants.fontSizeDLarge,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
   },
 
   dataTabular: {
@@ -133,7 +134,7 @@ const typography: ExtendedTypographyOptions = {
     fontSize: typographyConstants.fontSizePSmall,
     fontWeight: typographyConstants.fontWeightRegular,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.main,
+    color: palette.text.primary,
   },
 
   overline: {
@@ -141,7 +142,7 @@ const typography: ExtendedTypographyOptions = {
     fontSize: typographyConstants.fontSizeOSmall,
     fontWeight: typographyConstants.fontWeightBold,
     lineHeight: typographyConstants.lineHeightMedium,
-    color: palette.secondary.dark,
+    color: palette.text.primary,
     textTransform: "uppercase",
   },
 };

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-0.1.0.tgz#fa83caa21c419f20d7be7c10dafd70986613e6a0"
   integrity sha512-8dBa6CHFDuY/jAVtazVCDSl9796gaOLmsdMFX+uGBwQruEWpCq2jOkf/wvLypt9eoE+Dzi63Q5zbOIVXmlQRtQ==
 
-"@actnowcoalition/metrics@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.3.1.tgz#70fb5883bd87f4f942e12e342c92a0d4df887e4a"
-  integrity sha512-jKOG0yHphvsnAj8opi9P4A++hUb4IyqJM0BAKRMxCIitNzd/kh5P6vNpkgUg+cke7gyZGYYsE6GTavVZQNWBJw==
+"@actnowcoalition/metrics@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.3.2.tgz#d09c668cc24202051231b0495cead23f2f5b6566"
+  integrity sha512-ShigCR7/UL/YDKoEwANGVark/tAqeIqSaR0bSg1hUCIW6sE5/SBAo/azcd+e51fGR6W9/MML2eTDDGaMZnTVTg==
   dependencies:
     "@actnowcoalition/assert" "^0.1.0"
     "@actnowcoalition/number-format" "^0.1.1"
@@ -19,6 +19,8 @@
     "@types/papaparse" "^5.3.3"
     lodash "^4.17.21"
     node-fetch "^2.6.7"
+    p-limit "^3.1.0"
+    p-retry "^4.6.2"
     papaparse "^5.3.2"
 
 "@actnowcoalition/number-format@^0.1.1":
@@ -2950,6 +2952,11 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/scheduler@*":
   version "0.16.2"
@@ -8443,7 +8450,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -8489,6 +8496,14 @@ p-map@^4.0.0:
   integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-retry@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
 
 p-timeout@^3.1.0:
   version "3.2.0"
@@ -9560,6 +9575,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Partial solution for #368 

During the hackathon, we learned that some elements (chart lines, text, axes) assumed white backgrounds in their styling and were hard to configure for dark mode.

This PR [adds 2 variables to our palette module](https://github.com/covid-projections/act-now-packages/pull/372/files#diff-e8db90eaf056409aa60f99ae7e58bc599864cd6e284b72fcade7570c4697b1f8R72-R75), `chart.main` (applied to lines in line charts and bars in bar charts) and `chart.axis` (applied to chart axes) so that these color defaults can be controlled at the theme level in a single location. This PR also changes the typography object to reference `palette.text.{primary/secondary}`, so these defaults also can be controlled at the theme level in a single location.

Still to do:
`palette.text` only allows for `primary` and `secondary`, which is incompatible with our design system having 3 text colors. We need to edit the theme module for the text property to allow a third option