### PR TITLE
Demo: Controlling the state of CompareTable with a reducer

### DIFF
--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -12,7 +12,7 @@ import {
   compare,
   TableContainer,
 } from ".";
-import { Action, ActionType, SortState, useSortableTable } from "./utils";
+import { useSortableTable, SortControl } from "./utils";
 
 export default {
   title: "Table/CompareTable",
@@ -30,9 +30,8 @@ const rows: RowItem[] = states.all
 
 const StatefulCompareTable: React.FC<{
   rows: RowItem[];
-  dispatch: React.Dispatch<Action>;
-  state: SortState;
-}> = ({ dispatch, state }) => {
+  sortControl: SortControl;
+}> = ({ sortControl }) => {
   const columns: ColumnDefinition<RowItem>[] = [
     {
       columnId: "name",
@@ -138,12 +137,11 @@ const StatefulCompareTable: React.FC<{
     },
   ];
 
-  const sortColumnId = state.columnId;
-  const sortDirection = state.sortDirection;
+  const sortColumnId = sortControl.sortColumnId;
+  const sortDirection = sortControl.sortDirection;
 
   const onClickSort = (direction: SortDirection, columnId: string) => {
-    dispatch({ type: ActionType.SET_SORTING_COLUMN, columnId });
-    dispatch({ type: ActionType.SET_SORT_DIRECTION, sortDirection: direction });
+    sortControl.setSorting(columnId, direction);
   };
 
   return (
@@ -164,23 +162,16 @@ export const Example = () => {
     sortDirection: SortDirection.ASC,
   };
 
-  const [state, dispatch] = useSortableTable(initialState);
+  const sortControl = useSortableTable(initialState);
 
   return (
     <>
-      <Button
-        onClick={() =>
-          dispatch({
-            type: ActionType.SET_SORTING_COLUMN,
-            columnId: "population",
-          })
-        }
-      >
+      <Button onClick={() => sortControl.setSortingColumn("population")}>
         Sort By Population
       </Button>
 
       <TableContainer sx={{ maxWidth: 400, height: 600 }}>
-        <StatefulCompareTable rows={rows} dispatch={dispatch} state={state} />
+        <StatefulCompareTable rows={rows} sortControl={sortControl} />
       </TableContainer>
     </>
   );

--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { ComponentMeta } from "@storybook/react";
-import { Typography } from "@mui/material";
+import { Button, Typography } from "@mui/material";
 import { formatInteger } from "@actnowcoalition/number-format";
 import { states, Region } from "@actnowcoalition/regions";
 import {
@@ -12,6 +12,7 @@ import {
   compare,
   TableContainer,
 } from ".";
+import { Action, ActionType, SortState, useSortableTable } from "./utils";
 
 export default {
   title: "Table/CompareTable",
@@ -29,7 +30,9 @@ const rows: RowItem[] = states.all
 
 const StatefulCompareTable: React.FC<{
   rows: RowItem[];
-}> = () => {
+  dispatch: React.Dispatch<Action>;
+  state: SortState;
+}> = ({ dispatch, state }) => {
   const columns: ColumnDefinition<RowItem>[] = [
     {
       columnId: "name",
@@ -135,28 +138,50 @@ const StatefulCompareTable: React.FC<{
     },
   ];
 
-  const [sortColumnId, setSortColumnId] = useState(columns[0].columnId);
-  const [sortDirection, setSortDirection] = useState(SortDirection.ASC);
+  const sortColumnId = state.columnId;
+  const sortDirection = state.sortDirection;
 
   const onClickSort = (direction: SortDirection, columnId: string) => {
-    setSortColumnId(columnId);
-    setSortDirection(direction);
+    dispatch({ type: ActionType.SET_SORTING_COLUMN, columnId });
+    dispatch({ type: ActionType.SET_SORT_DIRECTION, sortDirection: direction });
   };
 
   return (
-    <CompareTable
-      rows={rows}
-      columns={columns}
-      sortColumnId={sortColumnId}
-      sortDirection={sortDirection}
-    />
+    <>
+      <CompareTable
+        rows={rows}
+        columns={columns}
+        sortColumnId={sortColumnId}
+        sortDirection={sortDirection}
+      />
+    </>
   );
 };
 
 export const Example = () => {
+  const initialState = {
+    columnId: "name",
+    sortDirection: SortDirection.ASC,
+  };
+
+  const [state, dispatch] = useSortableTable(initialState);
+
   return (
-    <TableContainer sx={{ maxWidth: 400, height: 600 }}>
-      <StatefulCompareTable rows={rows} />
-    </TableContainer>
+    <>
+      <Button
+        onClick={() =>
+          dispatch({
+            type: ActionType.SET_SORTING_COLUMN,
+            columnId: "population",
+          })
+        }
+      >
+        Sort By Population
+      </Button>
+
+      <TableContainer sx={{ maxWidth: 400, height: 600 }}>
+        <StatefulCompareTable rows={rows} dispatch={dispatch} state={state} />
+      </TableContainer>
+    </>
   );
 };

--- a/packages/ui-components/src/components/CompareTable/utils.ts
+++ b/packages/ui-components/src/components/CompareTable/utils.ts
@@ -9,11 +9,17 @@ export interface SortState {
 export enum ActionType {
   SET_SORTING_COLUMN = "SET_SORT_COLUMN",
   SET_SORT_DIRECTION = "SET_SORT_DIRECTION",
+  SET_SORTING = "SET_SORTING",
 }
 
 export type Action =
   | { type: ActionType.SET_SORTING_COLUMN; columnId: string }
-  | { type: ActionType.SET_SORT_DIRECTION; sortDirection: SortDirection };
+  | { type: ActionType.SET_SORT_DIRECTION; sortDirection: SortDirection }
+  | {
+      type: ActionType.SET_SORTING;
+      columnId: string;
+      sortDirection: SortDirection;
+    };
 
 const sortableTableReducer: Reducer<SortState, Action> = (
   prevState,
@@ -24,6 +30,12 @@ const sortableTableReducer: Reducer<SortState, Action> = (
       return { ...prevState, columnId: action.columnId };
     case ActionType.SET_SORT_DIRECTION:
       return { ...prevState, sortDirection: action.sortDirection };
+    case ActionType.SET_SORTING:
+      return {
+        ...prevState,
+        columnId: action.columnId,
+        sortDirection: action.sortDirection,
+      };
     default:
       return prevState;
   }

--- a/packages/ui-components/src/components/CompareTable/utils.ts
+++ b/packages/ui-components/src/components/CompareTable/utils.ts
@@ -14,12 +14,7 @@ export enum ActionType {
 
 export type Action =
   | { type: ActionType.SET_SORTING_COLUMN; columnId: string }
-  | { type: ActionType.SET_SORT_DIRECTION; sortDirection: SortDirection }
-  | {
-      type: ActionType.SET_SORTING;
-      columnId: string;
-      sortDirection: SortDirection;
-    };
+  | { type: ActionType.SET_SORT_DIRECTION; sortDirection: SortDirection };
 
 const sortableTableReducer: Reducer<SortState, Action> = (
   prevState,
@@ -30,12 +25,6 @@ const sortableTableReducer: Reducer<SortState, Action> = (
       return { ...prevState, columnId: action.columnId };
     case ActionType.SET_SORT_DIRECTION:
       return { ...prevState, sortDirection: action.sortDirection };
-    case ActionType.SET_SORTING:
-      return {
-        ...prevState,
-        columnId: action.columnId,
-        sortDirection: action.sortDirection,
-      };
     default:
       return prevState;
   }

--- a/packages/ui-components/src/components/CompareTable/utils.ts
+++ b/packages/ui-components/src/components/CompareTable/utils.ts
@@ -1,0 +1,34 @@
+import { Reducer, useReducer } from "react";
+import { SortDirection } from "./interfaces";
+
+export interface SortState {
+  columnId: string;
+  sortDirection: SortDirection;
+}
+
+export enum ActionType {
+  SET_SORTING_COLUMN = "SET_SORT_COLUMN",
+  SET_SORT_DIRECTION = "SET_SORT_DIRECTION",
+}
+
+export type Action =
+  | { type: ActionType.SET_SORTING_COLUMN; columnId: string }
+  | { type: ActionType.SET_SORT_DIRECTION; sortDirection: SortDirection };
+
+const sortableTableReducer: Reducer<SortState, Action> = (
+  prevState,
+  action
+) => {
+  switch (action.type) {
+    case ActionType.SET_SORTING_COLUMN:
+      return { ...prevState, columnId: action.columnId };
+    case ActionType.SET_SORT_DIRECTION:
+      return { ...prevState, sortDirection: action.sortDirection };
+    default:
+      return prevState;
+  }
+};
+
+export function useSortableTable(initialState: SortState) {
+  return useReducer(sortableTableReducer, initialState);
+}

--- a/packages/ui-components/src/components/CompareTable/utils.ts
+++ b/packages/ui-components/src/components/CompareTable/utils.ts
@@ -14,7 +14,12 @@ export enum ActionType {
 
 export type Action =
   | { type: ActionType.SET_SORTING_COLUMN; columnId: string }
-  | { type: ActionType.SET_SORT_DIRECTION; sortDirection: SortDirection };
+  | { type: ActionType.SET_SORT_DIRECTION; sortDirection: SortDirection }
+  | {
+      type: ActionType.SET_SORTING;
+      columnId: string;
+      sortDirection: SortDirection;
+    };
 
 const sortableTableReducer: Reducer<SortState, Action> = (
   prevState,
@@ -25,11 +30,39 @@ const sortableTableReducer: Reducer<SortState, Action> = (
       return { ...prevState, columnId: action.columnId };
     case ActionType.SET_SORT_DIRECTION:
       return { ...prevState, sortDirection: action.sortDirection };
+    case ActionType.SET_SORTING:
+      return {
+        ...prevState,
+        columnId: action.columnId,
+        sortDirection: action.sortDirection,
+      };
     default:
       return prevState;
   }
 };
 
-export function useSortableTable(initialState: SortState) {
-  return useReducer(sortableTableReducer, initialState);
+export interface SortControl {
+  sortColumnId: string;
+  sortDirection: SortDirection;
+  setSortDirection: (sortDirection: SortDirection) => void;
+  setSortingColumn: (columnId: string) => void;
+  setSorting: (columnId: string, sortDirection: SortDirection) => void;
+}
+
+export function useSortableTable(initialState: SortState): SortControl {
+  const [state, dispatch] = useReducer(sortableTableReducer, initialState);
+
+  return {
+    sortColumnId: state.columnId,
+    sortDirection: state.sortDirection,
+    setSortDirection(sortDirection: SortDirection) {
+      dispatch({ type: ActionType.SET_SORT_DIRECTION, sortDirection });
+    },
+    setSortingColumn(columnId: string) {
+      dispatch({ type: ActionType.SET_SORTING_COLUMN, columnId });
+    },
+    setSorting(columnId: string, sortDirection: SortDirection) {
+      dispatch({ type: ActionType.SET_SORTING, columnId, sortDirection });
+    },
+  };
 }


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/392

Idea: Use the [`useReducer`](https://beta.reactjs.org/apis/react/useReducer) hook to manage the state of the compare table. This will allow us to initialize and control the state from outside of `CompareTable` without adding too much complexity to the component interface, and to create more ergonomic state transitions (toggle column, etc) that update more than one state variable at once

[**Demo**](https://act-now-packages--pr397-pablo-demo-use-reduc-20yru3az.web.app/storybook/index.html?path=/story/table-comparetable--example)

**Example**

```tsx
const initialState = { 
  columnId: MetricId.WEEKLY_CASES, 
  sortDirection: SortDirection.ASC 
};

const [state, dispatch] = useSortableTable(initialState);

// We can call `dispatch` outside `CompareTable`
<Button onClick={() => dispatch({ type: ActionType.SORT_BY_COLUMN, columnId: "..." )}>
  Sort by Vaccination
</Button>

// The table can dispatch actions as the user interacts with its UI
<CompareTable
  rows={rows}
  columns={columns}
  state={state}
  dispatch={dispatch}
/>
```

Reducers are useful when the state or the actions that change the state are complex (in our case, we only have 2 state variables), and when we want to perform "atomic" updates to the state. See https://beta.reactjs.org/apis/react/useReducer for an introduction to the reducer pattern. 
