### PR TITLE
Fix timezone issues in charts

### DIFF
--- a/.changeset/short-ducks-vanish.md
+++ b/.changeset/short-ducks-vanish.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix a timezone issue in charts with a time-based axis'

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,19 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "lodash/import-scope": "warn",
-    "react/jsx-key": "error"
+    "react/jsx-key": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@visx/scale",
+            "importNames": ["scaleTime"],
+            "message": "Using 'scaleTime' can cause off-by-one errors when rendering tooltips and axes. Use 'scaleUtc' instead."
+          }
+        ]
+      }
+    ]
   },
   "ignorePatterns": ["!.storybook", "**/dist", "**/lib", "public/**"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,11 @@
             "name": "@visx/scale",
             "importNames": ["scaleTime"],
             "message": "Using 'scaleTime' can cause off-by-one errors when rendering tooltips and axes. Use 'scaleUtc' instead."
+          },
+          {
+            "name": "@actnowcoalition/time-utils",
+            "importNames": ["formatDateTime"],
+            "message": "Using 'formatDateTime' can cause off-by-one errors when rendering tooltips and axes. Use 'formatUTCDateTime' instead."
           }
         ]
       }

--- a/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
+++ b/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Story, ComponentMeta } from "@storybook/react";
-import { scaleLinear, scaleTime } from "@visx/scale";
+import { scaleLinear, scaleUtc } from "@visx/scale";
 import { AxesTimeseries, AxesTimeseriesProps } from "./AxesTimeseries";
 import { Group } from "@visx/group";
 import { formatPercent } from "@actnowcoalition/number-format";
@@ -15,8 +15,8 @@ const margin = 50;
 const chartWidth = width - 2 * margin;
 const chartHeight = height - 2 * margin;
 
-const dateScale = scaleTime({
-  domain: [new Date("2022-01-01"), new Date()],
+const dateScale = scaleUtc({
+  domain: [new Date("2022-01-01"), new Date("2022-10-31")],
   range: [0, chartWidth],
 });
 

--- a/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { scaleTime, scaleLinear } from "@visx/scale";
+import { scaleUtc, scaleLinear } from "@visx/scale";
 import { AxisBottom, AxisBottomProps } from ".";
 import { isOverTwoMonths, getNumTicks, formatDateTick } from "./utils";
 import { AutoWidth } from "../AutoWidth";
@@ -30,7 +30,7 @@ const ChartBottomAxis: React.FC<AxisBottomProps> = (args) => {
             {...commonProps}
             scale={
               isTimeSeries
-                ? scaleTime({
+                ? scaleUtc({
                     domain: [start, end],
                     range: [0, args.width - 2 * padding],
                   })
@@ -68,35 +68,35 @@ Units.args = {
 
 export const TwoYears = Template.bind({});
 TwoYears.args = {
-  scale: scaleTime({
+  scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2022-12-31")],
   }),
 };
 
 export const OneYear = Template.bind({});
 OneYear.args = {
-  scale: scaleTime({
+  scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2021-12-31")],
   }),
 };
 
 export const SixMonths = Template.bind({});
 SixMonths.args = {
-  scale: scaleTime({
+  scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2021-06-30")],
   }),
 };
 
 export const OneMonth = Template.bind({});
 OneMonth.args = {
-  scale: scaleTime({
+  scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2021-01-31")],
   }),
 };
 
 export const TenDays = Template.bind({});
 TenDays.args = {
-  scale: scaleTime({
+  scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2021-01-10")],
   }),
 };

--- a/packages/ui-components/src/components/Axis/utils.tsx
+++ b/packages/ui-components/src/components/Axis/utils.tsx
@@ -1,6 +1,6 @@
 import {
   DateFormat,
-  formatDateTime,
+  formatUTCDateTime,
   getTimeDiff,
   TimeUnit,
 } from "@actnowcoalition/time-utils";
@@ -29,7 +29,7 @@ export function formatDateTick(date: Date, isOverTwoMonths: boolean): string {
   if (isOverTwoMonths) {
     // To-do (Fai): Add month and year separated by apostrophe as a date format.
     return date.getMonth() === 0
-      ? formatDateTime(date, DateFormat.MMM_YY)
-      : formatDateTime(date, DateFormat.MMM);
-  } else return formatDateTime(date, DateFormat.MMM_D);
+      ? formatUTCDateTime(date, DateFormat.MMM_YY)
+      : formatUTCDateTime(date, DateFormat.MMM);
+  } else return formatUTCDateTime(date, DateFormat.MMM_D);
 }

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -30,7 +30,7 @@ export type LineChartProps = LineChartOwnProps &
  *
  * @example
  * ```tsx
- * const xScale = scaleTime({ domain: [minDate, maxDate], range: [0, 200] });
+ * const xScale = scaleUtc({ domain: [minDate, maxDate], range: [0, 200] });
  * const yScale = scaleLinear({ domain: [minVal, maxVal], range: [100, 0] });
  *
  * return (

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { scaleLinear, scaleTime } from "@visx/scale";
+import { scaleLinear, scaleUtc } from "@visx/scale";
 import { Group } from "@visx/group";
 import { useData } from "../../common/hooks";
 import { AxesTimeseries } from "../AxesTimeseries";
@@ -38,7 +38,7 @@ export const MetricLineChart: React.FC<MetricLineChartProps> = ({
 
   const { minDate, maxDate, maxValue } = timeseries;
 
-  const dateScale = scaleTime({
+  const dateScale = scaleUtc({
     domain: [minDate, maxDate],
     range: [0, chartWidth],
   });

--- a/packages/ui-components/src/components/MetricLineChart/TimeseriesLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/TimeseriesLineChart.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { TimeseriesLineChartProps } from "./interfaces";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import { Group } from "@visx/group";
 import { LineChart } from "../LineChart";
 import { AxesTimeseries } from "../AxesTimeseries";
-import { scaleLinear, scaleTime } from "@visx/scale";
-import { Group } from "@visx/group";
+import { TimeseriesLineChartProps } from "./interfaces";
 
 export const TimeseriesLineChart: React.FC<TimeseriesLineChartProps> = ({
   width,
@@ -19,7 +19,7 @@ export const TimeseriesLineChart: React.FC<TimeseriesLineChartProps> = ({
 
   const { minDate, maxDate, maxValue } = timeseries;
 
-  const dateScale = scaleTime({
+  const dateScale = scaleUtc({
     domain: [minDate, maxDate],
     range: [0, chartWidth],
   });

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { scaleLinear, scaleTime } from "@visx/scale";
+import { scaleLinear, scaleUtc } from "@visx/scale";
 import { Group } from "@visx/group";
 import max from "lodash/max";
 import { assert } from "@actnowcoalition/assert";
@@ -72,7 +72,7 @@ export const MetricLineThresholdChart = ({
     maxValue
   );
 
-  const dateScale = scaleTime({
+  const dateScale = scaleUtc({
     domain: [minDate, maxDate],
     range: [0, chartWidth],
   });

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Skeleton } from "@mui/material";
 import { Group } from "@visx/group";
-import { scaleLinear, scaleTime } from "@visx/scale";
+import { scaleLinear, scaleUtc } from "@visx/scale";
 import uniq from "lodash/uniq";
 import min from "lodash/min";
 import max from "lodash/max";
@@ -97,7 +97,7 @@ export const MetricSeriesChart = ({
   const chartWidth = width - marginLeft - marginRight;
   const chartHeight = height - marginTop - marginBottom;
 
-  const dateScale = scaleTime({
+  const dateScale = scaleUtc({
     domain: [minDate, maxDate],
     range: [0, chartWidth],
   });

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Stack, Typography, Tooltip, TooltipProps } from "@mui/material";
 import { Metric, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import { formatDateTime, DateFormat } from "@actnowcoalition/time-utils";
+import { formatUTCDateTime, DateFormat } from "@actnowcoalition/time-utils";
 import { useMetricCatalog } from "../MetricCatalogContext";
 
 export interface MetricTooltipProps extends MetricTooltipContentProps {
@@ -52,7 +52,7 @@ export const MetricTooltipContent = ({
   return (
     <Stack spacing={0.5}>
       <Typography variant="overline" color="inherit">
-        {formatDateTime(point.date, DateFormat.MMMM_D_YYYY)}
+        {formatUTCDateTime(point.date, DateFormat.MMMM_D_YYYY)}
       </Typography>
       <Typography variant="overline" color="inherit">
         {metric.name}

--- a/packages/ui-components/src/stories/mockData.ts
+++ b/packages/ui-components/src/stories/mockData.ts
@@ -1,5 +1,5 @@
 import { appleStock } from "@visx/mock-data";
-import { scaleLinear, scaleTime } from "@visx/scale";
+import { scaleLinear, scaleUtc } from "@visx/scale";
 import { assert } from "@actnowcoalition/assert";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 
@@ -27,7 +27,7 @@ export function createTimeseriesScales(
   assert(timeseries.hasData(), "Timeseries cannot be empty");
   const { minDate, maxDate, minValue, maxValue } = timeseries;
 
-  const xScale = scaleTime({
+  const xScale = scaleUtc({
     domain: [minDate, maxDate],
     range: [0, width],
   });


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/367

There were a few things that needed to be fixed for this problem to go away.

- We need to use `formatUTCDateTime` instead of `formatDateTime` for tooltips and axes
- We need to use `scaleUtc` instead of `scaleTime` to interpret and render times as UTC times

I added an ESLint rule to prevent us form using `scaleTime` from `@visx/scale` and using `scaleUtc` instead (also for `formatDateTime` and `formatUTCDateTime`), which is what we want in most (if not all) cases, we can disable the rule in specific cases if needed.


**Before** - Note the space before _Jan 1_, that's the timezone offset

<img width="885" alt="image" src="https://user-images.githubusercontent.com/114084/200644927-75081cbe-4f88-4704-95c3-b230209c6b3d.png">


**After** - No timezone offset

<img width="920" alt="image" src="https://user-images.githubusercontent.com/114084/200644845-995cdb6b-1ef6-4946-9868-c2f74ffb0c7c.png">
