### PR TITLE
Route MetricCatalog through SimpleMetricDataProviderBase.

### DIFF
--- a/.changeset/famous-camels-worry.md
+++ b/.changeset/famous-camels-worry.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/metrics": patch
+---
+
+Give SimpleMetricDataProviderBase access to the MetricCatalog.

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
@@ -171,7 +171,8 @@ describe("MetricCatalog", () => {
       await provider.fetchData(
         [testRegionCA],
         [metric],
-        /*includeTimeseries=*/ false
+        /*includeTimeseries=*/ false,
+        catalog
       )
     ).metricData(testRegionCA, metric);
     const catalogData = await catalog.fetchData(

--- a/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
+++ b/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
@@ -9,6 +9,7 @@ import { MetricData } from "./MetricData";
 import { Metric } from "../Metric";
 import { StaticValueDataProvider } from "../data_providers";
 import { isoDateOnlyString } from "@actnowcoalition/time-utils";
+import { MetricCatalog } from "../MetricCatalog";
 
 enum ProviderId {
   STATIC = "static",
@@ -24,6 +25,8 @@ const testMetric = new Metric({
 });
 
 const testProvider = new StaticValueDataProvider(ProviderId.STATIC);
+
+const testMetricCatalog = new MetricCatalog([testMetric], [testProvider]);
 
 // The snapshot JSON that corresponds to the data for `testRegion` and `testMetric`.
 const testSnapshot: SnapshotJSON = {
@@ -51,7 +54,8 @@ describe("MultiRegionMultiMetricDataStore", () => {
     const dataStore = await testProvider.fetchData(
       [testRegion],
       [testMetric],
-      /*includeTimeseries=*/ true
+      /*includeTimeseries=*/ true,
+      testMetricCatalog
     );
     expect(dataStore.toSnapshot()).toEqual(testSnapshot);
   });
@@ -60,7 +64,8 @@ describe("MultiRegionMultiMetricDataStore", () => {
     const dataStore = await testProvider.fetchData(
       [testRegion],
       [testMetric],
-      /*includeTimeseries=*/ true
+      /*includeTimeseries=*/ true,
+      testMetricCatalog
     );
     expect(
       MultiRegionMultiMetricDataStore.fromSnapshot(
@@ -74,7 +79,8 @@ describe("MultiRegionMultiMetricDataStore", () => {
     const dataStoreNoTs = await testProvider.fetchData(
       [testRegion],
       [testMetric],
-      /*includeTimeseries=*/ false
+      /*includeTimeseries=*/ false,
+      testMetricCatalog
     );
     expect(
       MultiRegionMultiMetricDataStore.fromSnapshot(

--- a/packages/metrics/src/data_providers/CsvDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.test.ts
@@ -1,6 +1,7 @@
 import { CsvDataProvider } from "./CsvDataProvider";
 import { Metric } from "../Metric";
 import { states } from "@actnowcoalition/regions";
+import { MetricCatalog } from "../MetricCatalog";
 
 const PROVIDER_ID = "csv-provider";
 
@@ -39,7 +40,10 @@ const testFetchingCsvData = async (
     dateColumn: dateCol,
     csvText: data,
   });
-  return (await provider.fetchData([newYork], [metric], includeTimeseries))
+  const catalog = new MetricCatalog([metric], [provider]);
+  return (
+    await provider.fetchData([newYork], [metric], includeTimeseries, catalog)
+  )
     .regionData(newYork)
     .metricData(testMetric);
 };

--- a/packages/metrics/src/data_providers/SimpleMetricDataProviderBase.ts
+++ b/packages/metrics/src/data_providers/SimpleMetricDataProviderBase.ts
@@ -3,6 +3,7 @@ import { Region } from "@actnowcoalition/regions";
 import { MetricDataProvider } from "./MetricDataProvider";
 import { Metric } from "../Metric";
 import { MetricData, MultiRegionMultiMetricDataStore } from "../data";
+import { MetricCatalog } from "../MetricCatalog";
 
 /**
  * Base class to help implement a MetricDataProvider that fetches one
@@ -25,24 +26,34 @@ export abstract class SimpleMetricDataProviderBase
    * @param region The region to get data for.
    * @param metric The metric to get data for.
    * @param includeTimeseries Whether to get timeseries data.
+   * @param metricCatalog The metric catalog using this data provider.  The data
+   * provider can call back into the catalog if it needs to fetch dependent
+   * data.
    * @returns The `MetricData` for the given `metric` and `region`.
    */
   abstract fetchDataForRegionAndMetric(
     region: Region,
     metric: Metric,
-    includeTimeseries: boolean
+    includeTimeseries: boolean,
+    metricCatalog: MetricCatalog
   ): Promise<MetricData>;
 
   async fetchData(
     regions: Region[],
     metrics: Metric[],
-    includeTimeseries: boolean
+    includeTimeseries: boolean,
+    metricCatalog: MetricCatalog
   ): Promise<MultiRegionMultiMetricDataStore> {
     return MultiRegionMultiMetricDataStore.fromRegionsAndMetricsAsync(
       regions,
       metrics,
       (region, metric) =>
-        this.fetchDataForRegionAndMetric(region, metric, includeTimeseries)
+        this.fetchDataForRegionAndMetric(
+          region,
+          metric,
+          includeTimeseries,
+          metricCatalog
+        )
     );
   }
 }


### PR DESCRIPTION
This was an oversight when I implemented `SimpleMetricDataProviderBase`.  This will make it easier to use `SimpleMetricDataProviderBase` to write a data provider that transforms multiple existing metrics, etc.