### PR TITLE
Fix floating zero on y-axis

### DIFF
--- a/.changeset/breezy-ravens-relate.md
+++ b/.changeset/breezy-ravens-relate.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix floating zero on y-axis

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
@@ -29,10 +29,14 @@ AppleStock.args = {
 
 export const NewYorkCityTemperature = Template.bind({});
 NewYorkCityTemperature.args = {
-  width,
-  height,
+  ...AppleStock.args,
   metric: MetricId.NYC_TEMPERATURE,
-  region: newYork,
+};
+
+export const YAxisStartsAtZero = Template.bind({});
+YAxisStartsAtZero.args = {
+  ...AppleStock.args,
+  metric: MetricId.APPLE_STOCK_LOW_THRESHOLDS,
 };
 
 export const LoadingDelay = Template.bind({});

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -94,7 +94,7 @@ export const MetricLineThresholdChart = ({
           yScale={yScale}
           axisLeftProps={{
             tickFormat: (value) => metric.formatValue(value),
-            tickValues: [0].concat(thresholds),
+            tickValues: thresholds,
           }}
         />
         <GridRows scale={yScale} width={chartWidth} tickValues={thresholds} />

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -94,7 +94,7 @@ export const MetricLineThresholdChart = ({
           yScale={yScale}
           axisLeftProps={{
             tickFormat: (value) => metric.formatValue(value),
-            tickValues: thresholds,
+            tickValues: [0].concat(thresholds),
           }}
         />
         <GridRows scale={yScale} width={chartWidth} tickValues={thresholds} />

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.test.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.test.ts
@@ -12,7 +12,7 @@ describe("calculateChartIntervals", () => {
     test("minValue < T < maxValue", () => {
       const intervals = calculateChartIntervals(categories, [10], 5, 25);
       expect(intervals).toEqual([
-        { lower: 5, upper: 10, color: LOW.color, category: LOW },
+        { lower: 0, upper: 10, color: LOW.color, category: LOW },
         { lower: 10, upper: 25, color: HIGH.color, category: HIGH },
       ]);
     });
@@ -28,7 +28,7 @@ describe("calculateChartIntervals", () => {
     test("T < minValue < maxValue", () => {
       const intervals = calculateChartIntervals(categories, [10], 15, 25);
       expect(intervals).toEqual([
-        { lower: 8, upper: 10, color: LOW.color, category: LOW },
+        { lower: 0, upper: 10, color: LOW.color, category: LOW },
         { lower: 10, upper: 25, color: HIGH.color, category: HIGH },
       ]);
     });
@@ -39,7 +39,7 @@ describe("calculateChartIntervals", () => {
     test("minValue < T1 < T2 < maxValue", () => {
       const intervals = calculateChartIntervals(categories, [10, 20], 5, 25);
       expect(intervals).toEqual([
-        { lower: 5, upper: 10, color: LOW.color, category: LOW },
+        { lower: 0, upper: 10, color: LOW.color, category: LOW },
         { lower: 10, upper: 20, color: MEDIUM.color, category: MEDIUM },
         { lower: 20, upper: 25, color: HIGH.color, category: HIGH },
       ]);
@@ -48,7 +48,7 @@ describe("calculateChartIntervals", () => {
     test("T1 < minValue < T2 < maxValue", () => {
       const intervals = calculateChartIntervals(categories, [10, 20], 15, 25);
       expect(intervals).toEqual([
-        { lower: 8, upper: 10, color: LOW.color, category: LOW },
+        { lower: 0, upper: 10, color: LOW.color, category: LOW },
         { lower: 10, upper: 20, color: MEDIUM.color, category: MEDIUM },
         { lower: 20, upper: 25, color: HIGH.color, category: HIGH },
       ]);
@@ -57,7 +57,7 @@ describe("calculateChartIntervals", () => {
     test("minValue < T1 < maxValue < T2", () => {
       const intervals = calculateChartIntervals(categories, [10, 20], 5, 15);
       expect(intervals).toEqual([
-        { lower: 5, upper: 10, color: LOW.color, category: LOW },
+        { lower: 0, upper: 10, color: LOW.color, category: LOW },
         { lower: 10, upper: 20, color: MEDIUM.color, category: MEDIUM },
         { lower: 20, upper: 22, color: HIGH.color, category: HIGH },
       ]);
@@ -66,7 +66,7 @@ describe("calculateChartIntervals", () => {
     test("T1 < minValue < maxValue < T2", () => {
       const intervals = calculateChartIntervals(categories, [10, 20], 14, 18);
       expect(intervals).toEqual([
-        { lower: 8, upper: 10, color: LOW.color, category: LOW },
+        { lower: 0, upper: 10, color: LOW.color, category: LOW },
         { lower: 10, upper: 20, color: MEDIUM.color, category: MEDIUM },
         { lower: 20, upper: 22, color: HIGH.color, category: HIGH },
       ]);
@@ -80,7 +80,7 @@ describe("calculateChartIntervals", () => {
       expect(intervals).toEqual([
         { lower: 20, upper: 25, color: LOW.color, category: LOW },
         { lower: 10, upper: 20, color: MEDIUM.color, category: MEDIUM },
-        { lower: 5, upper: 10, color: HIGH.color, category: HIGH },
+        { lower: 0, upper: 10, color: HIGH.color, category: HIGH },
       ]);
     });
 
@@ -89,7 +89,7 @@ describe("calculateChartIntervals", () => {
       expect(intervals).toEqual([
         { lower: 20, upper: 25, color: LOW.color, category: LOW },
         { lower: 10, upper: 20, color: MEDIUM.color, category: MEDIUM },
-        { lower: 8, upper: 10, color: HIGH.color, category: HIGH },
+        { lower: 0, upper: 10, color: HIGH.color, category: HIGH },
       ]);
     });
 
@@ -98,7 +98,7 @@ describe("calculateChartIntervals", () => {
       expect(intervals).toEqual([
         { lower: 20, upper: 22, color: LOW.color, category: LOW },
         { lower: 10, upper: 20, color: MEDIUM.color, category: MEDIUM },
-        { lower: 5, upper: 10, color: HIGH.color, category: HIGH },
+        { lower: 0, upper: 10, color: HIGH.color, category: HIGH },
       ]);
     });
 
@@ -107,7 +107,7 @@ describe("calculateChartIntervals", () => {
       expect(intervals).toEqual([
         { lower: 20, upper: 22, color: LOW.color, category: LOW },
         { lower: 10, upper: 20, color: MEDIUM.color, category: MEDIUM },
-        { lower: 8, upper: 10, color: HIGH.color, category: HIGH },
+        { lower: 0, upper: 10, color: HIGH.color, category: HIGH },
       ]);
     });
   });

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -91,7 +91,7 @@ export function calculateChartIntervals(
 
   // If minValue is higher than 0, don't pad below 0 on the y-axis.
   const lowestBound = Math.min(minVal, firstThreshold - padding);
-  const chartMin = lowestBound >= 0 ? Math.max(0, lowestBound) : lowestBound;
+  const chartMin = minVal >= 0 ? Math.max(0, lowestBound) : lowestBound;
   const chartMax = Math.max(maxVal, lastThreshold + padding);
 
   // Build the intervals in the same order as the categories.

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -89,26 +89,19 @@ export function calculateChartIntervals(
       ? 0.2 * (lastThreshold - firstThreshold)
       : 0.2 * (maxVal - minVal);
 
+  // If minValue is higher than 0, don't pad below 0 on the y-axis.
+  const lowestBound = Math.min(minVal, firstThreshold);
+  const chartMin = lowestBound >= 0 ? 0 : lowestBound - padding;
+  const chartMax = Math.max(maxVal, lastThreshold + padding);
+
   // Build the intervals in the same order as the categories.
   return metricCategories.map((category, categoryIndex) => {
     const isFirstCategory = categoryIndex === 0;
     const isLastCategory = categoryIndex === metricCategories.length - 1;
-    const lowestBound = Math.min(minVal, firstThreshold - padding);
-    // If minValue is higher than 0, don't pad below 0 on the y-axis.
-    const firstCategoryLowerThreshold =
-      isFirstCategory && minValue > 0 ? Math.max(0, lowestBound) : lowestBound;
-    const lastCategoryUpperThreshold = Math.max(
-      maxVal,
-      lastThreshold + padding
-    );
     return {
       category,
-      lower: isFirstCategory
-        ? firstCategoryLowerThreshold
-        : thresholds[categoryIndex - 1],
-      upper: isLastCategory
-        ? lastCategoryUpperThreshold
-        : thresholds[categoryIndex],
+      lower: isFirstCategory ? chartMin : thresholds[categoryIndex - 1],
+      upper: isLastCategory ? chartMax : thresholds[categoryIndex],
       color: category.color,
     };
   });

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -93,11 +93,10 @@ export function calculateChartIntervals(
   return metricCategories.map((category, categoryIndex) => {
     const isFirstCategory = categoryIndex === 0;
     const isLastCategory = categoryIndex === metricCategories.length - 1;
+    const lowestBound = Math.min(minVal, firstThreshold - padding);
     // If minValue is higher than 0, don't pad below 0 on the y-axis.
     const firstCategoryLowerThreshold =
-      isFirstCategory && minValue > 0
-        ? Math.max(0, firstThreshold - padding)
-        : Math.min(minVal, firstThreshold - padding);
+      isFirstCategory && minValue > 0 ? Math.max(0, lowestBound) : lowestBound;
     const lastCategoryUpperThreshold = Math.max(
       maxVal,
       lastThreshold + padding

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -90,8 +90,8 @@ export function calculateChartIntervals(
       : 0.2 * (maxVal - minVal);
 
   // If minValue is higher than 0, don't pad below 0 on the y-axis.
-  const lowestBound = Math.min(minVal, firstThreshold - padding);
-  const chartMin = minVal >= 0 ? Math.max(0, lowestBound) : lowestBound;
+  const lowestBound = Math.min(minVal, firstThreshold);
+  const chartMin = lowestBound >= 0 ? 0 : lowestBound - padding;
   const chartMax = Math.max(maxVal, lastThreshold + padding);
 
   // Build the intervals in the same order as the categories.

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -90,8 +90,8 @@ export function calculateChartIntervals(
       : 0.2 * (maxVal - minVal);
 
   // If minValue is higher than 0, don't pad below 0 on the y-axis.
-  const lowestBound = Math.min(minVal, firstThreshold);
-  const chartMin = lowestBound >= 0 ? 0 : lowestBound - padding;
+  const lowestBound = Math.min(minVal, firstThreshold - padding);
+  const chartMin = lowestBound >= 0 ? Math.max(0, lowestBound) : lowestBound;
   const chartMax = Math.max(maxVal, lastThreshold + padding);
 
   // Build the intervals in the same order as the categories.

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -10,6 +10,7 @@ import { NycTemperatureDataProvider } from "./NycTemperatureDataProvider";
 
 export enum MetricId {
   APPLE_STOCK = "apple_stock",
+  APPLE_STOCK_LOW_THRESHOLDS = "apple_stock_low_thresholds",
   NYC_TEMPERATURE = "nyc_temperature",
   PI = "pi",
   MOCK_CASES = "mock_cases",
@@ -36,6 +37,16 @@ const testMetricDefs: MetricDefinition[] = [
       providerId: ProviderId.APPLE_STOCK,
     },
     categoryThresholds: [100, 200, 400, 800],
+    categorySetId: "5_risk_categories",
+  },
+  {
+    id: MetricId.APPLE_STOCK_LOW_THRESHOLDS,
+    name: "AAPL (low thresholds)",
+    extendedName: "Apple Stock w/ low thresholds",
+    dataReference: {
+      providerId: ProviderId.APPLE_STOCK,
+    },
+    categoryThresholds: [0, 100, 200, 400],
     categorySetId: "5_risk_categories",
   },
   {


### PR DESCRIPTION
Closes https://github.com/covid-projections/act-now-packages/issues/401

The original issue linked above states that we should explore removing the padding from `MetricLineThresholdChart/utils.ts` and adding padding calculation to `LineIntervalChart.tsx` instead. On second thought, I think there is value is keeping this padding calculation in the utils file so we don't overcomplicate our `LineIntervalChart` implementation (although I don't feel strongly). I also don't think we necessarily need to remove padding from the bottom, since the only time we should is when the data's minimum value is above zero but the lower bound of the first interval is below zero.

So this PR simply implements a conditional where if the data's minimum value is higher than zero, then the lowest y-axis label should not be lower than zero.

Before
![image](https://user-images.githubusercontent.com/46338131/203151192-0b73e7fa-2cfa-4ff1-b78f-60ff6033b18c.png)

After
![image](https://user-images.githubusercontent.com/46338131/203151513-92f015b9-e720-4253-8ccd-bc66526bd31e.png)

To test
- Adjust `tickValues` prop of `AxesTimeseries` in `MetricThresholdChart.tsx` to include zero (i.e. `tickValues: [0].concat(thresholds)` OR
- Play around with metric thresholds (i.e. add zero as a threshold).
