### PR TITLE
Reenable typedoc with workarounds to avoid out-of-memory crash.

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -18,7 +18,8 @@ jobs:
       - run: yarn install
       - run: yarn build-public
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          # Set max_old_space_size to 8192 to work around typedoc memory issues. See #356
+          NODE_OPTIONS: "--max_old_space_size=8192"
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -16,7 +16,8 @@ jobs:
       - run: yarn install
       - run: yarn build-public
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          # Set max_old_space_size to 8192 to work around typedoc memory issues. See #356
+          NODE_OPTIONS: "--max_old_space_size=8192"
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "release": "yarn build:all && yarn changeset publish",
     "create-package": "yarn plop package",
     "create-component": "yarn plop component",
-    "generate-docs": "yarn typedoc --out public/docs --entryPointStrategy packages --name 'Act Now Packages' .",
+    "generate-module-docs": "yarn typedoc --out public/docs --entryPointStrategy packages --name 'Act Now Packages' . # See #356",
+    "generate-src-docs": "yarn typedoc --out public/docs packages/*/src/index.ts --name 'Act Now Packages' # See #356",
     "generate-storybook": "yarn build-storybook -c packages/ui-components/.storybook/ -o public/storybook",
-    "build-public": "yarn build:all && yarn generate-storybook"
+    "build-public": "yarn build:all && yarn generate-storybook && yarn generate-src-docs"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --max-warnings=0",
@@ -54,7 +55,7 @@
     "ts-jest": "^28.0.2",
     "ts-node": "^10.7.0",
     "tsconfig-paths": "^4.0.0",
-    "typedoc": "^0.23.10",
+    "typedoc": "^0.23.21",
     "typescript": "^4.6.4"
   },
   "dependencies": {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13928,10 +13928,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typedoc@^0.23.10:
-  version "0.23.19"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.19.tgz#6c8b76a7b5c1fc316e961464f0d6c3592ff09328"
-  integrity sha512-70jPL0GQnSJtgQqI7ifOWxpTXrB3sxc4SWPPRn3K0wdx3txI6ZIT/ZYMF39dNg2Gjmql45cO+cAKXJp0TpqOVA==
+typedoc@^0.23.21:
+  version "0.23.21"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.21.tgz#2a6b0e155f91ffa9689086706ad7e3e4bc11d241"
+  integrity sha512-VNE9Jv7BgclvyH9moi2mluneSviD43dCE9pY8RWkO88/DrEgJZk9KpUk7WO468c9WWs/+aG6dOnoH7ccjnErhg==
   dependencies:
     lunr "^2.3.9"
     marked "^4.0.19"


### PR DESCRIPTION
Typedoc has issues with monorepo support using lots of memory.  See https://github.com/covid-projections/act-now-packages/issues/356 and https://github.com/TypeStrong/typedoc/issues/1606.

This avoids the crash in two different ways:
1. I increased the node heap size to 8192 which seems to be sufficient to make the build succeed for now.
2. For now I am pointing typedoc at the packages' source code directly rather than using the monorepo support. This uses a lot less memory and is a lot faster, though the resulting docs are not formatted as nicely (it looks like all the code lives in one big package).  We can revisit this when https://github.com/TypeStrong/typedoc/issues/1835 is fixed.

I'm also upgrading typedoc just for good measure, though I don't think it fixes anything.

Not including a changeset, since this has no effect on our packages.

Fixes #356 for now.