### PR TITLE
Log and throw errors when CSV file contains invalid region IDs.

### DIFF
--- a/.changeset/quiet-pandas-change.md
+++ b/.changeset/quiet-pandas-change.md
@@ -1,0 +1,6 @@
+---
+"@actnowcoalition/metrics": patch
+"@actnowcoalition/ui-components": patch
+---
+
+CSVMetricDataProvider: Log warning if there are any unknown region IDs. Throw error if they're all unknown.

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
@@ -69,7 +69,8 @@ describe("MetricCatalog", () => {
   test("getMetric()", () => {
     const metricCatalog = new MetricCatalog(
       testMetricDefs,
-      testDataProviders()
+      testDataProviders(),
+      states
     );
     const piMetric = metricCatalog.getMetric(MetricId.PI);
     expect(piMetric.name).toStrictEqual("Pi");
@@ -80,7 +81,11 @@ describe("MetricCatalog", () => {
   });
 
   test("fetchData()", async () => {
-    const catalog = new MetricCatalog(testMetricDefs, testDataProviders());
+    const catalog = new MetricCatalog(
+      testMetricDefs,
+      testDataProviders(),
+      states
+    );
 
     const data = await catalog.fetchData(testRegionWA, MetricId.PI);
     expect(data.currentValue).toBe(Math.PI);
@@ -91,7 +96,11 @@ describe("MetricCatalog", () => {
   });
 
   test("fetchDataForMetricsAndRegions()", async () => {
-    const catalog = new MetricCatalog(testMetricDefs, testDataProviders());
+    const catalog = new MetricCatalog(
+      testMetricDefs,
+      testDataProviders(),
+      states
+    );
 
     // Fetch data for two metrics that come from different data providers.
     const dataStore = await catalog.fetchDataForRegionsAndMetrics(
@@ -120,9 +129,14 @@ describe("MetricCatalog", () => {
   });
 
   test("fetchData() correctly reads from a snapshot.", async () => {
-    const catalog = new MetricCatalog(testMetricDefs, testDataProviders(), {
-      snapshot: testSnapshot,
-    });
+    const catalog = new MetricCatalog(
+      testMetricDefs,
+      testDataProviders(),
+      states,
+      {
+        snapshot: testSnapshot,
+      }
+    );
 
     const data = await catalog.fetchData(
       testRegionCA,
@@ -135,9 +149,14 @@ describe("MetricCatalog", () => {
   });
 
   test("fetchData() falls back to data providers if snapshot doesn't have data", async () => {
-    const catalog = new MetricCatalog(testMetricDefs, testDataProviders(), {
-      snapshot: testSnapshot,
-    });
+    const catalog = new MetricCatalog(
+      testMetricDefs,
+      testDataProviders(),
+      states,
+      {
+        snapshot: testSnapshot,
+      }
+    );
 
     const data = await catalog.fetchData(
       testRegionCA,
@@ -163,7 +182,8 @@ describe("MetricCatalog", () => {
           },
         },
       ],
-      [provider]
+      [provider],
+      states
     );
     const metric = catalog.getMetric(MetricId.MOCK_CASES);
 

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.ts
@@ -1,7 +1,7 @@
 import groupBy from "lodash/groupBy";
 import keyBy from "lodash/keyBy";
 
-import { Region } from "@actnowcoalition/regions";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 import { assert } from "@actnowcoalition/assert";
 
 import { MetricCatalogOptions } from "./MetricCatalogOptions";
@@ -50,6 +50,7 @@ export class MetricCatalog {
   constructor(
     metrics: MetricDefinition[],
     dataProviders: MetricDataProvider[],
+    readonly regionDb: RegionDB,
     options: MetricCatalogOptions = {}
   ) {
     this.metrics = metrics.map((metric) => new Metric(metric, options));

--- a/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
+++ b/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
@@ -26,7 +26,11 @@ const testMetric = new Metric({
 
 const testProvider = new StaticValueDataProvider(ProviderId.STATIC);
 
-const testMetricCatalog = new MetricCatalog([testMetric], [testProvider]);
+const testMetricCatalog = new MetricCatalog(
+  [testMetric],
+  [testProvider],
+  states
+);
 
 // The snapshot JSON that corresponds to the data for `testRegion` and `testMetric`.
 const testSnapshot: SnapshotJSON = {

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.test.ts
@@ -65,7 +65,7 @@ const dataProviders = [
     testCacheData
   ),
 ];
-const catalog = new MetricCatalog(testMetrics, dataProviders);
+const catalog = new MetricCatalog(testMetrics, dataProviders, states);
 
 describe("CovidActNowDataProvider", () => {
   test("fetches data without timeseries", async () => {

--- a/packages/metrics/src/data_providers/CsvDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.test.ts
@@ -40,7 +40,7 @@ const testFetchingCsvData = async (
     dateColumn: dateCol,
     csvText: data,
   });
-  const catalog = new MetricCatalog([metric], [provider]);
+  const catalog = new MetricCatalog([metric], [provider], states);
   return (
     await provider.fetchData([newYork], [metric], includeTimeseries, catalog)
   )
@@ -81,6 +81,15 @@ describe("CsvDataProvider", () => {
     expect(async () =>
       testFetchingCsvData(`region,cool_metric`, /*includeTimeseries=*/ true)
     ).rejects.toThrow("CSV must not be empty.");
+  });
+
+  test("fetchData() fails if csv does not have at least one valid region ID.", async () => {
+    expect(async () =>
+      testFetchingCsvData(
+        `region,cool_metric\nNew York,1`,
+        /*includeTimeseries=*/ true
+      )
+    ).rejects.toThrow("Failed to parse CSV data: All region IDs were invalid.");
   });
 
   test("fetchData() fails if metric is missing a 'column' property.", async () => {

--- a/packages/metrics/src/data_providers/TransformedMetricDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/TransformedMetricDataProvider.test.ts
@@ -81,7 +81,7 @@ describe("TransformedMetricDataProvider", () => {
       new StaticValueDataProvider(ProviderId.STATIC),
       new InvertDataProvider(ProviderId.INVERT_DATA),
     ];
-    const catalog = new MetricCatalog(testMetrics, dataProviders);
+    const catalog = new MetricCatalog(testMetrics, dataProviders, states);
 
     const data = await catalog.fetchDataForMetrics(
       testRegion,

--- a/packages/ui-components/src/common/hooks/metric-data.test.tsx
+++ b/packages/ui-components/src/common/hooks/metric-data.test.tsx
@@ -207,7 +207,7 @@ describe("metric data hooks", () => {
 });
 
 function createCatalogAndWrapper() {
-  const catalog = new MetricCatalog(testMetricDefs, dataProviders);
+  const catalog = new MetricCatalog(testMetricDefs, dataProviders, states);
   const wrapper = ({ children }: { children: ReactNode }) => (
     <MetricCatalogProvider metricCatalog={catalog}>
       {children}

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -40,7 +40,7 @@ const metricDefs: MetricDefinition[] = [
   },
 ];
 
-const metricCatalog = new MetricCatalog(metricDefs, dataProviders);
+const metricCatalog = new MetricCatalog(metricDefs, dataProviders, states);
 
 const Template: ComponentStory<typeof MetricCatalogProvider> = (args) => (
   <MetricCatalogProvider metricCatalog={metricCatalog}>

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
@@ -1,7 +1,8 @@
 import { MetricCatalog } from "@actnowcoalition/metrics";
+import { RegionDB } from "@actnowcoalition/regions";
 import React, { createContext, useContext } from "react";
 
-const defaultMetricCatalog = new MetricCatalog([], []);
+const defaultMetricCatalog = new MetricCatalog([], [], new RegionDB([]));
 
 const MetricCatalogContext = createContext<MetricCatalog>(defaultMetricCatalog);
 

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -4,6 +4,7 @@ import {
   MockDataProvider,
   StaticValueDataProvider,
 } from "@actnowcoalition/metrics";
+import { states } from "@actnowcoalition/regions";
 import { theme } from "../styles";
 import { AppleStockDataProvider } from "./MockAppleStockDataProvider";
 import { NycTemperatureDataProvider } from "./NycTemperatureDataProvider";
@@ -193,9 +194,14 @@ const metricCategorySets = [
   },
 ];
 
-export const metricCatalog = new MetricCatalog(testMetricDefs, dataProviders, {
-  categorySets: metricCategorySets,
-});
+export const metricCatalog = new MetricCatalog(
+  testMetricDefs,
+  dataProviders,
+  states,
+  {
+    categorySets: metricCategorySets,
+  }
+);
 
 // Exporting a second metric catalog to confirm that the closest
 // MetricCatalogProvider instance is used
@@ -221,4 +227,8 @@ const metricDefsB: MetricDefinition[] = [
   },
 ];
 
-export const metricCatalogB = new MetricCatalog(metricDefsB, dataProviders);
+export const metricCatalogB = new MetricCatalog(
+  metricDefsB,
+  dataProviders,
+  states
+);


### PR DESCRIPTION
* Gives MetricCatalog access to the RegionDb so we can use it for validation.
* Makes CsvMetricDataProvider validate the encountered regionIds. If any are invalid, they will be logged. If all are invalid, then it will throw an error.

Fixes #424