### PR TITLE
Fix #280: Make maps render in grey while loading to avoid layout shift.

### DIFF
--- a/.changeset/tidy-kangaroos-call.md
+++ b/.changeset/tidy-kangaroos-call.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Render map regions in grey while data is loading to avoid layout shifts.

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
@@ -17,15 +17,13 @@ export const MetricUSNationalMap = ({
 }: MetricUSNationalMapProps) => {
   const { data } = useDataForRegionsAndMetrics(regionDB.all, [metric], false);
 
-  if (!data) {
-    return null;
-  }
-
   return (
     <USNationalMap
       getFillColor={(regionId: string) => {
         const region = regionDB.findByRegionId(regionId);
-        return region ? data.metricData(region, metric).getColor() : "#eee";
+        return region && data
+          ? data.metricData(region, metric).getColor()
+          : "#eee";
       }}
       getRegionUrl={(regionId: string) => {
         const region = regionDB.findByRegionId(regionId);

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
@@ -22,15 +22,13 @@ export const MetricUSStateMap = ({
 
   const { data } = useDataForRegionsAndMetrics(mapRegions, [metric], false);
 
-  if (!data) {
-    return null;
-  }
-
   return (
     <USStateMap
       getFillColor={(regionId: string) => {
         const region = regionDB.findByRegionId(regionId);
-        return region ? data.metricData(region, metric).getColor() : "#eee";
+        return region && data
+          ? data.metricData(region, metric).getColor()
+          : "#eee";
       }}
       getRegionUrl={(regionId: string) => {
         const region = regionDB.findByRegionId(regionId);

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
@@ -16,15 +16,13 @@ export const MetricWorldMap = ({
 }: MetricWorldMapProps) => {
   const { data } = useDataForRegionsAndMetrics(regionDB.all, [metric], false);
 
-  if (!data) {
-    return null;
-  }
-
   return (
     <WorldMap
       getFillColor={(regionId: string) => {
         const region = regionDB.findByRegionId(regionId);
-        return region ? data.metricData(region, metric).getColor() : "#eee";
+        return region && data
+          ? data.metricData(region, metric).getColor()
+          : "#eee";
       }}
       getRegionUrl={(regionId: string) => {
         const region = regionDB.findByRegionId(regionId);


### PR DESCRIPTION
Render regions in grey while map data is loading.  Fixes #280.

I'm not sure if this is the 100% best solution (vs. a MUI skeleton or similar), but it is the easiest (we can avoid layout shifts without knowing the width / height that the map is going to be) so I figured I'd just do this for now.

See:
* https://act-now-packages--pr457-mikelehen-map-loadin-mo8u1ptn.web.app/storybook/index.html?path=/story/maps-multimetric-us-state-map--loading-delay
* https://act-now-packages--pr457-mikelehen-map-loadin-mo8u1ptn.web.app/storybook/index.html?path=/story/maps-us-national-map--loading-delay
* https://act-now-packages--pr457-mikelehen-map-loadin-mo8u1ptn.web.app/storybook/index.html?path=/story/maps-us-state-map--loading-delay
* https://act-now-packages--pr457-mikelehen-map-loadin-mo8u1ptn.web.app/storybook/index.html?path=/story/maps-world-map--loading-delay
