### PR TITLE
Make sparkline Y-axis start from 0 and use dateFrom and dateTo

### DIFF
--- a/.changeset/ninety-ways-shop.md
+++ b/.changeset/ninety-ways-shop.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Make sparkline y-axis start from 0 and use dateFrom and dateTo

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
@@ -99,7 +99,6 @@ export const Sparklines = () => (
             region={region}
             metricBarChart={MetricId.MOCK_CASES}
             metricLineChart={MetricId.MOCK_CASES}
-            numDays={30}
           />
         </AutoWidth>
       </StyledGridItem>

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
@@ -24,7 +24,7 @@ export const ExampleFiveDays = Template.bind({});
 ExampleFiveDays.args = {
   ...defaultArgs,
   dateFrom: new Date("2012-01-01"),
-  dateTo: new Date("2012-01-06"),
+  dateTo: new Date("2012-01-05"),
 };
 
 export const ExampleSixtyDays = Template.bind({});

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
@@ -18,18 +18,20 @@ const defaultArgs = {
   // TODO: Make this a rolling avg. metric once provider is implemented.
   metricLineChart: MetricId.APPLE_STOCK,
   metricBarChart: MetricId.APPLE_STOCK,
-  numDays: 5,
 };
 
 export const ExampleFiveDays = Template.bind({});
 ExampleFiveDays.args = {
   ...defaultArgs,
+  dateFrom: new Date("2012-01-01"),
+  dateTo: new Date("2012-01-06"),
 };
 
 export const ExampleSixtyDays = Template.bind({});
 ExampleSixtyDays.args = {
   ...defaultArgs,
-  numDays: 60,
+  dateFrom: new Date("2012-01-01"),
+  dateTo: new Date("2012-03-02"),
 };
 
 export const LoadingDelay = Template.bind({});

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -14,15 +14,18 @@ export interface MetricSparklinesProps
   metricLineChart: Metric | string;
   /** Metric to use for bar elements of sparkline. */
   metricBarChart: Metric | string;
-  /** Number of days to show in sparkline, starting from the most recent date looking backwards. */
-  numDays: number;
+  /** Earliest date to be displayed. If not specified, earliest data point will be displayed. */
+  dateFrom?: Date;
+  /** Latest date to be displayed. If not specified, latest data point will be displayed.  */
+  dateTo?: Date;
 }
 
 export const MetricSparklines = ({
   region,
   metricLineChart,
   metricBarChart,
-  numDays = 30,
+  dateFrom,
+  dateTo,
   ...optionalProps
 }: MetricSparklinesProps) => {
   const metricCatalog = useMetricCatalog();
@@ -51,11 +54,11 @@ export const MetricSparklines = ({
     const timeseriesLineChart = data
       .metricData(metricLineChart)
       ?.timeseries.assertFiniteNumbers()
-      .slice(-numDays);
+      .filterToDateRange({ startAt: dateFrom, endAt: dateTo });
     const timeseriesBarChart = data
       .metricData(metricBarChart)
       ?.timeseries.assertFiniteNumbers()
-      .slice(-numDays);
+      .filterToDateRange({ startAt: dateFrom, endAt: dateTo });
 
     return (
       <SparkLine

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -43,7 +43,7 @@ export const SparkLine = ({
   });
 
   const yScaleBar = scaleLinear({
-    domain: [timeseriesBarChart.minValue, timeseriesBarChart.maxValue],
+    domain: [0, timeseriesBarChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 
@@ -53,7 +53,7 @@ export const SparkLine = ({
   });
 
   const yScaleLine = scaleLinear({
-    domain: [timeseriesLineChart.minValue, timeseriesLineChart.maxValue],
+    domain: [0, timeseriesLineChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 


### PR DESCRIPTION
- Adjust the Y-axis of the sparkline to start from zero instead of the minimum data value. Closes #411
- Replace `numDays` parameter with `dateFrom` and `dateTo`. Closes #387 