### PR TITLE
Component props cleanup cont.

### DIFF
--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
 import { LabelIcon } from ".";
+import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import React from "react";
 
 export default {
   title: "Components/LabelIcon",
@@ -9,9 +9,7 @@ export default {
 } as ComponentMeta<typeof LabelIcon>;
 
 const Template: ComponentStory<typeof LabelIcon> = (args) => (
-  <div style={{ width: 300 }}>
-    <LabelIcon {...args} />
-  </div>
+  <LabelIcon {...args} />
 );
 
 export const Example = Template.bind({});
@@ -25,5 +23,5 @@ Custom.args = {
   children: "Learn more",
   color: "primary",
   variant: "labelSmall",
-  endIcon: <LibraryBooksIcon fontSize="small" color="inherit" />,
+  endIcon: <LibraryBooksIcon fontSize="small" color="primary" />,
 };

--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
@@ -1,24 +1,26 @@
-import React from "react";
-import { Stack, Typography, TypographyProps } from "@mui/material";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { Stack, Typography, TypographyProps } from "@mui/material";
+import React from "react";
 
-export interface LabelIconProps extends TypographyProps {
-  /** Icon to show at the end of the label (ArrowForward by default) */
+export type LabelIconProps = Pick<
+  TypographyProps,
+  "color" | "variant" | "children"
+> & {
   endIcon?: React.ReactNode;
-}
+};
 
 export const LabelIcon = ({
   endIcon = <ArrowForwardIcon fontSize="small" color="inherit" />,
-  children,
   variant = "labelLarge",
-  ...otherTypographyProps
+  color,
+  children,
 }: LabelIconProps) => {
   return (
-    <Typography variant={variant} {...otherTypographyProps}>
-      <Stack direction="row" spacing={1} alignItems="center">
-        <span>{children}</span>
-        {endIcon}
-      </Stack>
-    </Typography>
+    <Stack direction="row" spacing={1} alignItems="center">
+      <Typography variant={variant} color={color}>
+        {children}
+      </Typography>
+      {endIcon}
+    </Stack>
   );
 };

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -1,13 +1,10 @@
-import { TickLabel, TickMark } from "./LegendThreshold.style";
-
 import { AutoWidth } from "../AutoWidth";
-import { Group } from "@visx/group";
-import { LegendThresholdProps } from "./LegendThreshold";
-import React from "react";
 import { RectClipGroup } from "../RectClipGroup";
+import { LegendThresholdProps } from "./LegendThreshold";
+import { TickLabel, TickMark } from "./LegendThreshold.style";
+import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
-
-export type LegendThresholdHorizontalProps<T> = LegendThresholdProps<T>;
+import React from "react";
 
 /**
  * `LegendThresholdHorizontal` represents a scale with thresholds that separate
@@ -74,7 +71,7 @@ export const LegendThresholdHorizontalInner = <T,>({
 
 export const LegendThresholdHorizontal = <T,>({
   ...props
-}: LegendThresholdHorizontalProps<T>) => {
+}: LegendThresholdProps<T>) => {
   return (
     <AutoWidth>
       <LegendThresholdHorizontalInner {...props} />

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -1,13 +1,13 @@
-import React from "react";
-import { Group } from "@visx/group";
-import { scaleBand } from "@visx/scale";
 import { TickLabel, TickMark } from "./LegendThreshold.style";
-import { LegendThresholdProps } from "./LegendThreshold";
-import { RectClipGroup } from "../RectClipGroup";
-import { AutoWidth } from "../AutoWidth";
 
-export type LegendThresholdHorizontalProps<T> = LegendThresholdProps<T> &
-  Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>;
+import { AutoWidth } from "../AutoWidth";
+import { Group } from "@visx/group";
+import { LegendThresholdProps } from "./LegendThreshold";
+import React from "react";
+import { RectClipGroup } from "../RectClipGroup";
+import { scaleBand } from "@visx/scale";
+
+export type LegendThresholdHorizontalProps<T> = LegendThresholdProps<T>;
 
 /**
  * `LegendThresholdHorizontal` represents a scale with thresholds that separate
@@ -22,8 +22,7 @@ export const LegendThresholdHorizontalInner = <T,>({
   getItemColor,
   getItemLabel,
   showLabels = true,
-  ...otherSvgProps
-}: LegendThresholdHorizontalProps<T>) => {
+}: LegendThresholdProps<T>) => {
   const indexList = items.map((item, itemIndex) => itemIndex);
   const scaleRect = scaleBand({ domain: indexList, range: [0, width] });
   const rectWidth = scaleRect.bandwidth();
@@ -36,7 +35,7 @@ export const LegendThresholdHorizontalInner = <T,>({
   const totalHeight = showLabels ? heightWithLabels : height;
 
   return (
-    <svg width={width} height={totalHeight} {...otherSvgProps}>
+    <svg width={width} height={totalHeight}>
       <RectClipGroup
         width={width}
         height={height}

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -1,18 +1,19 @@
-import React from "react";
-import isNumber from "lodash/isNumber";
-import { Stack, Typography } from "@mui/material";
-import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
-import { RegionDB } from "@actnowcoalition/regions";
-import { formatPopulation } from "../../common/utils";
-import { MetricValue } from "../MetricValue";
 import {
   ColumnDefinition,
   ColumnHeader,
   SortDirection,
   getAriaSort,
 } from "../CompareTable";
-import { StyledTableCell, StyledLink } from "./MetricCompareTable.style";
+import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
+import { Stack, Typography } from "@mui/material";
+import { StyledLink, StyledTableCell } from "./MetricCompareTable.style";
+
+import { MetricValue } from "../MetricValue";
+import React from "react";
 import { Region } from "@actnowcoalition/regions";
+import { RegionDB } from "@actnowcoalition/regions";
+import { formatPopulation } from "../../common/utils";
+import isNumber from "lodash/isNumber";
 
 export interface Row {
   /** Unique ID for the row. */
@@ -59,7 +60,6 @@ export function createMetricColumn(
             metric={metric}
             region={row.region}
             variant="dataTabular"
-            justifyContent="end"
           />
         </StyledLink>
       </StyledTableCell>

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { Stack, Typography, Box } from "@mui/material";
-import { LegendThreshold } from "../LegendThreshold";
-import { useMetricCatalog } from "../MetricCatalogContext";
-import { getMetricCategoryItems } from "./utils";
-import { Metric } from "@actnowcoalition/metrics";
+import { Box, Stack, Typography } from "@mui/material";
+
 import { CategoryItem } from "./utils";
+import { LegendThreshold } from "../LegendThreshold";
+import { Metric } from "@actnowcoalition/metrics";
+import React from "react";
+import { getMetricCategoryItems } from "./utils";
+import { useMetricCatalog } from "../MetricCatalogContext";
 
 export interface MetricLegendThresholdProps {
   /** Orientation of the bars. */
@@ -25,11 +26,6 @@ export interface MetricLegendThresholdProps {
   width?: number;
   /** Height of the bars */
   height?: number;
-  /** Optional other props. */
-  otherSvgProps?: Omit<
-    React.SVGProps<SVGSVGElement>,
-    keyof MetricLegendThresholdProps
-  >;
 }
 
 const getItemColor = (item: CategoryItem) => item.color;

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { MetricScoreOverview } from ".";
-import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
 import { MetricId } from "../../stories/mockMetricCatalog";
+import { MetricScoreOverview } from ".";
+import React from "react";
+import { states } from "@actnowcoalition/regions";
 
 export default {
   title: "Metrics/MetricScoreOverview",
@@ -25,15 +26,8 @@ Default.args = {
   ...defaultArgs,
 };
 
-export const ExtraStackProps = Template.bind({});
-ExtraStackProps.args = {
-  ...defaultArgs,
-  direction: "row-reverse",
-  sx: { maxWidth: 150 },
-};
-
-export const NoToolTip = Template.bind({});
-NoToolTip.args = {
+export const NoTooltip = Template.bind({});
+NoTooltip.args = {
   ...defaultArgs,
   tooltipTitle: undefined,
 };

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
@@ -1,15 +1,16 @@
-import React from "react";
-import { Region } from "@actnowcoalition/regions";
+import { Stack, Typography } from "@mui/material";
+
+import { IconButton } from "@mui/material";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { InfoTooltip } from "../InfoTooltip";
 import { Metric } from "@actnowcoalition/metrics";
-import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricLegendThreshold } from "../MetricLegendThreshold";
 import { MetricValue } from "../MetricValue";
-import { Stack, StackProps, Typography } from "@mui/material";
-import { InfoTooltip } from "../InfoTooltip";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { IconButton } from "@mui/material";
+import React from "react";
+import { Region } from "@actnowcoalition/regions";
+import { useMetricCatalog } from "../MetricCatalogContext";
 
-export interface MetricScoreOverviewProps extends StackProps {
+export interface MetricScoreOverviewProps {
   /** Region for which we want to show the metric overview */
   region: Region;
   /** Metric for which we want to show the metric overview */
@@ -22,13 +23,12 @@ export const MetricScoreOverview = ({
   region,
   metric,
   tooltipTitle,
-  ...otherStackProps
 }: MetricScoreOverviewProps) => {
   const metricCatalog = useMetricCatalog();
   const resolvedMetric = metricCatalog.getMetric(metric);
 
   return (
-    <Stack direction="row" spacing={2} alignItems="center" {...otherStackProps}>
+    <Stack direction="row" spacing={2} alignItems="center" width="fit-content">
       <MetricLegendThreshold
         orientation="vertical"
         metric={resolvedMetric}

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -1,13 +1,13 @@
+import { BaseSparkLineProps, SparkLine } from "../SparkLine";
+
+import { Metric } from "@actnowcoalition/metrics";
 import React from "react";
 import { Region } from "@actnowcoalition/regions";
-import { Metric } from "@actnowcoalition/metrics";
-import { SparkLine, SparkLineProps } from "../SparkLine";
-import { useMetricCatalog } from "../MetricCatalogContext";
 import { Skeleton } from "@mui/material";
 import { useDataForMetrics } from "../../common/hooks";
+import { useMetricCatalog } from "../MetricCatalogContext";
 
-export interface MetricSparklinesProps
-  extends Omit<SparkLineProps, "timeseriesBarChart" | "timeseriesLineChart"> {
+export interface MetricSparklinesProps extends BaseSparkLineProps {
   /** Region to generate sparkline for. */
   region: Region;
   /** Metric to use for line element of sparkline. */

--- a/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricValue } from ".";
+import React from "react";
+import { states } from "@actnowcoalition/regions";
 
 export default {
   title: "Metrics/MetricValue",
@@ -15,49 +16,23 @@ const Template: ComponentStory<typeof MetricValue> = (args) => (
 
 const washingtonState = states.findByRegionIdStrict("53");
 
-export const DefaultVariant = Template.bind({});
-DefaultVariant.args = {
+export const Default = Template.bind({});
+Default.args = {
   region: washingtonState,
   metric: MetricId.MOCK_CASES,
 };
 
-export const DataTabular = Template.bind({});
-DataTabular.args = { ...DefaultVariant.args, variant: "dataTabular" };
-
-export const AlignedRight = () => (
-  <div
-    style={{
-      width: 300,
-      border: "dashed 1px #eee",
-      display: "flex",
-      justifyContent: "flex-end",
-    }}
-  >
-    <MetricValue
-      region={washingtonState}
-      metric={MetricId.MOCK_CASES}
-      style={{ width: "fit-content" }}
-    />
-  </div>
-);
-
-export const SpaceBetween = () => (
-  <MetricValue
-    region={washingtonState}
-    metric={MetricId.MOCK_CASES}
-    justifyContent="space-between"
-    style={{ width: 300, border: "dashed 1px #eee" }}
-  />
-);
+export const DataTabularVariant = Template.bind({});
+DataTabularVariant.args = { ...Default.args, variant: "dataTabular" };
 
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
-  ...DefaultVariant.args,
+  ...Default.args,
   metric: MetricId.MOCK_CASES_DELAY_1S,
 };
 
 export const LoadingError = Template.bind({});
 LoadingError.args = {
-  ...DefaultVariant.args,
+  ...Default.args,
   metric: MetricId.MOCK_CASES_ERROR,
 };

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -1,12 +1,13 @@
-import React from "react";
-import { Stack, StackProps, Typography, TypographyProps } from "@mui/material";
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
-import { useMetricCatalog } from "../MetricCatalogContext";
-import { MetricDot } from "../MetricDot";
-import { useData } from "../../common/hooks";
+import { Stack, Typography, TypographyProps } from "@mui/material";
 
-export interface MetricValueProps extends StackProps {
+import { Metric } from "@actnowcoalition/metrics";
+import { MetricDot } from "../MetricDot";
+import React from "react";
+import { Region } from "@actnowcoalition/regions";
+import { useData } from "../../common/hooks";
+import { useMetricCatalog } from "../MetricCatalogContext";
+
+export interface MetricValueProps {
   /** Region for which we want to show the metric value */
   region: Region;
   /** Metric for which we want to show the metric value  */
@@ -22,7 +23,6 @@ export const MetricValue = ({
   region,
   metric: metricOrId,
   variant = "dataEmphasizedLarge",
-  ...stackProps
 }: MetricValueProps) => {
   const metricCatalog = useMetricCatalog();
   const metric = metricCatalog.getMetric(metricOrId);
@@ -34,7 +34,7 @@ export const MetricValue = ({
   }
 
   return (
-    <Stack direction="row" spacing={1} alignItems="center" {...stackProps}>
+    <Stack direction="row" spacing={1} alignItems="center" width="fit-content">
       <MetricDot region={region} metric={metric} />
       <Typography variant={variant}>
         {metric.formatValue(data.currentValue, "---")}

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
 import { ProgressBar } from ".";
+import React from "react";
 
 export default {
   title: "Charts/ProgressBar",
@@ -18,15 +19,5 @@ export const DefaultProps = Template.bind({});
 DefaultProps.args = {
   maxValue: 100,
   value: 39,
-  color: "#5936B6",
-  "aria-label": "Vaccination",
-};
-
-export const ARIALabelledBy = Template.bind({});
-ARIALabelledBy.args = {
-  "aria-labelledby": "meter-label",
-  minValue: 0,
-  maxValue: 100,
-  value: 75,
   color: "#5936B6",
 };

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,8 +1,12 @@
 import React from "react";
-import { scaleLinear } from "@visx/scale";
 import { RectClipGroup } from "../RectClipGroup";
+import { scaleLinear } from "@visx/scale";
 
-export interface BaseProgressBarProps {
+export interface ProgressBarProps {
+  /** Width of the progress bar */
+  width?: number;
+  /** Height of the progress bar */
+  height?: number;
   /** Border radius of the progress bar */
   borderRadius?: number;
   /** Minimum value in the range */
@@ -17,12 +21,6 @@ export interface BaseProgressBarProps {
   backgroundColor?: string;
 }
 
-export type ProgressBarProps = BaseProgressBarProps &
-  Omit<
-    React.SVGProps<SVGSVGElement>,
-    "aria-valuemin" | "aria-valuemax" | "aria-valuenow"
-  >;
-
 /**
  * Chart that shows a numeric value that varies within a defined range.
  *
@@ -30,12 +28,6 @@ export type ProgressBarProps = BaseProgressBarProps &
  * order for assistive technologies to describe the values correctly. For
  * example, to represent 35%, we should set minValue=0, maxValue=100, and
  * currentValue=35.
- *
- * By default, the role of the component is 'meter', since the role
- * 'progressbar' is appropriate to show progress of tasks.
- *
- * https://www.w3.org/WAI/ARIA/apg/patterns/meter/
- * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role
  */
 export const ProgressBar = ({
   width = 300,
@@ -46,7 +38,6 @@ export const ProgressBar = ({
   backgroundColor = "rgba(95, 108, 114, 0.2)",
   value,
   color,
-  role = "meter",
   ...otherSvgProps
 }: ProgressBarProps) => {
   const xScale = scaleLinear({
@@ -58,7 +49,6 @@ export const ProgressBar = ({
     <svg
       width={width}
       height={height}
-      role={role}
       aria-valuemin={minValue}
       aria-valuemax={maxValue}
       aria-valuenow={value}

--- a/packages/ui-components/src/components/RectClipGroup/RectClipGroup.tsx
+++ b/packages/ui-components/src/components/RectClipGroup/RectClipGroup.tsx
@@ -14,10 +14,12 @@ import React, { SVGProps, useId } from "react";
  * ```
  */
 
+export type RectClipGroupProps = SVGProps<SVGRectElement>;
+
 export const RectClipGroup = ({
   children,
   ...rectProps
-}: SVGProps<SVGRectElement>) => {
+}: RectClipGroupProps) => {
   const clipPathId = useId();
   return (
     <>

--- a/packages/ui-components/src/components/ShareButton/ShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.tsx
@@ -1,27 +1,27 @@
-import React, { useState } from "react";
-import { Button, ButtonProps } from "@mui/material";
-import ShareIcon from "@mui/icons-material/Share";
 import { CopyLinkButton } from "./CopyLinkButton";
-import { TwitterShareButton } from "./TwitterShareButton";
 import { FacebookShareButton } from "./FacebookShareButton";
 import { Menu, MenuItem } from "./ShareButton.style";
+import { TwitterShareButton } from "./TwitterShareButton";
+import ShareIcon from "@mui/icons-material/Share";
+import { Button, ButtonProps, PopoverOrigin } from "@mui/material";
 import isNull from "lodash/isNull";
+import React, { useState } from "react";
 
 const noop = () => {
   return;
 };
 
-export interface BaseShareButtonProps {
+export interface ShareButtonProps {
   url: string;
   quote: string;
   hashtags?: string[];
   onCopyLink?: () => void;
   onShareTwitter?: () => void;
   onShareFacebook?: () => void;
-  menuOrigin?: "left" | "center" | "right";
+  menuOrigin?: PopoverOrigin["horizontal"];
+  variant?: ButtonProps["variant"];
+  size?: ButtonProps["size"];
 }
-
-export type ShareButtonProps = ButtonProps & BaseShareButtonProps;
 
 export const ShareButton = ({
   url,
@@ -31,7 +31,8 @@ export const ShareButton = ({
   onShareTwitter = noop,
   onShareFacebook = noop,
   menuOrigin = "left",
-  ...muiButtonProps
+  variant = "outlined",
+  size = "large",
 }: ShareButtonProps) => {
   const [anchorButton, setAnchorButton] = useState<null | HTMLElement>(null);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -44,10 +45,10 @@ export const ShareButton = ({
   return (
     <>
       <Button
-        variant="outlined"
+        variant={variant}
+        size={size}
         endIcon={<ShareIcon />}
         onClick={handleClick}
-        {...muiButtonProps}
       >
         Share
       </Button>

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -1,18 +1,13 @@
-import React from "react";
-import { Group } from "@visx/group";
-import { Timeseries } from "@actnowcoalition/metrics";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+
 import { BarChart } from "../BarChart";
+import { Group } from "@visx/group";
 import { LineChart } from "../LineChart";
-import { scaleUtc, scaleLinear } from "@visx/scale";
+import React from "react";
+import { Timeseries } from "@actnowcoalition/metrics";
 import { useTheme } from "@mui/material";
 
-export interface SparkLineProps {
-  /** Timeseries used to draw the bar chart */
-  timeseriesBarChart: Timeseries<number>;
-
-  /** Timeseries used to draw the line chart */
-  timeseriesLineChart: Timeseries<number>;
-
+export interface BaseSparkLineProps {
   /** Width of the whole spark line component */
   width?: number;
 
@@ -21,6 +16,14 @@ export interface SparkLineProps {
 
   /** Width of each bar, in pixels (2px by default) */
   barWidth?: number;
+}
+
+export interface SparkLineProps extends BaseSparkLineProps {
+  /** Timeseries used to draw the bar chart */
+  timeseriesBarChart: Timeseries<number>;
+
+  /** Timeseries used to draw the line chart */
+  timeseriesLineChart: Timeseries<number>;
 }
 
 export const SparkLine = ({

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -7,16 +7,17 @@
   resolved "https://registry.yarnpkg.com/@actnowcoalition/assert/-/assert-0.1.0.tgz#fa83caa21c419f20d7be7c10dafd70986613e6a0"
   integrity sha512-8dBa6CHFDuY/jAVtazVCDSl9796gaOLmsdMFX+uGBwQruEWpCq2jOkf/wvLypt9eoE+Dzi63Q5zbOIVXmlQRtQ==
 
-"@actnowcoalition/metrics@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.3.2.tgz#d09c668cc24202051231b0495cead23f2f5b6566"
-  integrity sha512-ShigCR7/UL/YDKoEwANGVark/tAqeIqSaR0bSg1hUCIW6sE5/SBAo/azcd+e51fGR6W9/MML2eTDDGaMZnTVTg==
+"@actnowcoalition/metrics@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@actnowcoalition/metrics/-/metrics-0.3.3.tgz#8194523d8e0506e43d1384615831740b7178c8cb"
+  integrity sha512-Qla8WNQ1ipQDA1D48dZ41GDuT5vBNi8k4aVGYv401+yr1dBX5ojG2DC14imLB80ga8Kfh3SLcMpHpmDYNKve+g==
   dependencies:
     "@actnowcoalition/assert" "^0.1.0"
     "@actnowcoalition/number-format" "^0.1.1"
     "@actnowcoalition/regions" "^0.1.1"
     "@actnowcoalition/time-utils" "^0.1.0"
     "@types/papaparse" "^5.3.3"
+    delay "^5.0.0"
     lodash "^4.17.21"
     node-fetch "^2.6.7"
     p-limit "^3.1.0"
@@ -5173,6 +5174,11 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+delay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
 
 delayed-stream@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Cleans up props for components where we were previously including _all_ of an element's native props, and edits these instances to grab only the needed props (rather than all of them).

Overall I leaned toward simplifying things as much as possible 🧹. If we find that we need to include more native props as we implement these components in the future, we can always update them.

✏️💬 See comments throughout PR code 💬✏️

Note: the only remaining component using all of an element's props is the `CompareTable`, which I left alone for now since @pnavarrc is working in that code