### PR TITLE
Remove redundant extended name from metric legend

### DIFF
--- a/.changeset/tricky-experts-develop.md
+++ b/.changeset/tricky-experts-develop.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Remove redundant extended name from metric legend

--- a/.changeset/tricky-experts-develop.md
+++ b/.changeset/tricky-experts-develop.md
@@ -2,4 +2,4 @@
 "@actnowcoalition/ui-components": patch
 ---
 
-Remove redundant extended name from metric legend
+Default metric's extended name to empty string

--- a/packages/metrics/src/Metric/Metric.ts
+++ b/packages/metrics/src/Metric/Metric.ts
@@ -75,7 +75,7 @@ export class Metric {
     this.id = def.id;
     this.dataReference = def.dataReference;
     this.name = def.name ?? `${this.id}`;
-    this.extendedName = def.extendedName ?? this.name;
+    this.extendedName = def.extendedName ?? "";
     this.categorySetId = def.categorySetId;
     this.categoryThresholds =
       (def.categoryThresholds ?? []).length > 0

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
@@ -28,3 +28,15 @@ Vertical.args = {
   metric: MetricId.PASS_FAIL,
   orientation: "vertical",
 };
+
+export const HorizontalNoExtendedName = Template.bind({});
+HorizontalNoExtendedName.args = {
+  metric: MetricId.PASS_FAIL_NO_EXTENDED_NAME,
+  orientation: "horizontal",
+};
+
+export const VerticalNoExtendedName = Template.bind({});
+VerticalNoExtendedName.args = {
+  metric: MetricId.PASS_FAIL_NO_EXTENDED_NAME,
+  orientation: "vertical",
+};

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
@@ -30,13 +30,11 @@ const MetricLegendCategorical = ({
     "Metric must define categories in order to use MetricLegendCategorical. " +
       `No categories found for metric: ${metric}`
   );
-  const metricHasUniqueExtendedName =
-    metric.name !== metric.extendedName || metric.extendedName.length === 0;
   return (
     <Stack spacing={2}>
       <Stack spacing={0.5}>
         <Typography variant="labelLarge">{metric.name}</Typography>
-        {metricHasUniqueExtendedName && (
+        {metric.extendedName && (
           <Typography variant="paragraphSmall">
             {metric.extendedName}
           </Typography>

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
@@ -30,12 +30,17 @@ const MetricLegendCategorical = ({
     "Metric must define categories in order to use MetricLegendCategorical. " +
       `No categories found for metric: ${metric}`
   );
-
+  const metricHasUniqueExtendedName =
+    metric.name !== metric.extendedName || metric.extendedName.length === 0;
   return (
     <Stack spacing={2}>
       <Stack spacing={0.5}>
         <Typography variant="labelLarge">{metric.name}</Typography>
-        <Typography variant="paragraphSmall">{metric.extendedName}</Typography>
+        {metricHasUniqueExtendedName && (
+          <Typography variant="paragraphSmall">
+            {metric.extendedName}
+          </Typography>
+        )}
       </Stack>
       <LegendCategorical
         items={items}

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -27,6 +27,13 @@ HorizontalDefault.args = {
   metric: MetricId.MOCK_CASES,
 };
 
+export const HorizontalNoExtendedName = Template.bind({});
+HorizontalNoExtendedName.args = {
+  orientation: "horizontal",
+  height: horizontalBarHeight,
+  metric: MetricId.MOCK_CASES_NO_EXTENDED_NAME,
+};
+
 export const HorizontalNoLabels = Template.bind({});
 HorizontalNoLabels.args = {
   ...HorizontalDefault.args,
@@ -53,6 +60,12 @@ export const VerticalDefault = Template.bind({});
 VerticalDefault.args = {
   orientation: "vertical",
   metric: MetricId.MOCK_CASES,
+};
+
+export const VerticalNoExtendedName = Template.bind({});
+VerticalNoExtendedName.args = {
+  orientation: "vertical",
+  metric: MetricId.MOCK_CASES_NO_EXTENDED_NAME,
 };
 
 export const VerticalCategories = Template.bind({});

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -25,9 +25,6 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
   // Common props regardless of horizontal / vertical orientation
   const commonProps = { items, getItemColor, ...legendThresholdProps };
 
-  const metricHasUniqueExtendedName =
-    metric.name !== metric.extendedName || metric.extendedName.length === 0;
-
   if (!includeOverview) {
     return <LegendThreshold {...commonProps} />;
   }
@@ -37,7 +34,7 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
       <Stack spacing={2}>
         <Stack spacing={0.5} alignItems="center">
           <Typography variant="labelLarge">{metric.name}</Typography>
-          {metricHasUniqueExtendedName && (
+          {metric.extendedName && (
             <Typography variant="paragraphSmall">
               {metric.extendedName}
             </Typography>
@@ -60,7 +57,7 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
       <Stack spacing={3}>
         <Stack spacing={0.5}>
           <Typography variant="labelLarge">{metric.name}</Typography>
-          {metricHasUniqueExtendedName && (
+          {metric.extendedName && (
             <Typography variant="paragraphSmall">
               {metric.extendedName}
             </Typography>

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -25,6 +25,9 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
   // Common props regardless of horizontal / vertical orientation
   const commonProps = { items, getItemColor, ...legendThresholdProps };
 
+  const metricHasUniqueExtendedName =
+    metric.name !== metric.extendedName || metric.extendedName.length === 0;
+
   if (!includeOverview) {
     return <LegendThreshold {...commonProps} />;
   }
@@ -34,9 +37,11 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
       <Stack spacing={2}>
         <Stack spacing={0.5} alignItems="center">
           <Typography variant="labelLarge">{metric.name}</Typography>
-          <Typography variant="paragraphSmall">
-            {metric.extendedName}
-          </Typography>
+          {metricHasUniqueExtendedName && (
+            <Typography variant="paragraphSmall">
+              {metric.extendedName}
+            </Typography>
+          )}
         </Stack>
         <Stack direction="row" spacing={1}>
           <Box>{startLabel}</Box>
@@ -55,9 +60,11 @@ export const MetricLegendThreshold: React.FC<MetricLegendThresholdProps> = ({
       <Stack spacing={3}>
         <Stack spacing={0.5}>
           <Typography variant="labelLarge">{metric.name}</Typography>
-          <Typography variant="paragraphSmall">
-            {metric.extendedName}
-          </Typography>
+          {metricHasUniqueExtendedName && (
+            <Typography variant="paragraphSmall">
+              {metric.extendedName}
+            </Typography>
+          )}
         </Stack>
         <Stack direction="column" spacing={1}>
           {startLabel}

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -56,7 +56,6 @@ const testMetricDefs: MetricDefinition[] = [
   {
     id: MetricId.MOCK_CASES_NO_EXTENDED_NAME,
     name: "Cases (mock)",
-    extendedName: "",
     dataReference: {
       providerId: ProviderId.MOCK,
       startDate: "2020-01-01",
@@ -78,7 +77,6 @@ const testMetricDefs: MetricDefinition[] = [
   {
     id: MetricId.PASS_FAIL_NO_EXTENDED_NAME,
     name: "Pass or Fail",
-    extendedName: "",
     dataReference: {
       providerId: ProviderId.STATIC,
       value: 0,

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -13,6 +13,7 @@ export enum MetricId {
   MOCK_CASES = "mock_cases",
   MOCK_CASES_NO_EXTENDED_NAME = "mock_cases_no_extended_name",
   PASS_FAIL = "pass_fail",
+  PASS_FAIL_NO_EXTENDED_NAME = "pass_fail_no_extended_name",
 }
 
 export enum ProviderId {
@@ -67,6 +68,17 @@ const testMetricDefs: MetricDefinition[] = [
     id: MetricId.PASS_FAIL,
     name: "Pass or Fail",
     extendedName: "Passing or Failing grade on an arbitrary test",
+    dataReference: {
+      providerId: ProviderId.STATIC,
+      value: 0,
+    },
+    categorySetId: "pass_fail",
+    categoryValues: [0, 1],
+  },
+  {
+    id: MetricId.PASS_FAIL_NO_EXTENDED_NAME,
+    name: "Pass or Fail",
+    extendedName: "",
     dataReference: {
       providerId: ProviderId.STATIC,
       value: 0,


### PR DESCRIPTION
This PR defaults a metric's extended name to an empty string.

Closes https://github.com/covid-projections/act-now-packages/issues/364