### PR TITLE
Import sorting

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,10 @@
 {
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
-  "importOrder": ["<THIRD_PARTY_MODULES>", "^@actnowcoalition/", "^[./]"]
+  "importOrder": [
+    "^react$",
+    "<THIRD_PARTY_MODULES>",
+    "^@actnowcoalition/",
+    "^[./]"
+  ]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
   "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true
+  "importOrderSortSpecifiers": true,
+  "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
-  "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"]
+  "importOrder": ["<THIRD_PARTY_MODULES>", "^@actnowcoalition/", "^[./]"]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,5 @@
-{}
+{
+  "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.24.4",
+    "@trivago/prettier-plugin-sort-imports": "^3.4.0",
     "@types/jest": "^27.5.1",
     "@types/node": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^5.23.0",

--- a/packages/metrics/src/Metric/Metric.test.ts
+++ b/packages/metrics/src/Metric/Metric.test.ts
@@ -1,7 +1,7 @@
-import { Metric } from "./Metric";
-import { CategorySet } from "./Category";
-import { MetricDefinition } from "./MetricDefinition";
 import { MetricCatalogOptions } from "../MetricCatalog";
+import { CategorySet } from "./Category";
+import { Metric } from "./Metric";
+import { MetricDefinition } from "./MetricDefinition";
 
 // Example of a typical metric with mostly default options.
 const testMetricDef: MetricDefinition = {

--- a/packages/metrics/src/Metric/Metric.ts
+++ b/packages/metrics/src/Metric/Metric.ts
@@ -1,13 +1,12 @@
-import last from "lodash/last";
-import isEqual from "lodash/isEqual";
-
 import { assert, fail } from "@actnowcoalition/assert";
 import { isFinite } from "@actnowcoalition/number-format";
+import isEqual from "lodash/isEqual";
+import last from "lodash/last";
 
-import { MetricDataReference } from "./MetricDataReference";
-import { Category, CategorySet } from "./Category";
-import { MetricDefinition } from "./MetricDefinition";
 import { MetricCatalogOptions } from "../MetricCatalog";
+import { Category, CategorySet } from "./Category";
+import { MetricDataReference } from "./MetricDataReference";
+import { MetricDefinition } from "./MetricDefinition";
 
 /** Default format options used for metrics that don't specify any. */
 const DEFAULT_FORMAT_OPTIONS: Intl.NumberFormatOptions = {

--- a/packages/metrics/src/Metric/Metric.ts
+++ b/packages/metrics/src/Metric/Metric.ts
@@ -1,7 +1,8 @@
-import { assert, fail } from "@actnowcoalition/assert";
-import { isFinite } from "@actnowcoalition/number-format";
 import isEqual from "lodash/isEqual";
 import last from "lodash/last";
+
+import { assert, fail } from "@actnowcoalition/assert";
+import { isFinite } from "@actnowcoalition/number-format";
 
 import { MetricCatalogOptions } from "../MetricCatalog";
 import { Category, CategorySet } from "./Category";

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.test.ts
@@ -1,8 +1,8 @@
 import { states } from "@actnowcoalition/regions";
 
-import { MetricCatalog } from "./MetricCatalog";
 import { SnapshotJSON } from "../data";
 import { MockDataProvider, StaticValueDataProvider } from "../data_providers";
+import { MetricCatalog } from "./MetricCatalog";
 
 enum MetricId {
   PI = "pi",

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.ts
@@ -1,7 +1,8 @@
-import { assert } from "@actnowcoalition/assert";
-import { Region } from "@actnowcoalition/regions";
 import groupBy from "lodash/groupBy";
 import keyBy from "lodash/keyBy";
+
+import { assert } from "@actnowcoalition/assert";
+import { Region } from "@actnowcoalition/regions";
 
 import { Metric, MetricDefinition } from "../Metric";
 import {

--- a/packages/metrics/src/MetricCatalog/MetricCatalog.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalog.ts
@@ -1,17 +1,16 @@
+import { assert } from "@actnowcoalition/assert";
+import { Region } from "@actnowcoalition/regions";
 import groupBy from "lodash/groupBy";
 import keyBy from "lodash/keyBy";
 
-import { Region } from "@actnowcoalition/regions";
-import { assert } from "@actnowcoalition/assert";
-
-import { MetricCatalogOptions } from "./MetricCatalogOptions";
+import { Metric, MetricDefinition } from "../Metric";
 import {
   MetricData,
   MultiMetricDataStore,
   MultiRegionMultiMetricDataStore,
 } from "../data";
 import { MetricDataProvider } from "../data_providers";
-import { Metric, MetricDefinition } from "../Metric";
+import { MetricCatalogOptions } from "./MetricCatalogOptions";
 
 /**
  * Catalog of metrics and the accompanying data providers to fetch data for them.

--- a/packages/metrics/src/MetricCatalog/MetricCatalogOptions.ts
+++ b/packages/metrics/src/MetricCatalog/MetricCatalogOptions.ts
@@ -1,5 +1,5 @@
+import { CategorySet, MetricDefinition } from "../Metric";
 import { SnapshotJSON } from "../data";
-import { MetricDefinition, CategorySet } from "../Metric";
 
 /**
  * Options that can be provided when creating a {@link MetricCatalog} that apply

--- a/packages/metrics/src/Timeseries/Timeseries.ts
+++ b/packages/metrics/src/Timeseries/Timeseries.ts
@@ -1,13 +1,12 @@
-import isNil from "lodash/isNil";
+import { assert } from "@actnowcoalition/assert";
+import { isFinite } from "@actnowcoalition/number-format";
+import { PureDate, isoDateOnlyString } from "@actnowcoalition/time-utils";
 import first from "lodash/first";
+import isNil from "lodash/isNil";
 import last from "lodash/last";
 import maxBy from "lodash/maxBy";
 import minBy from "lodash/minBy";
 import sumBy from "lodash/sumBy";
-
-import { assert } from "@actnowcoalition/assert";
-import { isFinite } from "@actnowcoalition/number-format";
-import { isoDateOnlyString, PureDate } from "@actnowcoalition/time-utils";
 
 /** A single, serialized point in a timeseries containing a date-string and a value. */
 export interface TimeseriesPointJSON {

--- a/packages/metrics/src/Timeseries/Timeseries.ts
+++ b/packages/metrics/src/Timeseries/Timeseries.ts
@@ -1,12 +1,13 @@
-import { assert } from "@actnowcoalition/assert";
-import { isFinite } from "@actnowcoalition/number-format";
-import { PureDate, isoDateOnlyString } from "@actnowcoalition/time-utils";
 import first from "lodash/first";
 import isNil from "lodash/isNil";
 import last from "lodash/last";
 import maxBy from "lodash/maxBy";
 import minBy from "lodash/minBy";
 import sumBy from "lodash/sumBy";
+
+import { assert } from "@actnowcoalition/assert";
+import { isFinite } from "@actnowcoalition/number-format";
+import { PureDate, isoDateOnlyString } from "@actnowcoalition/time-utils";
 
 /** A single, serialized point in a timeseries containing a date-string and a value. */
 export interface TimeseriesPointJSON {

--- a/packages/metrics/src/data/MetricData.test.ts
+++ b/packages/metrics/src/data/MetricData.test.ts
@@ -1,4 +1,5 @@
 import { states } from "@actnowcoalition/regions";
+
 import { Metric } from "../Metric";
 import { Timeseries } from "../Timeseries";
 import { MetricData } from "./MetricData";

--- a/packages/metrics/src/data/MetricData.ts
+++ b/packages/metrics/src/data/MetricData.ts
@@ -1,7 +1,7 @@
-import { Region } from "@actnowcoalition/regions";
 import { assert } from "@actnowcoalition/assert";
+import { Region } from "@actnowcoalition/regions";
 
-import { Metric, Category } from "../Metric";
+import { Category, Metric } from "../Metric";
 import { Timeseries } from "../Timeseries";
 import { parseBoolean } from "./data_utils";
 

--- a/packages/metrics/src/data/MultiMetricDataStore.ts
+++ b/packages/metrics/src/data/MultiMetricDataStore.ts
@@ -1,6 +1,7 @@
+import mapValues from "lodash/mapValues";
+
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
-import mapValues from "lodash/mapValues";
 
 import { Metric } from "../Metric";
 import { MetricData } from "./MetricData";

--- a/packages/metrics/src/data/MultiMetricDataStore.ts
+++ b/packages/metrics/src/data/MultiMetricDataStore.ts
@@ -1,10 +1,9 @@
-import mapValues from "lodash/mapValues";
-
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
+import mapValues from "lodash/mapValues";
 
-import { MetricData } from "./MetricData";
 import { Metric } from "../Metric";
+import { MetricData } from "./MetricData";
 
 export interface MetricToDataMap<T> {
   [id: string]: MetricData<T>;

--- a/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
+++ b/packages/metrics/src/data/MultiRegionMultiMetricDataStore.test.ts
@@ -1,15 +1,15 @@
 import { states } from "@actnowcoalition/regions";
+import { isoDateOnlyString } from "@actnowcoalition/time-utils";
 
+import { Metric } from "../Metric";
+import { MetricCatalog } from "../MetricCatalog";
+import { StaticValueDataProvider } from "../data_providers";
+import { MetricData } from "./MetricData";
+import { MultiMetricDataStore } from "./MultiMetricDataStore";
 import {
   MultiRegionMultiMetricDataStore,
   SnapshotJSON,
 } from "./MultiRegionMultiMetricDataStore";
-import { MultiMetricDataStore } from "./MultiMetricDataStore";
-import { MetricData } from "./MetricData";
-import { Metric } from "../Metric";
-import { StaticValueDataProvider } from "../data_providers";
-import { isoDateOnlyString } from "@actnowcoalition/time-utils";
-import { MetricCatalog } from "../MetricCatalog";
 
 enum ProviderId {
   STATIC = "static",

--- a/packages/metrics/src/data/MultiRegionMultiMetricDataStore.ts
+++ b/packages/metrics/src/data/MultiRegionMultiMetricDataStore.ts
@@ -1,7 +1,8 @@
+import mapValues from "lodash/mapValues";
+
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
 import { isoDateOnlyString } from "@actnowcoalition/time-utils";
-import mapValues from "lodash/mapValues";
 
 import { Metric } from "../Metric";
 import { Timeseries, TimeseriesPointJSON } from "../Timeseries";

--- a/packages/metrics/src/data/MultiRegionMultiMetricDataStore.ts
+++ b/packages/metrics/src/data/MultiRegionMultiMetricDataStore.ts
@@ -1,13 +1,12 @@
-import mapValues from "lodash/mapValues";
-
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
+import { isoDateOnlyString } from "@actnowcoalition/time-utils";
+import mapValues from "lodash/mapValues";
 
-import { MetricData } from "./MetricData";
-import { MetricToDataMap, MultiMetricDataStore } from "./MultiMetricDataStore";
 import { Metric } from "../Metric";
 import { Timeseries, TimeseriesPointJSON } from "../Timeseries";
-import { isoDateOnlyString } from "@actnowcoalition/time-utils";
+import { MetricData } from "./MetricData";
+import { MetricToDataMap, MultiMetricDataStore } from "./MultiMetricDataStore";
 
 /**
  * JSON format of a data snapshot representing the contents of a

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.test.ts
@@ -1,4 +1,5 @@
-import { counties, nations, metros, states } from "@actnowcoalition/regions";
+import { counties, metros, nations, states } from "@actnowcoalition/regions";
+
 import { MetricCatalog } from "../MetricCatalog";
 import { CovidActNowDataProvider } from "./CovidActNowDataProvider";
 

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
@@ -1,17 +1,18 @@
-import pLimit from "p-limit";
-import { Region } from "@actnowcoalition/regions";
-import { Metric } from "../Metric";
 import { assert } from "@actnowcoalition/assert";
+import { Region } from "@actnowcoalition/regions";
+import mapValues from "lodash/mapValues";
+import pLimit from "p-limit";
+
+import { Metric } from "../Metric";
+import { MultiRegionMultiMetricDataStore } from "../data";
+import { MetricData } from "../data/MetricData";
+import { MetricDataProvider } from "./MetricDataProvider";
 import {
-  dataRowsToMetricData,
   dataRowToMetricData,
+  dataRowsToMetricData,
 } from "./data_provider_utils";
 import { DataRow } from "./data_provider_utils";
-import { MetricData } from "../data/MetricData";
 import { fetchJson } from "./utils";
-import { MetricDataProvider } from "./MetricDataProvider";
-import { MultiRegionMultiMetricDataStore } from "../data";
-import mapValues from "lodash/mapValues";
 
 // Limit having too many outstanding requests at once, to avoid timeouts, etc.
 const MAX_CONCURRENT_REQUESTS = 50;

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
@@ -1,7 +1,8 @@
-import { assert } from "@actnowcoalition/assert";
-import { Region } from "@actnowcoalition/regions";
 import mapValues from "lodash/mapValues";
 import pLimit from "p-limit";
+
+import { assert } from "@actnowcoalition/assert";
+import { Region } from "@actnowcoalition/regions";
 
 import { Metric } from "../Metric";
 import { MultiRegionMultiMetricDataStore } from "../data";

--- a/packages/metrics/src/data_providers/CsvDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.test.ts
@@ -1,7 +1,8 @@
-import { CsvDataProvider } from "./CsvDataProvider";
-import { Metric } from "../Metric";
 import { states } from "@actnowcoalition/regions";
+
+import { Metric } from "../Metric";
 import { MetricCatalog } from "../MetricCatalog";
+import { CsvDataProvider } from "./CsvDataProvider";
 
 const PROVIDER_ID = "csv-provider";
 

--- a/packages/metrics/src/data_providers/CsvDataProvider.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.ts
@@ -1,8 +1,9 @@
-import { assert } from "@actnowcoalition/assert";
-import { Region, RegionDB } from "@actnowcoalition/regions";
 import groupBy from "lodash/groupBy";
 import isEmpty from "lodash/isEmpty";
 import truncate from "lodash/truncate";
+
+import { assert } from "@actnowcoalition/assert";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { Metric } from "../Metric";
 import { MetricData } from "../data";

--- a/packages/metrics/src/data_providers/CsvDataProvider.ts
+++ b/packages/metrics/src/data_providers/CsvDataProvider.ts
@@ -1,17 +1,18 @@
 import { assert } from "@actnowcoalition/assert";
 import { Region, RegionDB } from "@actnowcoalition/regions";
-import { SimpleMetricDataProviderBase } from "./SimpleMetricDataProviderBase";
+import groupBy from "lodash/groupBy";
+import isEmpty from "lodash/isEmpty";
+import truncate from "lodash/truncate";
+
 import { Metric } from "../Metric";
 import { MetricData } from "../data";
+import { SimpleMetricDataProviderBase } from "./SimpleMetricDataProviderBase";
 import {
   DataRow,
   dataRowToMetricData,
   dataRowsToMetricData,
   parseCsv,
 } from "./data_provider_utils";
-import groupBy from "lodash/groupBy";
-import isEmpty from "lodash/isEmpty";
-import truncate from "lodash/truncate";
 import { fetchText } from "./utils";
 
 export interface CsvDataProviderOptions {

--- a/packages/metrics/src/data_providers/MetricDataProvider.ts
+++ b/packages/metrics/src/data_providers/MetricDataProvider.ts
@@ -1,8 +1,8 @@
 import { Region } from "@actnowcoalition/regions";
 
 import { Metric } from "../Metric";
-import { MultiRegionMultiMetricDataStore } from "../data";
 import type { MetricCatalog } from "../MetricCatalog";
+import { MultiRegionMultiMetricDataStore } from "../data";
 
 /**
  * Interface that all metric data providers must implement.

--- a/packages/metrics/src/data_providers/MockDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/MockDataProvider.test.ts
@@ -1,8 +1,8 @@
 import { assert } from "@actnowcoalition/assert";
 import { states } from "@actnowcoalition/regions";
 
-import { MockDataProvider } from "./MockDataProvider";
 import { Metric } from "../Metric";
+import { MockDataProvider } from "./MockDataProvider";
 
 const testRegion = states.findByRegionIdStrict("53"); // Washington.
 

--- a/packages/metrics/src/data_providers/MockDataProvider.ts
+++ b/packages/metrics/src/data_providers/MockDataProvider.ts
@@ -1,12 +1,12 @@
-import delay from "delay";
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
-import { getTimeDiff, TimeUnit } from "@actnowcoalition/time-utils";
+import { TimeUnit, getTimeDiff } from "@actnowcoalition/time-utils";
+import delay from "delay";
 
-import { SimpleMetricDataProviderBase } from "./SimpleMetricDataProviderBase";
-import { MetricData } from "../data";
 import { Metric } from "../Metric";
 import { mockTimeseries } from "../Timeseries";
+import { MetricData } from "../data";
+import { SimpleMetricDataProviderBase } from "./SimpleMetricDataProviderBase";
 
 /**
  * Fields allowed in the { @link MetricDefinition.dataReference } of metrics using the

--- a/packages/metrics/src/data_providers/MockDataProvider.ts
+++ b/packages/metrics/src/data_providers/MockDataProvider.ts
@@ -1,7 +1,8 @@
+import delay from "delay";
+
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
 import { TimeUnit, getTimeDiff } from "@actnowcoalition/time-utils";
-import delay from "delay";
 
 import { Metric } from "../Metric";
 import { mockTimeseries } from "../Timeseries";

--- a/packages/metrics/src/data_providers/SimpleMetricDataProviderBase.ts
+++ b/packages/metrics/src/data_providers/SimpleMetricDataProviderBase.ts
@@ -1,9 +1,9 @@
 import { Region } from "@actnowcoalition/regions";
 
-import { MetricDataProvider } from "./MetricDataProvider";
 import { Metric } from "../Metric";
-import { MetricData, MultiRegionMultiMetricDataStore } from "../data";
 import { MetricCatalog } from "../MetricCatalog";
+import { MetricData, MultiRegionMultiMetricDataStore } from "../data";
+import { MetricDataProvider } from "./MetricDataProvider";
 
 /**
  * Base class to help implement a MetricDataProvider that fetches one

--- a/packages/metrics/src/data_providers/StaticValueDataProvider.ts
+++ b/packages/metrics/src/data_providers/StaticValueDataProvider.ts
@@ -1,10 +1,10 @@
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
 
-import { SimpleMetricDataProviderBase } from "./SimpleMetricDataProviderBase";
 import { Metric } from "../Metric";
 import { Timeseries } from "../Timeseries";
 import { MetricData } from "../data";
+import { SimpleMetricDataProviderBase } from "./SimpleMetricDataProviderBase";
 
 /**
  * Simple data provider that provides a static value for all regions. Mostly

--- a/packages/metrics/src/data_providers/TransformedMetricDataProvider.test.ts
+++ b/packages/metrics/src/data_providers/TransformedMetricDataProvider.test.ts
@@ -1,10 +1,10 @@
 import { Region, states } from "@actnowcoalition/regions";
 
-import { TransformedMetricDataProvider } from "./TransformedMetricDataProvider";
 import { Metric } from "../Metric";
-import { MetricData } from "../data";
 import { MetricCatalog } from "../MetricCatalog";
+import { MetricData } from "../data";
 import { StaticValueDataProvider } from "./StaticValueDataProvider";
+import { TransformedMetricDataProvider } from "./TransformedMetricDataProvider";
 
 const testRegion = states.findByRegionIdStrict("53"); // Washington.
 

--- a/packages/metrics/src/data_providers/TransformedMetricDataProvider.ts
+++ b/packages/metrics/src/data_providers/TransformedMetricDataProvider.ts
@@ -1,12 +1,11 @@
-import fromPairs from "lodash/fromPairs";
-
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
+import fromPairs from "lodash/fromPairs";
 
-import { MetricDataProvider } from "./MetricDataProvider";
-import { MetricData, MultiRegionMultiMetricDataStore } from "../data";
 import { Metric } from "../Metric";
 import type { MetricCatalog } from "../MetricCatalog";
+import { MetricData, MultiRegionMultiMetricDataStore } from "../data";
+import { MetricDataProvider } from "./MetricDataProvider";
 
 /**
  * Base class to help implement a MetricDataProvider that provides data by

--- a/packages/metrics/src/data_providers/TransformedMetricDataProvider.ts
+++ b/packages/metrics/src/data_providers/TransformedMetricDataProvider.ts
@@ -1,6 +1,7 @@
+import fromPairs from "lodash/fromPairs";
+
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
-import fromPairs from "lodash/fromPairs";
 
 import { Metric } from "../Metric";
 import type { MetricCatalog } from "../MetricCatalog";

--- a/packages/metrics/src/data_providers/data_provider_utils.test.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.test.ts
@@ -1,7 +1,8 @@
-import { states } from "@actnowcoalition/regions";
 // eslint-disable-next-line lodash/import-scope
 import { Dictionary } from "lodash";
 import groupBy from "lodash/groupBy";
+
+import { states } from "@actnowcoalition/regions";
 
 import { Metric } from "../Metric";
 import {

--- a/packages/metrics/src/data_providers/data_provider_utils.test.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.test.ts
@@ -1,15 +1,16 @@
-import { Metric } from "../Metric";
 import { states } from "@actnowcoalition/regions";
+// eslint-disable-next-line lodash/import-scope
+import { Dictionary } from "lodash";
+import groupBy from "lodash/groupBy";
+
+import { Metric } from "../Metric";
 import {
   DataRow,
-  dataRowsToMetricData,
   dataRowToMetricData,
+  dataRowsToMetricData,
   generateCsv,
   parseCsv,
 } from "./data_provider_utils";
-import groupBy from "lodash/groupBy";
-// eslint-disable-next-line lodash/import-scope
-import { Dictionary } from "lodash";
 
 const newYork = states.findByRegionIdStrict("36");
 const testMetric = new Metric({

--- a/packages/metrics/src/data_providers/data_provider_utils.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.ts
@@ -1,11 +1,12 @@
 import { assert } from "@actnowcoalition/assert";
 import { Region } from "@actnowcoalition/regions";
-import { Metric } from "../Metric";
-import { MetricData } from "../data";
-import { Timeseries } from "../Timeseries";
 import get from "lodash/get";
 import isNil from "lodash/isNil";
 import Papa from "papaparse";
+
+import { Metric } from "../Metric";
+import { Timeseries } from "../Timeseries";
+import { MetricData } from "../data";
 
 /**
  * Represents a "row" of data (e.g. as read from a CSV), with key-value pairs

--- a/packages/metrics/src/data_providers/data_provider_utils.ts
+++ b/packages/metrics/src/data_providers/data_provider_utils.ts
@@ -1,8 +1,9 @@
-import { assert } from "@actnowcoalition/assert";
-import { Region } from "@actnowcoalition/regions";
 import get from "lodash/get";
 import isNil from "lodash/isNil";
 import Papa from "papaparse";
+
+import { assert } from "@actnowcoalition/assert";
+import { Region } from "@actnowcoalition/regions";
 
 import { Metric } from "../Metric";
 import { Timeseries } from "../Timeseries";

--- a/packages/number-format/src/index.test.ts
+++ b/packages/number-format/src/index.test.ts
@@ -1,9 +1,9 @@
 import {
-  formatInteger,
-  formatDecimal,
-  formatPercent,
-  formatMillions,
   formatBillions,
+  formatDecimal,
+  formatInteger,
+  formatMillions,
+  formatPercent,
 } from "./index";
 
 describe("numberFormatUtils", () => {

--- a/packages/regions/README.md
+++ b/packages/regions/README.md
@@ -48,7 +48,7 @@ See [`src/datasets/us/states.json`](src/datasets/us/states.json), [`src/datasets
 ##### Using states, counties, and metropolitan areas
 
 ```tsx
-import { states, counties, metros } from "@actnowcoalition/regions";
+import { counties, metros, states } from "@actnowcoalition/regions";
 
 const ny = states.findByRegionId("36");
 console.log(ny.fullName); // New York

--- a/packages/regions/src/Region.ts
+++ b/packages/regions/src/Region.ts
@@ -1,5 +1,6 @@
-import lowerCase from "lodash/lowerCase";
 import deburr from "lodash/deburr";
+import lowerCase from "lodash/lowerCase";
+
 import { urlJoin } from "./utils";
 
 export interface RegionJSON {

--- a/packages/regions/src/RegionDB.test.ts
+++ b/packages/regions/src/RegionDB.test.ts
@@ -1,4 +1,4 @@
-import { states, Region, RegionDB } from ".";
+import { Region, RegionDB, states } from ".";
 
 describe("RegionDB", () => {
   test("getRegionUrl returns the corresponding URL for the region", () => {

--- a/packages/regions/src/RegionDB.ts
+++ b/packages/regions/src/RegionDB.ts
@@ -1,5 +1,6 @@
-import keyBy from "lodash/keyBy";
 import { assert } from "@actnowcoalition/assert";
+import keyBy from "lodash/keyBy";
+
 import { Region } from "./Region";
 
 export interface RegionDBOptions {

--- a/packages/regions/src/RegionDB.ts
+++ b/packages/regions/src/RegionDB.ts
@@ -1,5 +1,6 @@
-import { assert } from "@actnowcoalition/assert";
 import keyBy from "lodash/keyBy";
+
+import { assert } from "@actnowcoalition/assert";
 
 import { Region } from "./Region";
 

--- a/packages/regions/src/datasets/nations/nations_db.ts
+++ b/packages/regions/src/datasets/nations/nations_db.ts
@@ -1,5 +1,5 @@
-import RegionDB from "../../RegionDB";
 import { Region } from "../../Region";
+import RegionDB from "../../RegionDB";
 import nationsJSON from "./nations.json";
 
 const nations = nationsJSON.map((country) => {

--- a/packages/regions/src/datasets/us/counties_db.ts
+++ b/packages/regions/src/datasets/us/counties_db.ts
@@ -1,5 +1,5 @@
-import RegionDB from "../../RegionDB";
 import { Region } from "../../Region";
+import RegionDB from "../../RegionDB";
 import countiesJSON from "./counties.json";
 import statesDB from "./states_db";
 

--- a/packages/regions/src/datasets/us/index.ts
+++ b/packages/regions/src/datasets/us/index.ts
@@ -1,5 +1,5 @@
-import states from "./states_db";
 import counties from "./counties_db";
 import metros from "./metros_db";
+import states from "./states_db";
 
 export { states, counties, metros };

--- a/packages/regions/src/datasets/us/metros_db.ts
+++ b/packages/regions/src/datasets/us/metros_db.ts
@@ -1,5 +1,5 @@
-import RegionDB from "../../RegionDB";
 import { Region } from "../../Region";
+import RegionDB from "../../RegionDB";
 import metrosJson from "./metros.json";
 import statesDB from "./states_db";
 

--- a/packages/regions/src/datasets/us/states_db.ts
+++ b/packages/regions/src/datasets/us/states_db.ts
@@ -1,6 +1,6 @@
-import statesJSON from "./states.json";
 import { Region } from "../../Region";
 import RegionDB from "../../RegionDB";
+import statesJSON from "./states.json";
 
 const states = statesJSON
   .map((state) => {

--- a/packages/time-utils/src/index.test.ts
+++ b/packages/time-utils/src/index.test.ts
@@ -1,16 +1,16 @@
 import {
   DateFormat,
   TimeUnit,
+  addTime,
+  assertDateOnly,
   formatDateTime,
   formatUTCDateTime,
-  parseDateString,
-  parseDateUnix,
-  addTime,
-  subtractTime,
   getStartOf,
   getTimeDiff,
   isoDateOnlyString,
-  assertDateOnly,
+  parseDateString,
+  parseDateUnix,
+  subtractTime,
 } from "./index";
 
 /**

--- a/packages/time-utils/src/index.ts
+++ b/packages/time-utils/src/index.ts
@@ -1,5 +1,6 @@
-import { assert } from "@actnowcoalition/assert";
 import { DateTime, Duration } from "luxon";
+
+import { assert } from "@actnowcoalition/assert";
 
 export * from "./PureDate";
 

--- a/packages/time-utils/src/index.ts
+++ b/packages/time-utils/src/index.ts
@@ -1,5 +1,5 @@
-import { DateTime, Duration } from "luxon";
 import { assert } from "@actnowcoalition/assert";
+import { DateTime, Duration } from "luxon";
 
 export * from "./PureDate";
 

--- a/packages/ui-components/.storybook/preview.tsx
+++ b/packages/ui-components/.storybook/preview.tsx
@@ -1,6 +1,7 @@
-import React from "react";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
+import React from "react";
+
 import { MetricCatalogProvider } from "../src/components/MetricCatalogContext";
 import { metricCatalog } from "../src/stories/mockMetricCatalog";
 import { theme } from "../src/styles";

--- a/packages/ui-components/.storybook/preview.tsx
+++ b/packages/ui-components/.storybook/preview.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
-import React from "react";
 
 import { MetricCatalogProvider } from "../src/components/MetricCatalogContext";
 import { metricCatalog } from "../src/stories/mockMetricCatalog";

--- a/packages/ui-components/src/common/geo-shapes/county-shapes.ts
+++ b/packages/ui-components/src/common/geo-shapes/county-shapes.ts
@@ -1,7 +1,8 @@
-import { Topology } from "topojson-specification";
-import { excludeTerritories, getGeoBorders, getGeoShapes } from "./utils";
 import { ExtendedFeature } from "d3-geo";
+import { Topology } from "topojson-specification";
+
 import countiesJSON from "./counties-10m.json";
+import { excludeTerritories, getGeoBorders, getGeoShapes } from "./utils";
 
 const countiesTopology = countiesJSON as unknown as Topology;
 

--- a/packages/ui-components/src/common/geo-shapes/nation-shapes.ts
+++ b/packages/ui-components/src/common/geo-shapes/nation-shapes.ts
@@ -1,6 +1,7 @@
-import { feature, mesh } from "topojson-client";
 import { FeatureCollection, Geometry, MultiLineString } from "geojson";
+import { feature, mesh } from "topojson-client";
 import { GeometryCollection } from "topojson-specification";
+
 import nationsJSON from "./nations.json";
 
 interface CountryGeoProps {

--- a/packages/ui-components/src/common/geo-shapes/state-shapes.ts
+++ b/packages/ui-components/src/common/geo-shapes/state-shapes.ts
@@ -1,7 +1,8 @@
-import { excludeTerritories, getGeoBorders, getGeoShapes } from "./utils";
 import { ExtendedFeature } from "d3-geo";
 import { Topology } from "topojson-specification";
+
 import statesJSON from "./states-10m.json";
+import { excludeTerritories, getGeoBorders, getGeoShapes } from "./utils";
 
 const statesTopology = statesJSON as unknown as Topology;
 

--- a/packages/ui-components/src/common/geo-shapes/utils.ts
+++ b/packages/ui-components/src/common/geo-shapes/utils.ts
@@ -1,8 +1,8 @@
-import { GeometryObject, Topology } from "topojson-specification";
-import { feature, mesh } from "topojson-client";
+import { RegionDB, counties, metros, states } from "@actnowcoalition/regions";
 import { ExtendedFeature } from "d3-geo";
-import { RegionDB, counties, states, metros } from "@actnowcoalition/regions";
 import isNull from "lodash/isNull";
+import { feature, mesh } from "topojson-client";
+import { GeometryObject, Topology } from "topojson-specification";
 
 type FeatureCollection = GeoJSON.FeatureCollection<
   GeoJSON.Geometry,

--- a/packages/ui-components/src/common/geo-shapes/utils.ts
+++ b/packages/ui-components/src/common/geo-shapes/utils.ts
@@ -1,8 +1,9 @@
-import { RegionDB, counties, metros, states } from "@actnowcoalition/regions";
 import { ExtendedFeature } from "d3-geo";
 import isNull from "lodash/isNull";
 import { feature, mesh } from "topojson-client";
 import { GeometryObject, Topology } from "topojson-specification";
+
+import { RegionDB, counties, metros, states } from "@actnowcoalition/regions";
 
 type FeatureCollection = GeoJSON.FeatureCollection<
   GeoJSON.Geometry,

--- a/packages/ui-components/src/common/hooks/metric-data.test.tsx
+++ b/packages/ui-components/src/common/hooks/metric-data.test.tsx
@@ -1,11 +1,12 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import React from "react";
+
 import {
   MetricCatalog,
   StaticValueDataProvider,
 } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";
-import { renderHook, waitFor } from "@testing-library/react";
-import { ReactNode } from "react";
-import React from "react";
 
 import { MetricCatalogProvider } from "../../components/MetricCatalogContext";
 import {

--- a/packages/ui-components/src/common/hooks/metric-data.test.tsx
+++ b/packages/ui-components/src/common/hooks/metric-data.test.tsx
@@ -1,6 +1,7 @@
-import { renderHook, waitFor } from "@testing-library/react";
 import { ReactNode } from "react";
 import React from "react";
+
+import { renderHook, waitFor } from "@testing-library/react";
 
 import {
   MetricCatalog,

--- a/packages/ui-components/src/common/hooks/metric-data.test.tsx
+++ b/packages/ui-components/src/common/hooks/metric-data.test.tsx
@@ -1,18 +1,18 @@
-import { renderHook, waitFor } from "@testing-library/react";
-
 import {
   MetricCatalog,
   StaticValueDataProvider,
 } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";
+import { renderHook, waitFor } from "@testing-library/react";
+import { ReactNode } from "react";
+import React from "react";
+
+import { MetricCatalogProvider } from "../../components/MetricCatalogContext";
 import {
   useData,
   useDataForMetrics,
   useDataForRegionsAndMetrics,
 } from "./metric-data";
-import { MetricCatalogProvider } from "../../components/MetricCatalogContext";
-import { ReactNode } from "react";
-import React from "react";
 
 enum MetricId {
   PI = "pi",

--- a/packages/ui-components/src/common/hooks/metric-data.ts
+++ b/packages/ui-components/src/common/hooks/metric-data.ts
@@ -1,12 +1,13 @@
-import truncate from "lodash/truncate";
-import useSWR, { Fetcher, Key, SWRResponse } from "swr";
-import { Region } from "@actnowcoalition/regions";
 import {
   Metric,
   MetricData,
   MultiMetricDataStore,
   MultiRegionMultiMetricDataStore,
 } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+import truncate from "lodash/truncate";
+import useSWR, { Fetcher, Key, SWRResponse } from "swr";
+
 import { useMetricCatalog } from "../../components/MetricCatalogContext";
 
 /**

--- a/packages/ui-components/src/common/hooks/metric-data.ts
+++ b/packages/ui-components/src/common/hooks/metric-data.ts
@@ -1,3 +1,6 @@
+import truncate from "lodash/truncate";
+import useSWR, { Fetcher, Key, SWRResponse } from "swr";
+
 import {
   Metric,
   MetricData,
@@ -5,8 +8,6 @@ import {
   MultiRegionMultiMetricDataStore,
 } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import truncate from "lodash/truncate";
-import useSWR, { Fetcher, Key, SWRResponse } from "swr";
 
 import { useMetricCatalog } from "../../components/MetricCatalogContext";
 

--- a/packages/ui-components/src/common/hooks/useResizeObserver.ts
+++ b/packages/ui-components/src/common/hooks/useResizeObserver.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseResizeObserverResult {
   setObservedNode: React.Dispatch<React.SetStateAction<HTMLElement | null>>;

--- a/packages/ui-components/src/common/hooks/useSvgBBox.tsx
+++ b/packages/ui-components/src/common/hooks/useSvgBBox.tsx
@@ -1,4 +1,4 @@
-import { useState, useLayoutEffect } from "react";
+import { useLayoutEffect, useState } from "react";
 
 /**
  * Returns an object with the width, height, top and left client coordinates

--- a/packages/ui-components/src/common/utils/index.ts
+++ b/packages/ui-components/src/common/utils/index.ts
@@ -1,5 +1,6 @@
-export { default as importJson } from "./importJson";
 import { formatInteger } from "@actnowcoalition/number-format";
+
+export { default as importJson } from "./importJson";
 
 /**
  * Format the population with thousands separator and keeping 3 significant

--- a/packages/ui-components/src/common/utils/maps.ts
+++ b/packages/ui-components/src/common/utils/maps.ts
@@ -1,4 +1,4 @@
-import { RegionDB, Region } from "@actnowcoalition/regions";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 export interface BaseUSMapProps {
   renderTooltip: (regionId: string) => React.ReactNode;

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
@@ -1,7 +1,8 @@
-import { states } from "@actnowcoalition/regions";
 import { Box, Grid, colors } from "@mui/material";
 import { ComponentMeta } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { AutoWidth } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Box, Grid, colors } from "@mui/material";
 import { ComponentMeta } from "@storybook/react";
-import React from "react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
@@ -1,11 +1,12 @@
-import React from "react";
-import { ComponentMeta } from "@storybook/react";
-import { Grid, Box, colors } from "@mui/material";
 import { states } from "@actnowcoalition/regions";
-import { MetricId } from "../../stories/mockMetricCatalog";
-import { MetricSparklines } from "../MetricSparklines";
-import { styled } from "../../styles";
+import { Box, Grid, colors } from "@mui/material";
+import { ComponentMeta } from "@storybook/react";
+import React from "react";
+
 import { AutoWidth } from ".";
+import { MetricId } from "../../stories/mockMetricCatalog";
+import { styled } from "../../styles";
+import { MetricSparklines } from "../MetricSparklines";
 
 export default {
   title: "Components/AutoWidth",

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import isNumber from "lodash/isNumber";
 import { ParentSize } from "@visx/responsive";
+import isNumber from "lodash/isNumber";
+import React from "react";
 
 // TODO (Pablo): The intent here is to ensure that the children elements
 // have an optional, numeric `width` prop, but the validation doesn't

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { ParentSize } from "@visx/responsive";
 import isNumber from "lodash/isNumber";
-import React from "react";
 
 // TODO (Pablo): The intent here is to ensure that the children elements
 // have an optional, numeric `width` prop, but the validation doesn't

--- a/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
+++ b/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
@@ -1,8 +1,9 @@
-import { formatPercent } from "@actnowcoalition/number-format";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import React from "react";
+
+import { formatPercent } from "@actnowcoalition/number-format";
 
 import { AxesTimeseries } from "./AxesTimeseries";
 

--- a/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
+++ b/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import React from "react";
 
 import { formatPercent } from "@actnowcoalition/number-format";
 

--- a/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
+++ b/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { scaleLinear, scaleUtc } from "@visx/scale";
-import { AxesTimeseries } from "./AxesTimeseries";
-import { Group } from "@visx/group";
 import { formatPercent } from "@actnowcoalition/number-format";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Group } from "@visx/group";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import React from "react";
+
+import { AxesTimeseries } from "./AxesTimeseries";
 
 export default {
   title: "Charts/AxesTimeseries",

--- a/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.tsx
+++ b/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.tsx
@@ -1,5 +1,6 @@
-import { ScaleLinear, ScaleTime } from "d3-scale";
 import React from "react";
+
+import { ScaleLinear, ScaleTime } from "d3-scale";
 
 import {
   AxisBottom,

--- a/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.tsx
+++ b/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.tsx
@@ -1,11 +1,12 @@
+import { ScaleLinear, ScaleTime } from "d3-scale";
 import React from "react";
+
 import {
-  AxisLeft,
-  AxisLeftProps,
   AxisBottom,
   AxisBottomProps,
+  AxisLeft,
+  AxisLeftProps,
 } from "../Axis/Axis.style";
-import { ScaleTime, ScaleLinear } from "d3-scale";
 
 export interface AxesTimeseriesProps {
   height: number;

--- a/packages/ui-components/src/components/Axis/Axis.style.tsx
+++ b/packages/ui-components/src/components/Axis/Axis.style.tsx
@@ -1,6 +1,7 @@
+import { AxisBottom as VxAxisBottom, AxisLeft as VxAxisLeft } from "@visx/axis";
 import React from "react";
+
 import { styled, theme } from "../../styles";
-import { AxisLeft as VxAxisLeft, AxisBottom as VxAxisBottom } from "@visx/axis";
 import typography from "../../styles/theme/typography";
 
 export type AxisLeftProps = React.ComponentProps<typeof VxAxisLeft> & {

--- a/packages/ui-components/src/components/Axis/Axis.style.tsx
+++ b/packages/ui-components/src/components/Axis/Axis.style.tsx
@@ -1,5 +1,6 @@
-import { AxisBottom as VxAxisBottom, AxisLeft as VxAxisLeft } from "@visx/axis";
 import React from "react";
+
+import { AxisBottom as VxAxisBottom, AxisLeft as VxAxisLeft } from "@visx/axis";
 
 import { styled, theme } from "../../styles";
 import typography from "../../styles/theme/typography";

--- a/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { scaleUtc, scaleLinear } from "@visx/scale";
-import { AxisBottom, AxisBottomProps } from ".";
-import { isOverTwoMonths, getNumTicks, formatDateTick } from "./utils";
-import { AutoWidth } from "../AutoWidth";
 import { Box } from "@mui/material";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import React from "react";
+
+import { AxisBottom, AxisBottomProps } from ".";
+import { AutoWidth } from "../AutoWidth";
+import { formatDateTick, getNumTicks, isOverTwoMonths } from "./utils";
 
 export default {
   title: "Charts/Axis Bottom",

--- a/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { Box } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import React from "react";
 
 import { AxisBottom, AxisBottomProps } from ".";
 import { AutoWidth } from "../AutoWidth";

--- a/packages/ui-components/src/components/Axis/AxisLeft.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisLeft.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { scaleLinear } from "@visx/scale";
+import React from "react";
+
 import { AxisLeft } from ".";
 
 export default {

--- a/packages/ui-components/src/components/Axis/AxisLeft.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisLeft.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { scaleLinear } from "@visx/scale";
-import React from "react";
 
 import { AxisLeft } from ".";
 

--- a/packages/ui-components/src/components/Axis/utils.tsx
+++ b/packages/ui-components/src/components/Axis/utils.tsx
@@ -1,8 +1,8 @@
 import {
   DateFormat,
+  TimeUnit,
   formatUTCDateTime,
   getTimeDiff,
-  TimeUnit,
 } from "@actnowcoalition/time-utils";
 
 /**

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -1,11 +1,12 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { scaleLinear, scaleUtc } from "@visx/scale";
-import { Group } from "@visx/group";
 import { assert } from "@actnowcoalition/assert";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Group } from "@visx/group";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import React from "react";
+
+import { BarChart } from ".";
 import { appleStockTimeseries } from "../../stories/mockData";
 import { LineChart } from "../LineChart";
-import { BarChart } from ".";
 
 export default {
   title: "Charts/BarChart",

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import React from "react";
 
 import { assert } from "@actnowcoalition/assert";
 

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -1,8 +1,9 @@
-import { assert } from "@actnowcoalition/assert";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import React from "react";
+
+import { assert } from "@actnowcoalition/assert";
 
 import { BarChart } from ".";
 import { appleStockTimeseries } from "../../stories/mockData";

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { ScaleLinear, ScaleTime } from "d3-scale";
-import { Group } from "@visx/group";
 import { Timeseries } from "@actnowcoalition/metrics";
 import { useTheme } from "@mui/material";
+import { Group } from "@visx/group";
+import { ScaleLinear, ScaleTime } from "d3-scale";
+import React from "react";
 
 export interface BaseBarChartProps {
   /** Timeseries used to draw the bar chart */

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { useTheme } from "@mui/material";
 import { Group } from "@visx/group";
 import { ScaleLinear, ScaleTime } from "d3-scale";
-import React from "react";
 
 import { Timeseries } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/BarChart/BarChart.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.tsx
@@ -1,8 +1,9 @@
-import { Timeseries } from "@actnowcoalition/metrics";
 import { useTheme } from "@mui/material";
 import { Group } from "@visx/group";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import React from "react";
+
+import { Timeseries } from "@actnowcoalition/metrics";
 
 export interface BaseBarChartProps {
   /** Timeseries used to draw the bar chart */

--- a/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.stories.tsx
@@ -1,7 +1,8 @@
+import React, { useState } from "react";
+
 import { ComponentMeta } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleUtc } from "@visx/scale";
-import React, { useState } from "react";
 
 import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
 

--- a/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.stories.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
-import { scaleUtc } from "@visx/scale";
-import { Group } from "@visx/group";
-import { AxisBottom } from "../Axis";
-import { formatUTCDateTime, DateFormat } from "@actnowcoalition/time-utils";
+import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
 import { ComponentMeta } from "@storybook/react";
+import { Group } from "@visx/group";
+import { scaleUtc } from "@visx/scale";
+import React, { useState } from "react";
+
 import { ChartOverlayX } from ".";
+import { AxisBottom } from "../Axis";
 
 export default {
   title: "Charts/ChartOverlayX",

--- a/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.stories.tsx
@@ -1,8 +1,9 @@
-import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
 import { ComponentMeta } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleUtc } from "@visx/scale";
 import React, { useState } from "react";
+
+import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
 
 import { ChartOverlayX } from ".";
 import { AxisBottom } from "../Axis";

--- a/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { localPoint } from "@visx/event";
 import { ScaleTime } from "d3-scale";
-import React from "react";
 
 export interface ChartOverlayXProps {
   /** Width of the overlay area */

--- a/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { ScaleTime } from "d3-scale";
 import { localPoint } from "@visx/event";
+import { ScaleTime } from "d3-scale";
+import React from "react";
 
 export interface ChartOverlayXProps {
   /** Width of the overlay area */

--- a/packages/ui-components/src/components/ChartOverlayX/useHoveredDate.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/useHoveredDate.tsx
@@ -1,5 +1,6 @@
-import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { useState } from "react";
+
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 
 import { ChartOverlayXProps } from "./ChartOverlayX";
 

--- a/packages/ui-components/src/components/ChartOverlayX/useHoveredDate.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/useHoveredDate.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+import { useState } from "react";
+
 import { ChartOverlayXProps } from "./ChartOverlayX";
 
 /**

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
@@ -1,11 +1,12 @@
-import React from "react";
+import { Timeseries } from "@actnowcoalition/metrics";
 import { ComponentMeta } from "@storybook/react";
 import { Group } from "@visx/group";
-import { scaleUtc, scaleLinear } from "@visx/scale";
-import { Timeseries } from "@actnowcoalition/metrics";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import React from "react";
+
+import { ChartOverlayXY, useHoveredPoint } from ".";
 import { AxisBottom, AxisLeft } from "../Axis";
 import { LineChart } from "../LineChart";
-import { ChartOverlayXY, useHoveredPoint } from ".";
 
 export default {
   title: "Charts/ChartOverlayXY",

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
@@ -1,8 +1,9 @@
-import { Timeseries } from "@actnowcoalition/metrics";
 import { ComponentMeta } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import React from "react";
+
+import { Timeseries } from "@actnowcoalition/metrics";
 
 import { ChartOverlayXY, useHoveredPoint } from ".";
 import { AxisBottom, AxisLeft } from "../Axis";

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { ComponentMeta } from "@storybook/react";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import React from "react";
 
 import { Timeseries } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -1,9 +1,10 @@
-import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { Group } from "@visx/group";
 import { VoronoiPolygon, voronoi } from "@visx/voronoi";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import concat from "lodash/concat";
 import React, { useMemo } from "react";
+
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 
 export interface ChartOverlayXYProps {
   /**

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo } from "react";
-import concat from "lodash/concat";
-import { ScaleTime, ScaleLinear } from "d3-scale";
-import { Group } from "@visx/group";
-import { voronoi, VoronoiPolygon } from "@visx/voronoi";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+import { Group } from "@visx/group";
+import { VoronoiPolygon, voronoi } from "@visx/voronoi";
+import { ScaleLinear, ScaleTime } from "d3-scale";
+import concat from "lodash/concat";
+import React, { useMemo } from "react";
 
 export interface ChartOverlayXYProps {
   /**

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -1,8 +1,9 @@
+import React, { useMemo } from "react";
+
 import { Group } from "@visx/group";
 import { VoronoiPolygon, voronoi } from "@visx/voronoi";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import concat from "lodash/concat";
-import React, { useMemo } from "react";
 
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
@@ -1,6 +1,7 @@
-import { useState } from "react";
-import isNumber from "lodash/isNumber";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+import isNumber from "lodash/isNumber";
+import { useState } from "react";
+
 import { ChartOverlayXYProps, HoveredPointInfo } from "./ChartOverlayXY";
 
 /**

--- a/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
@@ -1,6 +1,7 @@
-import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import isNumber from "lodash/isNumber";
 import { useState } from "react";
+
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 
 import { ChartOverlayXYProps, HoveredPointInfo } from "./ChartOverlayXY";
 

--- a/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
@@ -1,5 +1,6 @@
-import isNumber from "lodash/isNumber";
 import { useState } from "react";
+
+import isNumber from "lodash/isNumber";
 
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Paper, Stack, Typography } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import React from "react";
 
 import { ColumnHeader } from ".";
 import { SortDirection, Table, TableHead, TableRow } from "..";

--- a/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Paper, Stack, Typography } from "@mui/material";
-import { SortDirection, Table, TableHead, TableRow } from "..";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { ColumnHeader } from ".";
+import { SortDirection, Table, TableHead, TableRow } from "..";
 
 export default {
   title: "Table/ColumnHeader",

--- a/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.style.ts
+++ b/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.style.ts
@@ -1,5 +1,5 @@
-import { styled } from "../../../styles";
 import { TableCell } from "..";
+import { styled } from "../../../styles";
 
 export const StyledTableCell = styled(TableCell, {
   shouldForwardProp: (name: string) =>

--- a/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.tsx
+++ b/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Stack, Typography } from "@mui/material";
 import isNil from "lodash/isNil";
-import React from "react";
 
 import { SortControls, SortDirection, TableCellProps } from "..";
 import { StyledTableCell } from "./ColumnHeader.style";

--- a/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.tsx
+++ b/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import { Stack, Typography } from "@mui/material";
 import isNil from "lodash/isNil";
-import { Typography, Stack } from "@mui/material";
-import { TableCellProps, SortDirection, SortControls } from "..";
+import React from "react";
+
+import { SortControls, SortDirection, TableCellProps } from "..";
 import { StyledTableCell } from "./ColumnHeader.style";
 
 export interface ColumnHeaderProps extends TableCellProps {

--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -1,6 +1,7 @@
+import React, { useState } from "react";
+
 import { Typography } from "@mui/material";
 import { ComponentMeta } from "@storybook/react";
-import React, { useState } from "react";
 
 import { formatInteger } from "@actnowcoalition/number-format";
 import { Region, states } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -1,8 +1,9 @@
-import { formatInteger } from "@actnowcoalition/number-format";
-import { Region, states } from "@actnowcoalition/regions";
 import { Typography } from "@mui/material";
 import { ComponentMeta } from "@storybook/react";
 import React, { useState } from "react";
+
+import { formatInteger } from "@actnowcoalition/number-format";
+import { Region, states } from "@actnowcoalition/regions";
 
 import {
   ColumnDefinition,

--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -1,16 +1,17 @@
-import React, { useState } from "react";
-import { ComponentMeta } from "@storybook/react";
-import { Typography } from "@mui/material";
 import { formatInteger } from "@actnowcoalition/number-format";
-import { states, Region } from "@actnowcoalition/regions";
+import { Region, states } from "@actnowcoalition/regions";
+import { Typography } from "@mui/material";
+import { ComponentMeta } from "@storybook/react";
+import React, { useState } from "react";
+
 import {
-  SortDirection,
-  TableCell,
-  CompareTable,
   ColumnDefinition,
   ColumnHeader,
-  compare,
+  CompareTable,
+  SortDirection,
+  TableCell,
   TableContainer,
+  compare,
 } from ".";
 
 export default {

--- a/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
@@ -1,15 +1,16 @@
 import {
   Table as MuiTable,
-  TableHead as MuiTableHead,
   TableBody as MuiTableBody,
-  TableRow as MuiTableRow,
   TableCell as MuiTableCell,
+  TableContainer as MuiTableContainer,
+  TableHead as MuiTableHead,
+  TableRow as MuiTableRow,
+  linkClasses,
   tableCellClasses,
   typographyClasses,
-  linkClasses,
-  TableContainer as MuiTableContainer,
 } from "@mui/material";
 import React from "react";
+
 import { styled } from "../../styles";
 
 export const TableContainer = MuiTableContainer;

--- a/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 import {
   Table as MuiTable,
   TableBody as MuiTableBody,
@@ -9,7 +11,6 @@ import {
   tableCellClasses,
   typographyClasses,
 } from "@mui/material";
-import React from "react";
 
 import { styled } from "../../styles";
 

--- a/packages/ui-components/src/components/CompareTable/CompareTable.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.tsx
@@ -1,11 +1,12 @@
 import React, { Fragment } from "react";
+
 import {
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  SortDirection,
   CompareTableProps,
+  SortDirection,
+  Table,
+  TableBody,
+  TableHead,
+  TableRow,
 } from ".";
 
 export interface CompareTableRowBase {

--- a/packages/ui-components/src/components/CompareTable/SortControls/SortControls.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/SortControls/SortControls.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { SortControls, SortDirection } from "..";
 

--- a/packages/ui-components/src/components/CompareTable/SortControls/SortControls.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/SortControls/SortControls.stories.tsx
@@ -1,6 +1,7 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { SortDirection, SortControls } from "..";
+
+import { SortControls, SortDirection } from "..";
 
 export default {
   title: "Table/SortControls",

--- a/packages/ui-components/src/components/CompareTable/SortControls/SortControls.style.ts
+++ b/packages/ui-components/src/components/CompareTable/SortControls/SortControls.style.ts
@@ -1,6 +1,7 @@
 import isValidProp from "@emotion/is-prop-valid";
-import MuiArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import MuiArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import MuiArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+
 import { styled } from "../../../styles";
 
 export const ArrowUpIcon = styled(MuiArrowUpIcon, {

--- a/packages/ui-components/src/components/CompareTable/SortControls/SortControls.tsx
+++ b/packages/ui-components/src/components/CompareTable/SortControls/SortControls.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import isNil from "lodash/isNil";
-import { ArrowUpIcon, ArrowDownIcon } from "./SortControls.style";
 import { IconButton, Stack } from "@mui/material";
+import isNil from "lodash/isNil";
+import React from "react";
+
 import { SortDirection } from "..";
+import { ArrowDownIcon, ArrowUpIcon } from "./SortControls.style";
 
 export interface SortControlsProps {
   /**

--- a/packages/ui-components/src/components/CompareTable/SortControls/SortControls.tsx
+++ b/packages/ui-components/src/components/CompareTable/SortControls/SortControls.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { IconButton, Stack } from "@mui/material";
 import isNil from "lodash/isNil";
-import React from "react";
 
 import { SortDirection } from "..";
 import { ArrowDownIcon, ArrowUpIcon } from "./SortControls.style";

--- a/packages/ui-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { scaleLinear } from "@visx/scale";
-import React from "react";
 
 import { GridColumns, GridRows } from ".";
 import { AxisBottom, AxisLeft } from "../Axis";

--- a/packages/ui-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { scaleLinear } from "@visx/scale";
+import React from "react";
+
+import { GridColumns, GridRows } from ".";
 import { AxisBottom, AxisLeft } from "../Axis";
-import { GridRows, GridColumns } from ".";
 
 export default {
   title: "Charts/Grid",

--- a/packages/ui-components/src/components/Grid/Grid.style.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.style.tsx
@@ -1,8 +1,9 @@
-import { styled } from "../../styles";
 import {
-  GridRows as VxGridRows,
   GridColumns as VxGridColumns,
+  GridRows as VxGridRows,
 } from "@visx/grid";
+
+import { styled } from "../../styles";
 
 export const GridRows = styled(VxGridRows)`
   .visx-line {

--- a/packages/ui-components/src/components/InfoTooltip/InfoTooltip.stories.tsx
+++ b/packages/ui-components/src/components/InfoTooltip/InfoTooltip.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Typography } from "@mui/material";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { InfoTooltip } from ".";
 
 export default {

--- a/packages/ui-components/src/components/InfoTooltip/InfoTooltip.stories.tsx
+++ b/packages/ui-components/src/components/InfoTooltip/InfoTooltip.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Typography } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import React from "react";
 
 import { InfoTooltip } from ".";
 

--- a/packages/ui-components/src/components/InfoTooltip/InfoTooltip.style.ts
+++ b/packages/ui-components/src/components/InfoTooltip/InfoTooltip.style.ts
@@ -1,5 +1,6 @@
-import { styled } from "../../styles";
 import { Close as MuiCloseIcon } from "@mui/icons-material";
+
+import { styled } from "../../styles";
 
 export const CloseIcon = styled(MuiCloseIcon)`
   cursor: pointer;

--- a/packages/ui-components/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/packages/ui-components/src/components/InfoTooltip/InfoTooltip.tsx
@@ -1,5 +1,6 @@
+import { TooltipProps as MuiTooltipProps, Tooltip } from "@mui/material";
 import React, { useState } from "react";
-import { Tooltip, TooltipProps as MuiTooltipProps } from "@mui/material";
+
 import { CloseIcon } from "./InfoTooltip.style";
 
 export type InfoTooltipProps = MuiTooltipProps;

--- a/packages/ui-components/src/components/InfoTooltip/InfoTooltip.tsx
+++ b/packages/ui-components/src/components/InfoTooltip/InfoTooltip.tsx
@@ -1,5 +1,6 @@
-import { TooltipProps as MuiTooltipProps, Tooltip } from "@mui/material";
 import React, { useState } from "react";
+
+import { TooltipProps as MuiTooltipProps, Tooltip } from "@mui/material";
 
 import { CloseIcon } from "./InfoTooltip.style";
 

--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import React from "react";
 
 import { LabelIcon } from ".";
 

--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { LabelIcon } from ".";
 
 export default {

--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { Stack, Typography, TypographyProps } from "@mui/material";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import { Stack, Typography, TypographyProps } from "@mui/material";
+import React from "react";
 
 export interface LabelIconProps extends TypographyProps {
   /** Icon to show at the end of the label (ArrowForward by default) */

--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import { Stack, Typography, TypographyProps } from "@mui/material";
-import React from "react";
 
 export interface LabelIconProps extends TypographyProps {
   /** Icon to show at the end of the label (ArrowForward by default) */

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, Story } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, Story } from "@storybook/react";
 
 import { LegendCategorical, LegendCategoricalProps } from ".";
 

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.stories.tsx
@@ -1,5 +1,6 @@
+import { ComponentMeta, Story } from "@storybook/react";
 import React from "react";
-import { Story, ComponentMeta } from "@storybook/react";
+
 import { LegendCategorical, LegendCategoricalProps } from ".";
 
 export default {

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.style.ts
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.style.ts
@@ -1,5 +1,6 @@
-import { styled } from "../../styles";
 import isValidProp from "@emotion/is-prop-valid";
+
+import { styled } from "../../styles";
 
 export const Square = styled("div", { shouldForwardProp: isValidProp })<{
   color: string;

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import React from "react";
 
 import { Square } from "./LegendCategorical.style";
 

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -1,6 +1,7 @@
-import React from "react";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import React from "react";
+
 import { Square } from "./LegendCategorical.style";
 
 export interface LegendCategoricalProps<T> {

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -1,5 +1,6 @@
+import { ComponentMeta, Story } from "@storybook/react";
 import React from "react";
-import { Story, ComponentMeta } from "@storybook/react";
+
 import { LegendThreshold, LegendThresholdProps } from "./LegendThreshold";
 
 export default {

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, Story } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, Story } from "@storybook/react";
 
 import { LegendThreshold, LegendThresholdProps } from "./LegendThreshold";
 

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.style.ts
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.style.ts
@@ -1,6 +1,7 @@
-import { styled } from "../../styles";
 import isValidProp from "@emotion/is-prop-valid";
 import { css } from "@emotion/react";
+
+import { styled } from "../../styles";
 
 export const TickLabel = styled("text")`
   text-anchor: middle;

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { LegendThresholdHorizontal } from "./LegendThresholdHorizontal";
 import { LegendThresholdVertical } from "./LegendThresholdVertical";
 

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
-import React from "react";
 
 import { AutoWidth } from "../AutoWidth";
 import { RectClipGroup } from "../RectClipGroup";

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -1,10 +1,11 @@
-import React from "react";
 import { Group } from "@visx/group";
 import { scaleBand } from "@visx/scale";
-import { TickLabel, TickMark } from "./LegendThreshold.style";
-import { LegendThresholdProps } from "./LegendThreshold";
-import { RectClipGroup } from "../RectClipGroup";
+import React from "react";
+
 import { AutoWidth } from "../AutoWidth";
+import { RectClipGroup } from "../RectClipGroup";
+import { LegendThresholdProps } from "./LegendThreshold";
+import { TickLabel, TickMark } from "./LegendThreshold.style";
 
 export type LegendThresholdHorizontalProps<T> = LegendThresholdProps<T> &
   Omit<React.SVGProps<SVGSVGElement>, keyof LegendThresholdProps<T>>;

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -1,5 +1,6 @@
-import { Box, Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Box, Stack, Typography } from "@mui/material";
 
 import { LegendThresholdProps } from "./LegendThreshold";
 import { LegendColor } from "./LegendThreshold.style";

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdVertical.tsx
@@ -1,7 +1,8 @@
+import { Box, Stack, Typography } from "@mui/material";
 import React from "react";
+
 import { LegendThresholdProps } from "./LegendThreshold";
 import { LegendColor } from "./LegendThreshold.style";
-import { Typography, Box, Stack } from "@mui/material";
 
 /**
  * `LegendThresholdVertical` represents a scale with thresholds that separate

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { LineChart } from ".";
 import {

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -1,10 +1,11 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import {
-  appleStockTimeseries as timeseries,
-  createTimeseriesScales,
-} from "../../stories/mockData";
+
 import { LineChart } from ".";
+import {
+  createTimeseriesScales,
+  appleStockTimeseries as timeseries,
+} from "../../stories/mockData";
 
 export default {
   title: "Charts/LineChart",

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { LinePath } from "@visx/shape";
-import { curveMonotoneX } from "@visx/curve";
-import { ScaleLinear, ScaleTime } from "d3-scale";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
-import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
 import { useTheme } from "@mui/material";
+import { curveMonotoneX } from "@visx/curve";
+import { LinePath } from "@visx/shape";
+import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
+import { ScaleLinear, ScaleTime } from "d3-scale";
+import React from "react";
 
 export interface BaseLineChartProps {
   /** Timeseries used to draw the line chart */

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -1,9 +1,10 @@
+import React from "react";
+
 import { useTheme } from "@mui/material";
 import { curveMonotoneX } from "@visx/curve";
 import { LinePath } from "@visx/shape";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
 import { ScaleLinear, ScaleTime } from "d3-scale";
-import React from "react";
 
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/LineChart/LineChart.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.tsx
@@ -1,10 +1,11 @@
-import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { useTheme } from "@mui/material";
 import { curveMonotoneX } from "@visx/curve";
 import { LinePath } from "@visx/shape";
 import { LinePathProps } from "@visx/shape/lib/shapes/LinePath";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import React from "react";
+
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 
 export interface BaseLineChartProps {
   /** Timeseries used to draw the line chart */

--- a/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.stories.tsx
+++ b/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { LineInterval, LineIntervalChart } from ".";
 import {

--- a/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.stories.tsx
+++ b/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.stories.tsx
@@ -1,11 +1,12 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { LineInterval, LineIntervalChart } from ".";
 import {
-  appleStockTimeseries as timeseries,
   createTimeseriesScales,
+  appleStockTimeseries as timeseries,
 } from "../../stories/mockData";
 import { theme } from "../../styles";
-import { LineIntervalChart, LineInterval } from ".";
 
 export default {
   title: "Charts/LineIntervalChart",

--- a/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.tsx
+++ b/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.tsx
@@ -1,7 +1,8 @@
-import { Timeseries } from "@actnowcoalition/metrics";
 import { Group } from "@visx/group";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import React from "react";
+
+import { Timeseries } from "@actnowcoalition/metrics";
 
 import { LineChart } from "../LineChart";
 import { RectClipGroup } from "../RectClipGroup";

--- a/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.tsx
+++ b/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Group } from "@visx/group";
 import { ScaleLinear, ScaleTime } from "d3-scale";
-import React from "react";
 
 import { Timeseries } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.tsx
+++ b/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { ScaleLinear, ScaleTime } from "d3-scale";
-import { Group } from "@visx/group";
 import { Timeseries } from "@actnowcoalition/metrics";
+import { Group } from "@visx/group";
+import { ScaleLinear, ScaleTime } from "d3-scale";
+import React from "react";
+
 import { LineChart } from "../LineChart";
 import { RectClipGroup } from "../RectClipGroup";
 

--- a/packages/ui-components/src/components/Markdown/InlineMarkdown.tsx
+++ b/packages/ui-components/src/components/Markdown/InlineMarkdown.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { ReactMarkdownOptions } from "react-markdown/lib/react-markdown";
 
 import { MarkdownBody } from "./Markdown.style";

--- a/packages/ui-components/src/components/Markdown/InlineMarkdown.tsx
+++ b/packages/ui-components/src/components/Markdown/InlineMarkdown.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { ReactMarkdownOptions } from "react-markdown/lib/react-markdown";
+
 import { MarkdownBody } from "./Markdown.style";
 
 /** Override 'div' and 'p' components so they just render as fragments. */

--- a/packages/ui-components/src/components/Markdown/Markdown.stories.tsx
+++ b/packages/ui-components/src/components/Markdown/Markdown.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { InlineMarkdown, Markdown } from ".";
 import { styled } from "../../styles";

--- a/packages/ui-components/src/components/Markdown/Markdown.stories.tsx
+++ b/packages/ui-components/src/components/Markdown/Markdown.stories.tsx
@@ -1,5 +1,6 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+
 import { InlineMarkdown, Markdown } from ".";
 import { styled } from "../../styles";
 

--- a/packages/ui-components/src/components/Markdown/Markdown.style.ts
+++ b/packages/ui-components/src/components/Markdown/Markdown.style.ts
@@ -1,4 +1,5 @@
 import { lazy } from "react";
+
 import { styled } from "../../styles";
 
 const ReactMarkdown = lazy(() => import("react-markdown"));

--- a/packages/ui-components/src/components/Markdown/Markdown.tsx
+++ b/packages/ui-components/src/components/Markdown/Markdown.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { ReactMarkdownOptions } from "react-markdown/lib/react-markdown";
+
 import { MarkdownBody } from "./Markdown.style";
 
 export const Markdown = ({ children, ...otherProps }: ReactMarkdownOptions) => (

--- a/packages/ui-components/src/components/Markdown/Markdown.tsx
+++ b/packages/ui-components/src/components/Markdown/Markdown.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { ReactMarkdownOptions } from "react-markdown/lib/react-markdown";
 
 import { MarkdownBody } from "./Markdown.style";

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { Stack, Typography } from "@mui/material";
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import { useMetricCatalog } from "./MetricCatalogContext";
+import { Stack, Typography } from "@mui/material";
+import React from "react";
+
 import { useData } from "../../common/hooks";
+import { useMetricCatalog } from "./MetricCatalogContext";
 
 const MetricAwareDemo = ({
   metric: metricOrId,

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
@@ -1,5 +1,6 @@
-import { Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Stack, Typography } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
@@ -1,7 +1,8 @@
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
 import { Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
 
 import { useData } from "../../common/hooks";
 import { useMetricCatalog } from "./MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { MetricCatalog, MetricDefinition } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -1,14 +1,15 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { states } from "@actnowcoalition/regions";
 import { MetricCatalog, MetricDefinition } from "@actnowcoalition/metrics";
-import { MetricCatalogProvider } from "./MetricCatalogContext";
+import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import {
   MetricId,
-  dataProviders,
   ProviderId,
+  dataProviders,
 } from "../../stories/mockMetricCatalog";
 import MetricAwareDemo from "./MetricAwareDemo";
+import { MetricCatalogProvider } from "./MetricCatalogContext";
 
 export default {
   title: "Metrics/MetricCatalogContext",

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -1,7 +1,8 @@
-import { MetricCatalog, MetricDefinition } from "@actnowcoalition/metrics";
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { MetricCatalog, MetricDefinition } from "@actnowcoalition/metrics";
+import { states } from "@actnowcoalition/regions";
 
 import {
   MetricId,

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
@@ -1,5 +1,6 @@
-import { MetricCatalog } from "@actnowcoalition/metrics";
 import React, { createContext, useContext } from "react";
+
+import { MetricCatalog } from "@actnowcoalition/metrics";
 
 const defaultMetricCatalog = new MetricCatalog([], []);
 

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -1,6 +1,7 @@
-import { Region, RegionDB, states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { Region, RegionDB, states } from "@actnowcoalition/regions";
 
 import { MetricCompareTable } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { Region, RegionDB, states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -1,9 +1,10 @@
+import { Region, RegionDB, states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { states, Region, RegionDB } from "@actnowcoalition/regions";
+
+import { MetricCompareTable } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { TableContainer } from "../CompareTable";
-import { MetricCompareTable } from ".";
 
 const regionDB = new RegionDB(states.all, {
   getRegionUrl: (region: Region) => `/us/${region.slug}`,

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
@@ -1,5 +1,6 @@
-import { styled } from "../../styles";
 import { Link as MuiLink } from "@mui/material";
+
+import { styled } from "../../styles";
 import { TableCell } from "../CompareTable";
 
 // We remove the padding on the table cells to ensure that the link they

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -1,16 +1,17 @@
+import { Metric } from "@actnowcoalition/metrics";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 import React, { useState } from "react";
+
+import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import {
   ColumnDefinition,
   CompareTable,
+  CompareTableProps,
   SortDirection,
   sortRows,
-  CompareTableProps,
 } from "../CompareTable";
 import { useMetricCatalog } from "../MetricCatalogContext";
-import { useDataForRegionsAndMetrics } from "../../common/hooks";
-import { createMetricColumn, createLocationColumn, Row } from "./utils";
-import { Region, RegionDB } from "@actnowcoalition/regions";
-import { Metric } from "@actnowcoalition/metrics";
+import { Row, createLocationColumn, createMetricColumn } from "./utils";
 
 export interface MetricCompareTableProps
   extends Omit<CompareTableProps<Row>, "rows" | "columns"> {

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -1,6 +1,7 @@
+import React, { useState } from "react";
+
 import { Metric } from "@actnowcoalition/metrics";
 import { Region, RegionDB } from "@actnowcoalition/regions";
-import React, { useState } from "react";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import {

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -1,18 +1,19 @@
-import React from "react";
-import isNumber from "lodash/isNumber";
-import { Stack, Typography } from "@mui/material";
 import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
+import { Region } from "@actnowcoalition/regions";
+import { Stack, Typography } from "@mui/material";
+import isNumber from "lodash/isNumber";
+import React from "react";
+
 import { formatPopulation } from "../../common/utils";
-import { MetricValue } from "../MetricValue";
 import {
   ColumnDefinition,
   ColumnHeader,
   SortDirection,
   getAriaSort,
 } from "../CompareTable";
-import { StyledTableCell, StyledLink } from "./MetricCompareTable.style";
-import { Region } from "@actnowcoalition/regions";
+import { MetricValue } from "../MetricValue";
+import { StyledLink, StyledTableCell } from "./MetricCompareTable.style";
 
 export interface Row {
   /** Unique ID for the row. */

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Stack, Typography } from "@mui/material";
 import isNumber from "lodash/isNumber";
-import React from "react";
 
 import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -1,9 +1,10 @@
-import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
-import { RegionDB } from "@actnowcoalition/regions";
-import { Region } from "@actnowcoalition/regions";
 import { Stack, Typography } from "@mui/material";
 import isNumber from "lodash/isNumber";
 import React from "react";
+
+import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
+import { RegionDB } from "@actnowcoalition/regions";
+import { Region } from "@actnowcoalition/regions";
 
 import { formatPopulation } from "../../common/utils";
 import {

--- a/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
@@ -1,6 +1,7 @@
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricDot } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { states } from "@actnowcoalition/regions";
-import { MetricId } from "../../stories/mockMetricCatalog";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { MetricDot } from ".";
+import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
   title: "Metrics/MetricDot",

--- a/packages/ui-components/src/components/MetricDot/MetricDot.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import React from "react";
 
 import { useData } from "../../common/hooks";
 import { useMetricCatalog } from "../MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricDot/MetricDot.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { Region } from "@actnowcoalition/regions";
 import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+import React from "react";
+
+import { useData } from "../../common/hooks";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { Dot, PlaceholderDot } from "./MetricDot.style";
-import { useData } from "../../common/hooks";
 
 export interface MetricDotProps {
   /** Region for which we want to represent the current category */

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLegendCategorical } from "./MetricLegendCategorical";

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLegendCategorical } from "./MetricLegendCategorical";
 

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
@@ -1,5 +1,6 @@
-import { Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Stack, Typography } from "@mui/material";
 
 import { assert } from "@actnowcoalition/assert";
 import { Category, Metric } from "@actnowcoalition/metrics";

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { Stack, Typography } from "@mui/material";
-import { Metric, Category } from "@actnowcoalition/metrics";
 import { assert } from "@actnowcoalition/assert";
-import { useMetricCatalog } from "../MetricCatalogContext";
+import { Category, Metric } from "@actnowcoalition/metrics";
+import { Stack, Typography } from "@mui/material";
+import React from "react";
+
 import { LegendCategorical } from "../LegendCategorical";
+import { useMetricCatalog } from "../MetricCatalogContext";
 
 export interface MetricLegendCategoricalProps {
   /** Metric which we want to display categories for. */

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.tsx
@@ -1,7 +1,8 @@
-import { assert } from "@actnowcoalition/assert";
-import { Category, Metric } from "@actnowcoalition/metrics";
 import { Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { assert } from "@actnowcoalition/assert";
+import { Category, Metric } from "@actnowcoalition/metrics";
 
 import { LegendCategorical } from "../LegendCategorical";
 import { useMetricCatalog } from "../MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { Typography, Paper } from "@mui/material";
+import { Paper, Typography } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLegendThreshold } from "./MetricLegendThreshold";
 

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Paper, Typography } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import React from "react";
 
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLegendThreshold } from "./MetricLegendThreshold";

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -1,5 +1,6 @@
-import { Box, Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Box, Stack, Typography } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -1,6 +1,7 @@
-import { Metric } from "@actnowcoalition/metrics";
 import { Box, Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Metric } from "@actnowcoalition/metrics";
 
 import { LegendThreshold } from "../LegendThreshold";
 import { useMetricCatalog } from "../MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -1,9 +1,10 @@
+import { Metric } from "@actnowcoalition/metrics";
+import { Box, Stack, Typography } from "@mui/material";
 import React from "react";
-import { Stack, Typography, Box } from "@mui/material";
+
 import { LegendThreshold } from "../LegendThreshold";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { getMetricCategoryItems } from "./utils";
-import { Metric } from "@actnowcoalition/metrics";
 import { CategoryItem } from "./utils";
 
 export interface MetricLegendThresholdProps {

--- a/packages/ui-components/src/components/MetricLegendThreshold/utils.test.ts
+++ b/packages/ui-components/src/components/MetricLegendThreshold/utils.test.ts
@@ -1,5 +1,5 @@
+import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 import { getMetricCategoryItems } from "./utils";
-import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
 
 describe("MetricLegendThreshold", () => {
   describe("getMetricCategoryItems", () => {

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
@@ -1,6 +1,7 @@
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLineChart } from "./MetricLineChart";

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { MetricLineChart } from "./MetricLineChart";
-import { MetricId } from "../../stories/mockMetricCatalog";
 import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
+import { MetricId } from "../../stories/mockMetricCatalog";
+import { MetricLineChart } from "./MetricLineChart";
 
 const [width, height] = [600, 400];
 const newYork = states.findByRegionIdStrict("36");

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -1,16 +1,17 @@
-import React from "react";
-import { scaleLinear, scaleUtc } from "@visx/scale";
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
 import { Group } from "@visx/group";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import React from "react";
+
 import { useData } from "../../common/hooks";
+import { BaseChartProps } from "../../common/utils/charts";
 import { AxesTimeseries } from "../AxesTimeseries";
 import { ChartOverlayX, useHoveredDate } from "../ChartOverlayX";
 import { LineChart } from "../LineChart";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricTooltip } from "../MetricTooltip";
 import { PointMarker } from "../PointMarker";
-import { BaseChartProps } from "../../common/utils/charts";
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
 
 export interface MetricLineChartProps extends BaseChartProps {
   metric: Metric | string;

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import React from "react";
 
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -1,8 +1,9 @@
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import React from "react";
+
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
 
 import { useData } from "../../common/hooks";
 import { BaseChartProps } from "../../common/utils/charts";

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
@@ -1,6 +1,7 @@
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLineThresholdChart } from "./MetricLineThresholdChart";

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLineThresholdChart } from "./MetricLineThresholdChart";
 

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -1,11 +1,12 @@
-import { assert } from "@actnowcoalition/assert";
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import max from "lodash/max";
 import min from "lodash/min";
 import React from "react";
+
+import { assert } from "@actnowcoalition/assert";
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
 
 import { useData } from "../../common/hooks";
 import { BaseChartProps } from "../../common/utils/charts";

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -1,8 +1,9 @@
+import React from "react";
+
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import max from "lodash/max";
 import min from "lodash/min";
-import React from "react";
 
 import { assert } from "@actnowcoalition/assert";
 import { Metric } from "@actnowcoalition/metrics";

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -1,20 +1,21 @@
-import React from "react";
-import { scaleLinear, scaleUtc } from "@visx/scale";
-import { Group } from "@visx/group";
-import min from "lodash/min";
-import max from "lodash/max";
 import { assert } from "@actnowcoalition/assert";
-import { Region } from "@actnowcoalition/regions";
 import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+import { Group } from "@visx/group";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import max from "lodash/max";
+import min from "lodash/min";
+import React from "react";
+
 import { useData } from "../../common/hooks";
+import { BaseChartProps } from "../../common/utils/charts";
 import { AxesTimeseries } from "../AxesTimeseries";
-import { GridRows } from "../Grid";
 import { ChartOverlayX, useHoveredDate } from "../ChartOverlayX";
+import { GridRows } from "../Grid";
+import { LineIntervalChart } from "../LineIntervalChart";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricTooltip } from "../MetricTooltip";
-import { BaseChartProps } from "../../common/utils/charts";
 import { PointMarker } from "../PointMarker";
-import { LineIntervalChart } from "../LineIntervalChart";
 import { calculateChartIntervals } from "./utils";
 
 export interface MetricLineThresholdChartProps extends BaseChartProps {

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.test.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.test.ts
@@ -1,4 +1,5 @@
 import { Category } from "@actnowcoalition/metrics";
+
 import { calculateChartIntervals } from "./utils";
 
 const LOW = { id: "low", color: "green" };

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -1,5 +1,6 @@
-import { Category } from "@actnowcoalition/metrics";
 import { assert } from "@actnowcoalition/assert";
+import { Category } from "@actnowcoalition/metrics";
+
 import { LineInterval } from "../LineIntervalChart";
 
 export interface ChartInterval extends LineInterval {

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { MetricMultiProgressBar } from ".";
 import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
+import { MetricMultiProgressBar } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
@@ -1,6 +1,7 @@
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricMultiProgressBar } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -1,11 +1,12 @@
-import React from "react";
-import { Region } from "@actnowcoalition/regions";
 import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
-import {
-  MultiProgressBar,
-  BaseMultiProgressBarProps,
-} from "../MultiProgressBar";
+import { Region } from "@actnowcoalition/regions";
+import React from "react";
+
 import { useDataForMetrics } from "../../common/hooks";
+import {
+  BaseMultiProgressBarProps,
+  MultiProgressBar,
+} from "../MultiProgressBar";
 
 type MetricProp = Metric | string;
 

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import React from "react";
 
 import { useDataForMetrics } from "../../common/hooks";
 import {

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { Typography } from "@mui/material";
 import { states } from "@actnowcoalition/regions";
-import { MetricId } from "../../stories/mockMetricCatalog";
+import { Typography } from "@mui/material";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { MetricOverview } from ".";
+import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
   title: "Metrics/MetricOverview",

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Typography } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import React from "react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
@@ -1,7 +1,8 @@
-import { states } from "@actnowcoalition/regions";
 import { Typography } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricOverview } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { Stack, Typography } from "@mui/material";
-import { Region } from "@actnowcoalition/regions";
 import { Metric } from "@actnowcoalition/metrics";
-import { useMetricCatalog } from "../MetricCatalogContext";
+import { Region } from "@actnowcoalition/regions";
+import { Stack, Typography } from "@mui/material";
+import React from "react";
+
 import { LabelIcon } from "../LabelIcon";
+import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricValue } from "../MetricValue";
 
 export interface MetricOverviewProps {

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.tsx
@@ -1,7 +1,8 @@
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
 import { Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
 
 import { LabelIcon } from "../LabelIcon";
 import { useMetricCatalog } from "../MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.tsx
@@ -1,5 +1,6 @@
-import { Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Stack, Typography } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { MetricScoreOverview } from ".";
 import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
+import { MetricScoreOverview } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
@@ -1,6 +1,7 @@
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricScoreOverview } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { Stack, StackProps, Typography } from "@mui/material";
 import { IconButton } from "@mui/material";
-import React from "react";
 
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
@@ -1,13 +1,14 @@
-import React from "react";
-import { Region } from "@actnowcoalition/regions";
 import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { Stack, StackProps, Typography } from "@mui/material";
+import { IconButton } from "@mui/material";
+import React from "react";
+
+import { InfoTooltip } from "../InfoTooltip";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricLegendThreshold } from "../MetricLegendThreshold";
 import { MetricValue } from "../MetricValue";
-import { Stack, StackProps, Typography } from "@mui/material";
-import { InfoTooltip } from "../InfoTooltip";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { IconButton } from "@mui/material";
 
 export interface MetricScoreOverviewProps extends StackProps {
   /** Region for which we want to show the metric overview */

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
@@ -1,9 +1,10 @@
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { Stack, StackProps, Typography } from "@mui/material";
 import { IconButton } from "@mui/material";
 import React from "react";
+
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
 
 import { InfoTooltip } from "../InfoTooltip";
 import { useMetricCatalog } from "../MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { schemeCategory10 } from "d3-scale-chromatic";
-import React from "react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -1,7 +1,8 @@
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { schemeCategory10 } from "d3-scale-chromatic";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricSeriesChart } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { schemeCategory10 } from "d3-scale-chromatic";
 import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { schemeCategory10 } from "d3-scale-chromatic";
+import React from "react";
 
+import { MetricSeriesChart } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 import { theme } from "../../styles";
-import { MetricSeriesChart } from ".";
 import { SeriesType } from "../SeriesChart";
 
 export default {

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { Skeleton } from "@mui/material";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
@@ -5,7 +7,6 @@ import isNumber from "lodash/isNumber";
 import max from "lodash/max";
 import min from "lodash/min";
 import uniq from "lodash/uniq";
-import React from "react";
 
 import { assert } from "@actnowcoalition/assert";
 import { Timeseries } from "@actnowcoalition/metrics";

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -1,5 +1,3 @@
-import { assert } from "@actnowcoalition/assert";
-import { Timeseries } from "@actnowcoalition/metrics";
 import { Skeleton } from "@mui/material";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
@@ -8,6 +6,9 @@ import max from "lodash/max";
 import min from "lodash/min";
 import uniq from "lodash/uniq";
 import React from "react";
+
+import { assert } from "@actnowcoalition/assert";
+import { Timeseries } from "@actnowcoalition/metrics";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { BaseChartProps } from "../../common/utils/charts";

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -1,22 +1,23 @@
-import React from "react";
+import { assert } from "@actnowcoalition/assert";
+import { Timeseries } from "@actnowcoalition/metrics";
 import { Skeleton } from "@mui/material";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import uniq from "lodash/uniq";
-import min from "lodash/min";
-import max from "lodash/max";
 import isNumber from "lodash/isNumber";
-import { assert } from "@actnowcoalition/assert";
-import { Timeseries } from "@actnowcoalition/metrics";
+import max from "lodash/max";
+import min from "lodash/min";
+import uniq from "lodash/uniq";
+import React from "react";
+
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
-import { AxesTimeseries } from "../AxesTimeseries";
 import { BaseChartProps } from "../../common/utils/charts";
+import { AxesTimeseries } from "../AxesTimeseries";
+import { ChartOverlayXY, useHoveredPoint } from "../ChartOverlayXY";
+import { useMetricCatalog } from "../MetricCatalogContext";
+import { MetricTooltip } from "../MetricTooltip";
+import { PointMarker } from "../PointMarker";
 import { Series, SeriesType } from "../SeriesChart";
 import { SeriesChart } from "../SeriesChart";
-import { ChartOverlayXY, useHoveredPoint } from "../ChartOverlayXY";
-import { PointMarker } from "../PointMarker";
-import { MetricTooltip } from "../MetricTooltip";
-import { useMetricCatalog } from "../MetricCatalogContext";
 
 export interface MetricSeriesChartProps extends BaseChartProps {
   /** List of series to be rendered */

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { MetricSparklines } from ".";
 import { states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
+import { MetricSparklines } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
@@ -1,6 +1,7 @@
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricSparklines } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -1,7 +1,8 @@
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
 import { Skeleton } from "@mui/material";
 import React from "react";
+
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
 
 import { useDataForMetrics } from "../../common/hooks";
 import { useMetricCatalog } from "../MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { Region } from "@actnowcoalition/regions";
 import { Metric } from "@actnowcoalition/metrics";
-import { SparkLine, SparkLineProps } from "../SparkLine";
-import { useMetricCatalog } from "../MetricCatalogContext";
+import { Region } from "@actnowcoalition/regions";
 import { Skeleton } from "@mui/material";
+import React from "react";
+
 import { useDataForMetrics } from "../../common/hooks";
+import { useMetricCatalog } from "../MetricCatalogContext";
+import { SparkLine, SparkLineProps } from "../SparkLine";
 
 export interface MetricSparklinesProps
   extends Omit<SparkLineProps, "timeseriesBarChart" | "timeseriesLineChart"> {

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -1,5 +1,6 @@
-import { Skeleton } from "@mui/material";
 import React from "react";
+
+import { Skeleton } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { TimeseriesPoint } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";
 import { colors } from "@mui/material";
-import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { MetricTooltip } from ".";
+import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 
 export default {
   title: "Charts/MetricTooltip",

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { colors } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import React from "react";
 
 import { TimeseriesPoint } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -1,8 +1,9 @@
-import { TimeseriesPoint } from "@actnowcoalition/metrics";
-import { states } from "@actnowcoalition/regions";
 import { colors } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { TimeseriesPoint } from "@actnowcoalition/metrics";
+import { states } from "@actnowcoalition/regions";
 
 import { MetricTooltip } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { Stack, Typography, Tooltip, TooltipProps } from "@mui/material";
 import { Metric, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import { formatUTCDateTime, DateFormat } from "@actnowcoalition/time-utils";
+import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
+import { Stack, Tooltip, TooltipProps, Typography } from "@mui/material";
+import React from "react";
+
 import { useMetricCatalog } from "../MetricCatalogContext";
 
 export interface MetricTooltipWithChildren extends MetricTooltipContentProps {

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -1,5 +1,6 @@
-import { Stack, Tooltip, TooltipProps, Typography } from "@mui/material";
 import React from "react";
+
+import { Stack, Tooltip, TooltipProps, Typography } from "@mui/material";
 
 import { Metric, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.tsx
@@ -1,8 +1,9 @@
+import { Stack, Tooltip, TooltipProps, Typography } from "@mui/material";
+import React from "react";
+
 import { Metric, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
-import { Stack, Tooltip, TooltipProps, Typography } from "@mui/material";
-import React from "react";
 
 import { useMetricCatalog } from "../MetricCatalogContext";
 

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltipContent.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltipContent.stories.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { TimeseriesPoint } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";
-import { metricCatalog, MetricId } from "../../stories/mockMetricCatalog";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { MetricTooltipContent } from ".";
+import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 
 export default {
   title: "Charts/MetricTooltipContent",

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltipContent.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltipContent.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { TimeseriesPoint } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltipContent.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltipContent.stories.tsx
@@ -1,7 +1,8 @@
-import { TimeseriesPoint } from "@actnowcoalition/metrics";
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { TimeseriesPoint } from "@actnowcoalition/metrics";
+import { states } from "@actnowcoalition/regions";
 
 import { MetricTooltipContent } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
@@ -1,6 +1,7 @@
-import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricUSNationalMap } from "./MetricUSNationalMap";

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
@@ -1,6 +1,7 @@
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
+
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricUSNationalMap } from "./MetricUSNationalMap";
 

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Metric } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
-import React from "react";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { USNationalMap, USNationalMapProps } from "../USNationalMap";

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { useDataForRegionsAndMetrics } from "../../common/hooks";
-import { USNationalMap, USNationalMapProps } from "../USNationalMap";
 import { Metric } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
+import React from "react";
+
+import { useDataForRegionsAndMetrics } from "../../common/hooks";
+import { USNationalMap, USNationalMapProps } from "../USNationalMap";
 
 export interface MetricUSNationalMapProps extends USNationalMapProps {
   metric: Metric | string;

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
@@ -1,6 +1,7 @@
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
+
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricUSStateMap } from "./MetricUSStateMap";
 

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
@@ -1,6 +1,7 @@
-import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricUSStateMap } from "./MetricUSStateMap";

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { USStateMap, USStateMapProps } from "../USStateMap";
-import { useDataForRegionsAndMetrics } from "../../common/hooks";
-import { getCountiesOfState } from "../../common/utils/maps";
 import { Metric } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
+import React from "react";
+
+import { useDataForRegionsAndMetrics } from "../../common/hooks";
+import { getCountiesOfState } from "../../common/utils/maps";
+import { USStateMap, USStateMapProps } from "../USStateMap";
 
 export interface MetricUSStateMapProps extends USStateMapProps {
   metric: Metric | string;

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Metric } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
-import React from "react";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { getCountiesOfState } from "../../common/utils/maps";

--- a/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
@@ -1,6 +1,7 @@
-import { states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricValue } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { states } from "@actnowcoalition/regions";
-import { MetricId } from "../../stories/mockMetricCatalog";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { MetricValue } from ".";
+import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
   title: "Metrics/MetricValue",

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -1,7 +1,8 @@
-import { Metric } from "@actnowcoalition/metrics";
-import { Region } from "@actnowcoalition/regions";
 import { Stack, StackProps, Typography, TypographyProps } from "@mui/material";
 import React from "react";
+
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
 
 import { useData } from "../../common/hooks";
 import { useMetricCatalog } from "../MetricCatalogContext";

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -1,5 +1,6 @@
-import { Stack, StackProps, Typography, TypographyProps } from "@mui/material";
 import React from "react";
+
+import { Stack, StackProps, Typography, TypographyProps } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { Stack, StackProps, Typography, TypographyProps } from "@mui/material";
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
+import { Stack, StackProps, Typography, TypographyProps } from "@mui/material";
+import React from "react";
+
+import { useData } from "../../common/hooks";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricDot } from "../MetricDot";
-import { useData } from "../../common/hooks";
 
 export interface MetricValueProps extends StackProps {
   /** Region for which we want to show the metric value */

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { Region, RegionDB, nations } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
@@ -1,6 +1,7 @@
-import { Region, RegionDB, nations } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { Region, RegionDB, nations } from "@actnowcoalition/regions";
 
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricWorldMap } from "./MetricWorldMap";

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
@@ -1,6 +1,7 @@
+import { Region, RegionDB, nations } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { nations, Region, RegionDB } from "@actnowcoalition/regions";
+
 import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricWorldMap } from "./MetricWorldMap";
 

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { useDataForRegionsAndMetrics } from "../../common/hooks";
-import WorldMap, { WorldMapProps } from "../WorldMap";
 import { Metric } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
+import React from "react";
+
+import { useDataForRegionsAndMetrics } from "../../common/hooks";
+import WorldMap, { WorldMapProps } from "../WorldMap";
 
 export interface MetricWorldMapProps extends WorldMapProps {
   metric: Metric | string;

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Metric } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
-import React from "react";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import WorldMap, { WorldMapProps } from "../WorldMap";

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.stories.tsx
@@ -1,8 +1,9 @@
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+
 import { MultiMetricUSStateMap } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
-import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
 
 export default {
   title: "Maps/MultiMetric US State Map",

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.stories.tsx
@@ -1,6 +1,7 @@
-import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 
 import { MultiMetricUSStateMap } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.style.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.style.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@mui/material";
+
 import { styled } from "../../styles";
 
 export const BorderedContainer = styled(Box)`

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
@@ -1,7 +1,8 @@
-import { Metric } from "@actnowcoalition/metrics";
-import { Region, RegionDB } from "@actnowcoalition/regions";
 import { MenuItem, TextField, Typography } from "@mui/material";
 import React, { useState } from "react";
+
+import { Metric } from "@actnowcoalition/metrics";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricLegendThreshold } from "../MetricLegendThreshold";

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
@@ -1,15 +1,16 @@
-import React, { useState } from "react";
-import { RegionDB, Region } from "@actnowcoalition/regions";
-import { MetricUSStateMap } from "../MetricUSStateMap";
-import { Typography, TextField, MenuItem } from "@mui/material";
-import { MetricLegendThreshold } from "../MetricLegendThreshold";
-import { useMetricCatalog } from "../MetricCatalogContext";
 import { Metric } from "@actnowcoalition/metrics";
-import { getStartLabel, getEndLabel } from "./utils";
+import { Region, RegionDB } from "@actnowcoalition/regions";
+import { MenuItem, TextField, Typography } from "@mui/material";
+import React, { useState } from "react";
+
+import { useMetricCatalog } from "../MetricCatalogContext";
+import { MetricLegendThreshold } from "../MetricLegendThreshold";
+import { MetricUSStateMap } from "../MetricUSStateMap";
 import {
   BorderedContainer,
   BorderedContainerLast,
 } from "./MultiMetricUSStateMap.style";
+import { getEndLabel, getStartLabel } from "./utils";
 
 export interface MultiMetricUSStateMapProps {
   /** Region ID of the state being mapped */

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
@@ -1,5 +1,6 @@
-import { MenuItem, TextField, Typography } from "@mui/material";
 import React, { useState } from "react";
+
+import { MenuItem, TextField, Typography } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
 import { Region, RegionDB } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/utils.ts
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/utils.ts
@@ -1,5 +1,6 @@
-import { Metric } from "@actnowcoalition/metrics";
 import startCase from "lodash/startCase";
+
+import { Metric } from "@actnowcoalition/metrics";
 
 // TODO(#325) - move these to MetricLegendThreshold (or somewhere more central than here)
 

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, Story } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, Story } from "@storybook/react";
 
 import { MultiProgressBar, MultiProgressBarProps } from "./MultiProgressBar";
 

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
@@ -1,5 +1,6 @@
+import { ComponentMeta, Story } from "@storybook/react";
 import React from "react";
-import { Story, ComponentMeta } from "@storybook/react";
+
 import { MultiProgressBar, MultiProgressBarProps } from "./MultiProgressBar";
 
 export default {

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
@@ -1,7 +1,8 @@
+import React, { useId } from "react";
+
 import { useTheme } from "@mui/material";
 import { scaleLinear } from "@visx/scale";
 import sortBy from "lodash/sortBy";
-import React, { useId } from "react";
 
 import { RectClipGroup } from "../RectClipGroup";
 

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
@@ -1,8 +1,9 @@
-import React, { useId } from "react";
-import sortBy from "lodash/sortBy";
 import { useTheme } from "@mui/material";
-import { RectClipGroup } from "../RectClipGroup";
 import { scaleLinear } from "@visx/scale";
+import sortBy from "lodash/sortBy";
+import React, { useId } from "react";
+
+import { RectClipGroup } from "../RectClipGroup";
 
 export interface BaseMultiProgressBarProps {
   maxValue: number;

--- a/packages/ui-components/src/components/PointMarker/PointMarker.stories.tsx
+++ b/packages/ui-components/src/components/PointMarker/PointMarker.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { PointMarker } from ".";
 

--- a/packages/ui-components/src/components/PointMarker/PointMarker.stories.tsx
+++ b/packages/ui-components/src/components/PointMarker/PointMarker.stories.tsx
@@ -1,5 +1,6 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+
 import { PointMarker } from ".";
 
 export default {

--- a/packages/ui-components/src/components/PointMarker/PointMarker.tsx
+++ b/packages/ui-components/src/components/PointMarker/PointMarker.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { CircleMarker } from "./PointMarker.style";
 
 export interface PointMarkerProps {

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { ProgressBar } from ".";
 

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,5 +1,6 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+
 import { ProgressBar } from ".";
 
 export default {

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,6 @@
-import { scaleLinear } from "@visx/scale";
 import React from "react";
+
+import { scaleLinear } from "@visx/scale";
 
 import { RectClipGroup } from "../RectClipGroup";
 

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import { scaleLinear } from "@visx/scale";
+import React from "react";
+
 import { RectClipGroup } from "../RectClipGroup";
 
 export interface BaseProgressBarProps {

--- a/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
+++ b/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta } from "@storybook/react";
 
 import { RectClipGroup } from ".";
 

--- a/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
+++ b/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
@@ -1,5 +1,6 @@
-import React from "react";
 import { ComponentMeta } from "@storybook/react";
+import React from "react";
+
 import { RectClipGroup } from ".";
 
 export default {

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
@@ -1,15 +1,16 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { TextField, InputAdornment } from "@mui/material";
-import MapIcon from "@mui/icons-material/Map";
-import sortBy from "lodash/sortBy";
 import {
-  states,
+  Region,
+  RegionDB,
   counties,
   metros,
-  RegionDB,
-  Region,
+  states,
 } from "@actnowcoalition/regions";
+import MapIcon from "@mui/icons-material/Map";
+import { InputAdornment, TextField } from "@mui/material";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import sortBy from "lodash/sortBy";
+import React from "react";
+
 import { RegionSearch } from ".";
 
 export default {

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
@@ -1,3 +1,9 @@
+import MapIcon from "@mui/icons-material/Map";
+import { InputAdornment, TextField } from "@mui/material";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import sortBy from "lodash/sortBy";
+import React from "react";
+
 import {
   Region,
   RegionDB,
@@ -5,11 +11,6 @@ import {
   metros,
   states,
 } from "@actnowcoalition/regions";
-import MapIcon from "@mui/icons-material/Map";
-import { InputAdornment, TextField } from "@mui/material";
-import { ComponentMeta, ComponentStory } from "@storybook/react";
-import sortBy from "lodash/sortBy";
-import React from "react";
 
 import { RegionSearch } from ".";
 

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
@@ -1,8 +1,9 @@
+import React from "react";
+
 import MapIcon from "@mui/icons-material/Map";
 import { InputAdornment, TextField } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import sortBy from "lodash/sortBy";
-import React from "react";
 
 import {
   Region,

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.style.ts
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.style.ts
@@ -1,4 +1,5 @@
 import { Link } from "@mui/material";
+
 import { styled } from "../../styles";
 
 export const StyledLink = styled(Link)`

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -1,15 +1,16 @@
-import React, { HTMLAttributes } from "react";
+import { Region, RegionDB } from "@actnowcoalition/regions";
+import SearchIcon from "@mui/icons-material/Search";
 import {
   Autocomplete,
   AutocompleteProps,
   TextField,
   createFilterOptions,
 } from "@mui/material";
-import SearchIcon from "@mui/icons-material/Search";
-import { Region, RegionDB } from "@actnowcoalition/regions";
+import React, { HTMLAttributes } from "react";
+
 import { formatPopulation } from "../../common/utils";
-import { StyledLink } from "./RegionSearch.style";
 import { SearchItem } from "../SearchItem";
+import { StyledLink } from "./RegionSearch.style";
 
 function stringifyOption(region: Region) {
   return region.fullName;

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -1,4 +1,3 @@
-import { Region, RegionDB } from "@actnowcoalition/regions";
 import SearchIcon from "@mui/icons-material/Search";
 import {
   Autocomplete,
@@ -7,6 +6,8 @@ import {
   createFilterOptions,
 } from "@mui/material";
 import React, { HTMLAttributes } from "react";
+
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { formatPopulation } from "../../common/utils";
 import { SearchItem } from "../SearchItem";

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -1,3 +1,5 @@
+import React, { HTMLAttributes } from "react";
+
 import SearchIcon from "@mui/icons-material/Search";
 import {
   Autocomplete,
@@ -5,7 +7,6 @@ import {
   TextField,
   createFilterOptions,
 } from "@mui/material";
-import React, { HTMLAttributes } from "react";
 
 import { Region, RegionDB } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/SearchItem/SearchItem.stories.tsx
+++ b/packages/ui-components/src/components/SearchItem/SearchItem.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import { counties, states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { states, counties } from "@actnowcoalition/regions";
+import React from "react";
+
 import { SearchItem } from "./SearchItem";
 
 export default {

--- a/packages/ui-components/src/components/SearchItem/SearchItem.stories.tsx
+++ b/packages/ui-components/src/components/SearchItem/SearchItem.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { counties, states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/SearchItem/SearchItem.stories.tsx
+++ b/packages/ui-components/src/components/SearchItem/SearchItem.stories.tsx
@@ -1,6 +1,7 @@
-import { counties, states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { counties, states } from "@actnowcoalition/regions";
 
 import { SearchItem } from "./SearchItem";
 

--- a/packages/ui-components/src/components/SearchItem/SearchItem.style.tsx
+++ b/packages/ui-components/src/components/SearchItem/SearchItem.style.tsx
@@ -1,7 +1,8 @@
-import { styled } from "../../styles";
 import isValidProp from "@emotion/is-prop-valid";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import Box from "@mui/material/Box";
+
+import { styled } from "../../styles";
 import { Dot } from "../MetricDot/MetricDot.style";
 
 export const CircleIcon = styled(Dot, {

--- a/packages/ui-components/src/components/SearchItem/SearchItem.tsx
+++ b/packages/ui-components/src/components/SearchItem/SearchItem.tsx
@@ -1,5 +1,6 @@
-import { Stack, Typography } from "@mui/material";
 import React from "react";
+
+import { Stack, Typography } from "@mui/material";
 
 import { ArrowIcon, CircleIcon, Container } from "./SearchItem.style";
 

--- a/packages/ui-components/src/components/SearchItem/SearchItem.tsx
+++ b/packages/ui-components/src/components/SearchItem/SearchItem.tsx
@@ -1,6 +1,7 @@
-import React from "react";
 import { Stack, Typography } from "@mui/material";
-import { CircleIcon, ArrowIcon, Container } from "./SearchItem.style";
+import React from "react";
+
+import { ArrowIcon, CircleIcon, Container } from "./SearchItem.style";
 
 export interface SearchItemProps {
   /** Top label of the search item, in bold text. */

--- a/packages/ui-components/src/components/SeriesChart/SeriesChart.tsx
+++ b/packages/ui-components/src/components/SeriesChart/SeriesChart.tsx
@@ -1,8 +1,9 @@
+import { ScaleLinear, ScaleTime } from "d3-scale";
+import React from "react";
+
 import { Timeseries } from "@actnowcoalition/metrics";
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import { ScaleLinear, ScaleTime } from "d3-scale";
-import React from "react";
 
 import { BarChart } from "../BarChart";
 import { LineChart } from "../LineChart";

--- a/packages/ui-components/src/components/SeriesChart/SeriesChart.tsx
+++ b/packages/ui-components/src/components/SeriesChart/SeriesChart.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { ScaleTime, ScaleLinear } from "d3-scale";
 import { Timeseries } from "@actnowcoalition/metrics";
-import { BarChart } from "../BarChart";
-import { LineChart } from "../LineChart";
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
+import { ScaleLinear, ScaleTime } from "d3-scale";
+import React from "react";
+
+import { BarChart } from "../BarChart";
+import { LineChart } from "../LineChart";
 
 export enum SeriesType {
   LINE = "LINE",

--- a/packages/ui-components/src/components/SeriesChart/SeriesChart.tsx
+++ b/packages/ui-components/src/components/SeriesChart/SeriesChart.tsx
@@ -1,5 +1,6 @@
-import { ScaleLinear, ScaleTime } from "d3-scale";
 import React from "react";
+
+import { ScaleLinear, ScaleTime } from "d3-scale";
 
 import { Timeseries } from "@actnowcoalition/metrics";
 import { Metric } from "@actnowcoalition/metrics";

--- a/packages/ui-components/src/components/ShareButton/CopyLinkButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/CopyLinkButton.tsx
@@ -1,6 +1,7 @@
+import React, { useState } from "react";
+
 import LinkIcon from "@mui/icons-material/Link";
 import Button from "@mui/material/Button";
-import React, { useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 
 interface CopyLinkButtonProps {

--- a/packages/ui-components/src/components/ShareButton/CopyLinkButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/CopyLinkButton.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import { CopyToClipboard } from "react-copy-to-clipboard";
 import LinkIcon from "@mui/icons-material/Link";
 import Button from "@mui/material/Button";
+import React, { useState } from "react";
+import { CopyToClipboard } from "react-copy-to-clipboard";
 
 interface CopyLinkButtonProps {
   url: string;

--- a/packages/ui-components/src/components/ShareButton/FacebookShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/FacebookShareButton.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import FacebookIcon from "@mui/icons-material/Facebook";
 import { Button } from "@mui/material";
-import React from "react";
 import { FacebookShareButton as ReactShareFacebookShareButton } from "react-share";
 
 export type FacebookShareButtonProps = React.ComponentProps<

--- a/packages/ui-components/src/components/ShareButton/FacebookShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/FacebookShareButton.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { FacebookShareButton as ReactShareFacebookShareButton } from "react-share";
 import FacebookIcon from "@mui/icons-material/Facebook";
 import { Button } from "@mui/material";
+import React from "react";
+import { FacebookShareButton as ReactShareFacebookShareButton } from "react-share";
 
 export type FacebookShareButtonProps = React.ComponentProps<
   typeof ReactShareFacebookShareButton

--- a/packages/ui-components/src/components/ShareButton/ShareButton.stories.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Box } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import React from "react";
 
 import { ShareButton, ShareButtonProps } from ".";
 

--- a/packages/ui-components/src/components/ShareButton/ShareButton.stories.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.stories.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { ShareButton, ShareButtonProps } from ".";
 import { Box } from "@mui/material";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
+import { ShareButton, ShareButtonProps } from ".";
 
 export default {
   title: "Components/ShareButton",

--- a/packages/ui-components/src/components/ShareButton/ShareButton.style.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.style.tsx
@@ -1,5 +1,6 @@
-import { styled } from "../../styles";
 import { Menu as MuiMenu, MenuItem as MuiMenuItem } from "@mui/material";
+
+import { styled } from "../../styles";
 
 export const Menu = styled(MuiMenu)`
   .MuiMenu-paper {

--- a/packages/ui-components/src/components/ShareButton/ShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.tsx
@@ -1,7 +1,8 @@
+import React, { useState } from "react";
+
 import ShareIcon from "@mui/icons-material/Share";
 import { Button, ButtonProps } from "@mui/material";
 import isNull from "lodash/isNull";
-import React, { useState } from "react";
 
 import { CopyLinkButton } from "./CopyLinkButton";
 import { FacebookShareButton } from "./FacebookShareButton";

--- a/packages/ui-components/src/components/ShareButton/ShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from "react";
-import { Button, ButtonProps } from "@mui/material";
 import ShareIcon from "@mui/icons-material/Share";
+import { Button, ButtonProps } from "@mui/material";
+import isNull from "lodash/isNull";
+import React, { useState } from "react";
+
 import { CopyLinkButton } from "./CopyLinkButton";
-import { TwitterShareButton } from "./TwitterShareButton";
 import { FacebookShareButton } from "./FacebookShareButton";
 import { Menu, MenuItem } from "./ShareButton.style";
-import isNull from "lodash/isNull";
+import { TwitterShareButton } from "./TwitterShareButton";
 
 const noop = () => {
   return;

--- a/packages/ui-components/src/components/ShareButton/TwitterShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/TwitterShareButton.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import TwitterIcon from "@mui/icons-material/Twitter";
 import { Button } from "@mui/material";
-import React from "react";
 import { TwitterShareButton as ReactShareTwitterShareButton } from "react-share";
 
 export type TwitterShareButtonProps = React.ComponentProps<

--- a/packages/ui-components/src/components/ShareButton/TwitterShareButton.tsx
+++ b/packages/ui-components/src/components/ShareButton/TwitterShareButton.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import TwitterIcon from "@mui/icons-material/Twitter";
 import { Button } from "@mui/material";
+import React from "react";
 import { TwitterShareButton as ReactShareTwitterShareButton } from "react-share";
 
 export type TwitterShareButtonProps = React.ComponentProps<

--- a/packages/ui-components/src/components/SparkLine/SparkLine.stories.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.stories.tsx
@@ -1,6 +1,7 @@
-import { assert } from "@actnowcoalition/assert";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { assert } from "@actnowcoalition/assert";
 
 import { SparkLine } from ".";
 import { appleStockTimeseries } from "../../stories/mockData";

--- a/packages/ui-components/src/components/SparkLine/SparkLine.stories.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { assert } from "@actnowcoalition/assert";
-import { appleStockTimeseries } from "../../stories/mockData";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { SparkLine } from ".";
+import { appleStockTimeseries } from "../../stories/mockData";
 
 export default {
   title: "Charts/SparkLine",

--- a/packages/ui-components/src/components/SparkLine/SparkLine.stories.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { assert } from "@actnowcoalition/assert";
 

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { Group } from "@visx/group";
 import { Timeseries } from "@actnowcoalition/metrics";
+import { useTheme } from "@mui/material";
+import { Group } from "@visx/group";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import React from "react";
+
 import { BarChart } from "../BarChart";
 import { LineChart } from "../LineChart";
-import { scaleUtc, scaleLinear } from "@visx/scale";
-import { useTheme } from "@mui/material";
 
 export interface SparkLineProps {
   /** Timeseries used to draw the bar chart */

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { useTheme } from "@mui/material";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import React from "react";
 
 import { Timeseries } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -1,8 +1,9 @@
-import { Timeseries } from "@actnowcoalition/metrics";
 import { useTheme } from "@mui/material";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import React from "react";
+
+import { Timeseries } from "@actnowcoalition/metrics";
 
 import { BarChart } from "../BarChart";
 import { LineChart } from "../LineChart";

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
@@ -1,6 +1,7 @@
-import { assert } from "@actnowcoalition/assert";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { assert } from "@actnowcoalition/assert";
 
 import { appleStockTimeseries } from "../../stories/mockData";
 import { TimeseriesLineChart } from "./TimeseriesLineChart";

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { TimeseriesLineChart } from "./TimeseriesLineChart";
 import { assert } from "@actnowcoalition/assert";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { appleStockTimeseries } from "../../stories/mockData";
+import { TimeseriesLineChart } from "./TimeseriesLineChart";
 
 const [width, height] = [600, 400];
 

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { assert } from "@actnowcoalition/assert";
 

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.tsx
@@ -1,7 +1,8 @@
-import { NonEmptyTimeseries } from "@actnowcoalition/metrics";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import React from "react";
+
+import { NonEmptyTimeseries } from "@actnowcoalition/metrics";
 
 import { BaseChartProps } from "../../common/utils/charts";
 import { AxesTimeseries } from "../AxesTimeseries";

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.tsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { scaleLinear, scaleUtc } from "@visx/scale";
-import { Group } from "@visx/group";
-import { LineChart } from "../LineChart";
-import { AxesTimeseries } from "../AxesTimeseries";
 import { NonEmptyTimeseries } from "@actnowcoalition/metrics";
+import { Group } from "@visx/group";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import React from "react";
+
 import { BaseChartProps } from "../../common/utils/charts";
+import { AxesTimeseries } from "../AxesTimeseries";
+import { LineChart } from "../LineChart";
 
 export interface TimeseriesLineChartProps extends BaseChartProps {
   timeseries: NonEmptyTimeseries<number>;

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import React from "react";
 
 import { NonEmptyTimeseries } from "@actnowcoalition/metrics";
 

--- a/packages/ui-components/src/components/USNationalMap/CanvasMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/CanvasMap.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef } from "react";
 import { ExtendedFeature, GeoProjection, geoPath as d3GeoPath } from "d3-geo";
+import React, { useEffect, useRef } from "react";
+
 import { stateBorders } from "../../common/geo-shapes";
 import { StyledCanvas } from "../../styles/common/Maps.style";
 

--- a/packages/ui-components/src/components/USNationalMap/CanvasMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/CanvasMap.tsx
@@ -1,5 +1,6 @@
-import { ExtendedFeature, GeoProjection, geoPath as d3GeoPath } from "d3-geo";
 import React, { useEffect, useRef } from "react";
+
+import { ExtendedFeature, GeoProjection, geoPath as d3GeoPath } from "d3-geo";
 
 import { stateBorders } from "../../common/geo-shapes";
 import { StyledCanvas } from "../../styles/common/Maps.style";

--- a/packages/ui-components/src/components/USNationalMap/CountiesMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/CountiesMap.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { countiesGeographies } from "../../common/geo-shapes";
 import { CanvasMap, CanvasMapProps } from "./CanvasMap";
 

--- a/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import { Link, Tooltip } from "@mui/material";
 import { GeoPath } from "d3-geo";
-import { Tooltip, Link } from "@mui/material";
+import React from "react";
+
 import { statesGeographies } from "../../common/geo-shapes";
 import { RegionOverlay, RegionShapeBase } from "../../styles/common/Maps.style";
 

--- a/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Link, Tooltip } from "@mui/material";
 import { GeoPath } from "d3-geo";
-import React from "react";
 
 import { statesGeographies } from "../../common/geo-shapes";
 import { RegionOverlay, RegionShapeBase } from "../../styles/common/Maps.style";

--- a/packages/ui-components/src/components/USNationalMap/USNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/USNationalMap/USNationalMap.stories.tsx
@@ -1,9 +1,10 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import { scaleOrdinal, scaleLinear } from "@visx/scale";
-import { interpolatePiYG } from "d3-scale-chromatic";
 import { assert } from "@actnowcoalition/assert";
-import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { scaleLinear, scaleOrdinal } from "@visx/scale";
+import { interpolatePiYG } from "d3-scale-chromatic";
+import React from "react";
+
 import { USNationalMap } from "./USNationalMap";
 
 export default {

--- a/packages/ui-components/src/components/USNationalMap/USNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/USNationalMap/USNationalMap.stories.tsx
@@ -1,9 +1,10 @@
-import { assert } from "@actnowcoalition/assert";
-import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { scaleLinear, scaleOrdinal } from "@visx/scale";
 import { interpolatePiYG } from "d3-scale-chromatic";
 import React from "react";
+
+import { assert } from "@actnowcoalition/assert";
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 
 import { USNationalMap } from "./USNationalMap";
 

--- a/packages/ui-components/src/components/USNationalMap/USNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/USNationalMap/USNationalMap.stories.tsx
@@ -1,7 +1,8 @@
+import React from "react";
+
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { scaleLinear, scaleOrdinal } from "@visx/scale";
 import { interpolatePiYG } from "d3-scale-chromatic";
-import React from "react";
 
 import { assert } from "@actnowcoalition/assert";
 import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/USNationalMap/USNationalMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/USNationalMap.tsx
@@ -1,16 +1,17 @@
-import React from "react";
 import { geoPath as d3GeoPath, geoAlbersUsa } from "d3-geo";
+import React from "react";
+
 import {
   defaultHeight,
   defaultScale,
   defaultWidth,
   getCountyGeoId,
 } from "../../common/geo-shapes";
-import { MapContainer, PositionAbsolute } from "../../styles/common/Maps.style";
-import StatesMap from "./StatesMap";
-import CountiesMap from "./CountiesMap";
-import { AutoWidth } from "../AutoWidth";
 import { BaseUSMapProps } from "../../common/utils/maps";
+import { MapContainer, PositionAbsolute } from "../../styles/common/Maps.style";
+import { AutoWidth } from "../AutoWidth";
+import CountiesMap from "./CountiesMap";
+import StatesMap from "./StatesMap";
 
 export interface USNationalMapProps extends BaseUSMapProps {
   showCounties?: boolean;

--- a/packages/ui-components/src/components/USNationalMap/USNationalMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/USNationalMap.tsx
@@ -1,5 +1,6 @@
-import { geoPath as d3GeoPath, geoAlbersUsa } from "d3-geo";
 import React from "react";
+
+import { geoPath as d3GeoPath, geoAlbersUsa } from "d3-geo";
 
 import {
   defaultHeight,

--- a/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { assert } from "@actnowcoalition/assert";
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+
 import { USStateMap } from "./USStateMap";
-import { states, counties, Region, RegionDB } from "@actnowcoalition/regions";
 
 const regionDB = new RegionDB([...states.all, ...counties.all], {
   getRegionUrl: (region: Region) => `/us/${region.slug}`,

--- a/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
@@ -1,7 +1,8 @@
-import { assert } from "@actnowcoalition/assert";
-import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { assert } from "@actnowcoalition/assert";
+import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 
 import { USStateMap } from "./USStateMap";
 

--- a/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { assert } from "@actnowcoalition/assert";
 import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.tsx
@@ -1,21 +1,22 @@
-import React from "react";
-import { Tooltip, Link } from "@mui/material";
+import { Region } from "@actnowcoalition/regions";
+import { Link, Tooltip } from "@mui/material";
 import { geoPath as d3GeoPath, geoAlbersUsa, geoMercator } from "d3-geo";
+import React from "react";
+
 import {
-  statesGeographies,
   countiesGeographies,
   defaultHeight,
   defaultWidth,
+  statesGeographies,
 } from "../../common/geo-shapes";
-import { belongsToState, BaseUSMapProps } from "../../common/utils/maps";
+import { BaseUSMapProps, belongsToState } from "../../common/utils/maps";
 import {
-  MapContainer,
   BorderingRegion,
   HighlightableShape,
+  MapContainer,
   RegionOverlay,
 } from "../../styles/common/Maps.style";
 import { AutoWidth } from "../AutoWidth";
-import { Region } from "@actnowcoalition/regions";
 
 export interface USStateMapProps extends BaseUSMapProps {
   /** Region ID of the state being mapped */

--- a/packages/ui-components/src/components/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.tsx
@@ -1,7 +1,8 @@
-import { Region } from "@actnowcoalition/regions";
 import { Link, Tooltip } from "@mui/material";
 import { geoPath as d3GeoPath, geoAlbersUsa, geoMercator } from "d3-geo";
 import React from "react";
+
+import { Region } from "@actnowcoalition/regions";
 
 import {
   countiesGeographies,

--- a/packages/ui-components/src/components/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Link, Tooltip } from "@mui/material";
 import { geoPath as d3GeoPath, geoAlbersUsa, geoMercator } from "d3-geo";
-import React from "react";
 
 import { Region } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/components/WorldMap/WorldMap.stories.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.stories.tsx
@@ -1,5 +1,6 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import WorldMap from "./WorldMap";
 

--- a/packages/ui-components/src/components/WorldMap/WorldMap.stories.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.stories.tsx
@@ -1,5 +1,6 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+
 import WorldMap from "./WorldMap";
 
 export default {

--- a/packages/ui-components/src/components/WorldMap/WorldMap.style.ts
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.style.ts
@@ -1,5 +1,6 @@
-import { styled } from "../../styles";
 import { Box } from "@mui/material";
+
+import { styled } from "../../styles";
 
 export const colorDisputedAreas = "#aaa";
 export const colorWaterBodies = "rgb(248,248,248)";

--- a/packages/ui-components/src/components/WorldMap/WorldMap.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.tsx
@@ -1,6 +1,7 @@
+import * as React from "react";
+
 import { Link, Tooltip } from "@mui/material";
 import { geoPath as d3GeoPath, geoMercator } from "d3-geo";
-import * as React from "react";
 
 import { defaultWidth, nationsGeographies } from "../../common/geo-shapes";
 import { MapContainer, RegionOverlay } from "../../styles/common/Maps.style";

--- a/packages/ui-components/src/components/WorldMap/WorldMap.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.tsx
@@ -1,15 +1,16 @@
+import { Link, Tooltip } from "@mui/material";
+import { geoPath as d3GeoPath, geoMercator } from "d3-geo";
 import * as React from "react";
-import { Tooltip, Link } from "@mui/material";
-import { geoMercator, geoPath as d3GeoPath } from "d3-geo";
+
+import { defaultWidth, nationsGeographies } from "../../common/geo-shapes";
+import { MapContainer, RegionOverlay } from "../../styles/common/Maps.style";
+import { AutoWidth } from "../AutoWidth";
+import { DiagonalHatchPattern } from "./DiagonalHatchPattern";
 import {
   DisputedAreaPath,
   DisputedBorderPath,
   colorDisputedAreas,
 } from "./WorldMap.style";
-import { DiagonalHatchPattern } from "./DiagonalHatchPattern";
-import { AutoWidth } from "../AutoWidth";
-import { defaultWidth, nationsGeographies } from "../../common/geo-shapes";
-import { MapContainer, RegionOverlay } from "../../styles/common/Maps.style";
 
 export interface WorldMapProps {
   renderTooltip: (regionId: string) => React.ReactNode;

--- a/packages/ui-components/src/stories/Buttons.stories.tsx
+++ b/packages/ui-components/src/stories/Buttons.stories.tsx
@@ -1,9 +1,10 @@
+import React from "react";
+
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import FacebookIcon from "@mui/icons-material/Facebook";
 import LinkIcon from "@mui/icons-material/Link";
 import TwitterIcon from "@mui/icons-material/Twitter";
 import { Button, ButtonGroup, IconButton, Stack } from "@mui/material";
-import React from "react";
 
 export default {
   title: "Design System/Buttons",

--- a/packages/ui-components/src/stories/Buttons.stories.tsx
+++ b/packages/ui-components/src/stories/Buttons.stories.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { Stack, Button, ButtonGroup, IconButton } from "@mui/material";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import FacebookIcon from "@mui/icons-material/Facebook";
-import TwitterIcon from "@mui/icons-material/Twitter";
 import LinkIcon from "@mui/icons-material/Link";
+import TwitterIcon from "@mui/icons-material/Twitter";
+import { Button, ButtonGroup, IconButton, Stack } from "@mui/material";
+import React from "react";
 
 export default {
   title: "Design System/Buttons",

--- a/packages/ui-components/src/stories/Chip.stories.tsx
+++ b/packages/ui-components/src/stories/Chip.stories.tsx
@@ -1,5 +1,6 @@
-import { Chip } from "@mui/material";
 import React from "react";
+
+import { Chip } from "@mui/material";
 
 export default {
   title: "Design System/Chip",

--- a/packages/ui-components/src/stories/Chip.stories.tsx
+++ b/packages/ui-components/src/stories/Chip.stories.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { Chip } from "@mui/material";
+import React from "react";
 
 export default {
   title: "Design System/Chip",

--- a/packages/ui-components/src/stories/Colors.stories.tsx
+++ b/packages/ui-components/src/stories/Colors.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Box, Grid, Palette, Stack, Typography } from "@mui/material";
 import isObject from "lodash/isObject";
-import React from "react";
 
 import theme from "../styles/theme";
 

--- a/packages/ui-components/src/stories/Colors.stories.tsx
+++ b/packages/ui-components/src/stories/Colors.stories.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import { Box, Grid, Palette, Stack, Typography } from "@mui/material";
 import isObject from "lodash/isObject";
-import { Typography, Palette, Grid, Box, Stack } from "@mui/material";
+import React from "react";
+
 import theme from "../styles/theme";
 
 export default {

--- a/packages/ui-components/src/stories/MockAppleStockDataProvider.ts
+++ b/packages/ui-components/src/stories/MockAppleStockDataProvider.ts
@@ -1,10 +1,11 @@
 import { assert } from "@actnowcoalition/assert";
-import { Region } from "@actnowcoalition/regions";
 import {
-  SimpleMetricDataProviderBase,
-  MetricData,
   Metric,
+  MetricData,
+  SimpleMetricDataProviderBase,
 } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+
 import { appleStockTimeseries } from "./mockData";
 
 /**

--- a/packages/ui-components/src/stories/NycTemperatureDataProvider.ts
+++ b/packages/ui-components/src/stories/NycTemperatureDataProvider.ts
@@ -1,10 +1,11 @@
 import { assert } from "@actnowcoalition/assert";
-import { Region } from "@actnowcoalition/regions";
 import {
-  SimpleMetricDataProviderBase,
-  MetricData,
   Metric,
+  MetricData,
+  SimpleMetricDataProviderBase,
 } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+
 import { nycTemperatureTimeseries } from "./mockData";
 
 /**

--- a/packages/ui-components/src/stories/Select.stories.tsx
+++ b/packages/ui-components/src/stories/Select.stories.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from "react";
+
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import {
   Box,
@@ -6,7 +8,6 @@ import {
   TextFieldProps,
   Typography,
 } from "@mui/material";
-import React, { useState } from "react";
 
 export default {
   title: "Design System/Select",

--- a/packages/ui-components/src/stories/Select.stories.tsx
+++ b/packages/ui-components/src/stories/Select.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import {
   Box,
   MenuItem,
@@ -6,7 +6,7 @@ import {
   TextFieldProps,
   Typography,
 } from "@mui/material";
-import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import React, { useState } from "react";
 
 export default {
   title: "Design System/Select",

--- a/packages/ui-components/src/stories/SelectMultiple.stories.tsx
+++ b/packages/ui-components/src/stories/SelectMultiple.stories.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import {
   Autocomplete,
   Box,
@@ -6,7 +8,6 @@ import {
   TextFieldProps,
   Typography,
 } from "@mui/material";
-import React from "react";
 
 export default {
   title: "Design System/SelectMultiple",

--- a/packages/ui-components/src/stories/SelectMultiple.stories.tsx
+++ b/packages/ui-components/src/stories/SelectMultiple.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Autocomplete,
   Box,
@@ -7,6 +6,7 @@ import {
   TextFieldProps,
   Typography,
 } from "@mui/material";
+import React from "react";
 
 export default {
   title: "Design System/SelectMultiple",

--- a/packages/ui-components/src/stories/Tabs.stories.tsx
+++ b/packages/ui-components/src/stories/Tabs.stories.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
-import { Stack, Tab, Typography, Tabs } from "@mui/material";
-import { metricCatalog, MetricId } from "./mockMetricCatalog";
 import { states } from "@actnowcoalition/regions";
+import { Stack, Tab, Tabs, Typography } from "@mui/material";
+import React, { useState } from "react";
+
 import { MetricValue } from "../components/MetricValue";
+import { MetricId, metricCatalog } from "./mockMetricCatalog";
 
 export default {
   title: "Design System/Tabs",

--- a/packages/ui-components/src/stories/Tabs.stories.tsx
+++ b/packages/ui-components/src/stories/Tabs.stories.tsx
@@ -1,5 +1,6 @@
-import { Stack, Tab, Tabs, Typography } from "@mui/material";
 import React, { useState } from "react";
+
+import { Stack, Tab, Tabs, Typography } from "@mui/material";
 
 import { states } from "@actnowcoalition/regions";
 

--- a/packages/ui-components/src/stories/Tabs.stories.tsx
+++ b/packages/ui-components/src/stories/Tabs.stories.tsx
@@ -1,6 +1,7 @@
-import { states } from "@actnowcoalition/regions";
 import { Stack, Tab, Tabs, Typography } from "@mui/material";
 import React, { useState } from "react";
+
+import { states } from "@actnowcoalition/regions";
 
 import { MetricValue } from "../components/MetricValue";
 import { MetricId, metricCatalog } from "./mockMetricCatalog";

--- a/packages/ui-components/src/stories/ToggleButtons.stories.tsx
+++ b/packages/ui-components/src/stories/ToggleButtons.stories.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from "react";
+
 import {
   FormatAlignCenter,
   FormatAlignJustify,
@@ -5,7 +7,6 @@ import {
   FormatAlignRight,
 } from "@mui/icons-material";
 import { ToggleButton, ToggleButtonGroup } from "@mui/material";
-import React, { useState } from "react";
 
 export default {
   title: "Design System/ToggleButtons",

--- a/packages/ui-components/src/stories/ToggleButtons.stories.tsx
+++ b/packages/ui-components/src/stories/ToggleButtons.stories.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from "react";
-import { ToggleButtonGroup, ToggleButton } from "@mui/material";
 import {
-  FormatAlignLeft,
-  FormatAlignRight,
   FormatAlignCenter,
   FormatAlignJustify,
+  FormatAlignLeft,
+  FormatAlignRight,
 } from "@mui/icons-material";
+import { ToggleButton, ToggleButtonGroup } from "@mui/material";
+import React, { useState } from "react";
 
 export default {
   title: "Design System/ToggleButtons",

--- a/packages/ui-components/src/stories/Typography.stories.tsx
+++ b/packages/ui-components/src/stories/Typography.stories.tsx
@@ -1,6 +1,7 @@
+import React from "react";
+
 import { Box, Grid, Typography } from "@mui/material";
 import { ComponentMeta } from "@storybook/react";
-import React from "react";
 
 export default {
   title: "Design System/Typography",

--- a/packages/ui-components/src/stories/Typography.stories.tsx
+++ b/packages/ui-components/src/stories/Typography.stories.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import { Box, Grid, Typography } from "@mui/material";
 import { ComponentMeta } from "@storybook/react";
-import { Typography, Grid, Box } from "@mui/material";
+import React from "react";
 
 export default {
   title: "Design System/Typography",

--- a/packages/ui-components/src/stories/mockData.ts
+++ b/packages/ui-components/src/stories/mockData.ts
@@ -1,7 +1,7 @@
-import { appleStock, cityTemperature } from "@visx/mock-data";
-import { scaleLinear, scaleUtc } from "@visx/scale";
 import { assert } from "@actnowcoalition/assert";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
+import { appleStock, cityTemperature } from "@visx/mock-data";
+import { scaleLinear, scaleUtc } from "@visx/scale";
 
 // We format the points from appleStock to match TimeseriesPoint<number>
 // so we can use them to initialize Timeseries.

--- a/packages/ui-components/src/stories/mockData.ts
+++ b/packages/ui-components/src/stories/mockData.ts
@@ -1,7 +1,8 @@
-import { assert } from "@actnowcoalition/assert";
-import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 import { appleStock, cityTemperature } from "@visx/mock-data";
 import { scaleLinear, scaleUtc } from "@visx/scale";
+
+import { assert } from "@actnowcoalition/assert";
+import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 
 // We format the points from appleStock to match TimeseriesPoint<number>
 // so we can use them to initialize Timeseries.

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -1,9 +1,10 @@
 import {
-  MetricDefinition,
   MetricCatalog,
+  MetricDefinition,
   MockDataProvider,
   StaticValueDataProvider,
 } from "@actnowcoalition/metrics";
+
 import { theme } from "../styles";
 import { AppleStockDataProvider } from "./MockAppleStockDataProvider";
 import { NycTemperatureDataProvider } from "./NycTemperatureDataProvider";

--- a/packages/ui-components/src/styles/common/Maps.style.tsx
+++ b/packages/ui-components/src/styles/common/Maps.style.tsx
@@ -1,5 +1,6 @@
-import { styled } from "../../styles";
 import isValidProp from "@emotion/is-prop-valid";
+
+import { styled } from "../../styles";
 
 export const StyledCanvas = styled("canvas")`
   pointer-events: none;

--- a/packages/ui-components/src/styles/index.ts
+++ b/packages/ui-components/src/styles/index.ts
@@ -1,4 +1,5 @@
 import { createStyled } from "@mui/system";
+
 import theme, { themeConfig } from "./theme";
 
 const styled = createStyled({ defaultTheme: theme });

--- a/packages/ui-components/src/styles/theme/components.tsx
+++ b/packages/ui-components/src/styles/theme/components.tsx
@@ -1,7 +1,8 @@
 /** MUI theme components */
+import React from "react";
+
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import { ThemeOptions, createTheme } from "@mui/material";
-import React from "react";
 
 const referenceTheme = createTheme();
 

--- a/packages/ui-components/src/styles/theme/components.tsx
+++ b/packages/ui-components/src/styles/theme/components.tsx
@@ -1,7 +1,7 @@
 /** MUI theme components */
-import React from "react";
-import { ThemeOptions, createTheme } from "@mui/material";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import { ThemeOptions, createTheme } from "@mui/material";
+import React from "react";
 
 const referenceTheme = createTheme();
 

--- a/packages/ui-components/src/styles/theme/interfaces.ts
+++ b/packages/ui-components/src/styles/theme/interfaces.ts
@@ -1,6 +1,7 @@
 /** Theme interfaces */
-import { TypographyOptions } from "@mui/material/styles/createTypography";
 import React from "react";
+
+import { TypographyOptions } from "@mui/material/styles/createTypography";
 
 /** Typography */
 export interface ExtendedTypographyOptions extends TypographyOptions {

--- a/packages/ui-components/src/styles/theme/theme.ts
+++ b/packages/ui-components/src/styles/theme/theme.ts
@@ -1,7 +1,9 @@
 import { createTheme, responsiveFontSizes } from "@mui/material/styles";
+
+import components from "./components";
 import palette from "./palette";
 import typography from "./typography";
-import components from "./components";
+
 /**
  * Theme configuration variables
  * https://mui.com/customization/theming/#theme-configuration-variables

--- a/packages/ui-components/src/styles/theme/typography.ts
+++ b/packages/ui-components/src/styles/theme/typography.ts
@@ -1,5 +1,5 @@
-import palette from "./palette";
 import { ExtendedTypographyOptions } from "./interfaces";
+import palette from "./palette";
 
 /**
  * Note: The default theme includes some fonts that need to be included at the

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,27 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@7.17.8":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.8.tgz#3dac27c190ebc3a4381110d46c80e77efe172e1a"
+  integrity sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.7"
+    "@babel/helper-compilation-targets" "^7.17.7"
+    "@babel/helper-module-transforms" "^7.17.7"
+    "@babel/helpers" "^7.17.8"
+    "@babel/parser" "^7.17.8"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+
 "@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.18.9", "@babel/core@^7.7.5":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.9.tgz#805461f967c77ff46c74ca0460ccf4fe933ddd59"
@@ -98,6 +119,15 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
+"@babel/generator@7.17.7":
+  version "7.17.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
+  integrity sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
+  dependencies:
+    "@babel/types" "^7.17.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.12.11", "@babel/generator@^7.12.5", "@babel/generator@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
@@ -114,6 +144,15 @@
   dependencies:
     "@babel/types" "^7.17.10"
     "@jridgewell/gen-mapping" "^0.1.0"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.17.3", "@babel/generator@^7.17.7", "@babel/generator@^7.20.1":
+  version "7.20.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.4.tgz#4d9f8f0c30be75fd90a0562099a26e5839602ab8"
+  integrity sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==
+  dependencies:
+    "@babel/types" "^7.20.2"
+    "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
 "@babel/helper-annotate-as-pure@^7.18.6":
@@ -216,6 +255,14 @@
   integrity sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
+  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/types" "^7.19.0"
 
 "@babel/helper-function-name@^7.17.9":
   version "7.17.9"
@@ -374,6 +421,11 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-string-parser@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
+  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
@@ -383,6 +435,11 @@
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
+"@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
@@ -413,6 +470,15 @@
     "@babel/traverse" "^7.18.9"
     "@babel/types" "^7.18.9"
 
+"@babel/helpers@^7.17.8":
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.1.tgz#2ab7a0fcb0a03b5bf76629196ed63c2d7311f4c9"
+  integrity sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.20.1"
+    "@babel/types" "^7.20.0"
+
 "@babel/helpers@^7.17.9":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.17.9.tgz#b2af120821bfbe44f9907b1826e168e819375a1a"
@@ -440,15 +506,20 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/parser@7.18.9", "@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
+  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.16.7", "@babel/parser@^7.17.10":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.10.tgz#873b16db82a8909e0fbd7f115772f4b739f6ce78"
   integrity sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==
 
-"@babel/parser@^7.12.11", "@babel/parser@^7.12.7", "@babel/parser@^7.18.6", "@babel/parser@^7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
-  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
+"@babel/parser@^7.16.4", "@babel/parser@^7.17.3", "@babel/parser@^7.17.8", "@babel/parser@^7.18.10", "@babel/parser@^7.20.1":
+  version "7.20.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.3.tgz#5358cf62e380cf69efcb87a7bb922ff88bfac6e2"
+  integrity sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1272,6 +1343,31 @@
     "@babel/parser" "^7.16.7"
     "@babel/types" "^7.16.7"
 
+"@babel/template@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
+  integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/parser" "^7.18.10"
+    "@babel/types" "^7.18.10"
+
+"@babel/traverse@7.17.3":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.17.3"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.17.3"
+    "@babel/types" "^7.17.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/traverse@^7.1.6", "@babel/traverse@^7.12.11", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
@@ -1304,6 +1400,30 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.20.1":
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.1.tgz#9b15ccbf882f6d107eeeecf263fbcdd208777ec8"
+  integrity sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.1"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.20.1"
+    "@babel/types" "^7.20.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/types@7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.17.10", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.10.tgz#d35d7b4467e439fcf06d195f8100e0fea7fc82c4"
@@ -1318,6 +1438,15 @@
   integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.10", "@babel/types@^7.19.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2":
+  version "7.20.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.2.tgz#67ac09266606190f496322dbaff360fdaa5e7842"
+  integrity sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@base2/pretty-print-object@1.0.1":
@@ -3329,6 +3458,20 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@trivago/prettier-plugin-sort-imports@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.4.0.tgz#68a6e9b49882eaf71566a00e283b46ed268daa72"
+  integrity sha512-485Iailw8X5f7KetzRka20RF1kPBEINR5LJMNwlBZWY1gRAlVnv5dZzyNPnLxSP0Qcia8HETa9Cdd8LlX9o+pg==
+  dependencies:
+    "@babel/core" "7.17.8"
+    "@babel/generator" "7.17.7"
+    "@babel/parser" "7.18.9"
+    "@babel/traverse" "7.17.3"
+    "@babel/types" "7.17.0"
+    "@vue/compiler-sfc" "^3.2.40"
+    javascript-natural-sort "0.7.1"
+    lodash "4.17.21"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -4093,6 +4236,64 @@
     classnames "^2.3.1"
     d3-voronoi "^1.1.2"
     prop-types "^15.6.1"
+
+"@vue/compiler-core@3.2.45":
+  version "3.2.45"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.2.45.tgz#d9311207d96f6ebd5f4660be129fb99f01ddb41b"
+  integrity sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/shared" "3.2.45"
+    estree-walker "^2.0.2"
+    source-map "^0.6.1"
+
+"@vue/compiler-dom@3.2.45":
+  version "3.2.45"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz#c43cc15e50da62ecc16a42f2622d25dc5fd97dce"
+  integrity sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==
+  dependencies:
+    "@vue/compiler-core" "3.2.45"
+    "@vue/shared" "3.2.45"
+
+"@vue/compiler-sfc@^3.2.40":
+  version "3.2.45"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz#7f7989cc04ec9e7c55acd406827a2c4e96872c70"
+  integrity sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.45"
+    "@vue/compiler-dom" "3.2.45"
+    "@vue/compiler-ssr" "3.2.45"
+    "@vue/reactivity-transform" "3.2.45"
+    "@vue/shared" "3.2.45"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+    postcss "^8.1.10"
+    source-map "^0.6.1"
+
+"@vue/compiler-ssr@3.2.45":
+  version "3.2.45"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz#bd20604b6e64ea15344d5b6278c4141191c983b2"
+  integrity sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==
+  dependencies:
+    "@vue/compiler-dom" "3.2.45"
+    "@vue/shared" "3.2.45"
+
+"@vue/reactivity-transform@3.2.45":
+  version "3.2.45"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz#07ac83b8138550c83dfb50db43cde1e0e5e8124d"
+  integrity sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==
+  dependencies:
+    "@babel/parser" "^7.16.4"
+    "@vue/compiler-core" "3.2.45"
+    "@vue/shared" "3.2.45"
+    estree-walker "^2.0.2"
+    magic-string "^0.25.7"
+
+"@vue/shared@3.2.45":
+  version "3.2.45"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.45.tgz#a3fffa7489eafff38d984e23d0236e230c818bc2"
+  integrity sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -7217,6 +7418,11 @@ estree-to-babel@^3.1.0:
     "@babel/types" "^7.2.0"
     c8 "^7.6.0"
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -9131,6 +9337,11 @@ iterate-value@^1.0.2:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
+javascript-natural-sort@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
+  integrity sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
+
 jest-changed-files@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-28.0.2.tgz#7d7810660a5bd043af9e9cfbe4d58adb05e91531"
@@ -10005,7 +10216,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10094,6 +10305,13 @@ lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
+magic-string@^0.25.7:
+  version "0.25.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
+  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
+  dependencies:
+    sourcemap-codec "^1.4.8"
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
@@ -10796,7 +11014,7 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
 
-nanoid@^3.3.1:
+nanoid@^3.3.1, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
@@ -11728,6 +11946,15 @@ postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0
   dependencies:
     picocolors "^0.2.1"
     source-map "^0.6.1"
+
+postcss@^8.1.10:
+  version "8.4.19"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.19.tgz#61178e2add236b17351897c8bcc0b4c8ecab56fc"
+  integrity sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 preferred-pm@^3.0.0:
   version "3.0.3"
@@ -13057,6 +13284,11 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -13103,6 +13335,11 @@ source-map@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 space-separated-tokens@^1.0.0:
   version "1.1.5"


### PR DESCRIPTION
Sorts imports in `/packages` using [@trivago/prettier-plugin-sort-imports](https://github.com/trivago/prettier-plugin-sort-imports), using the following sort order:
- react
- third party imports
- @actnowcoalition
- local imports


### Example (SparkLine.tsx):

**Before sort:**

```
import React from "react";
import { Group } from "@visx/group";
import { Timeseries } from "@actnowcoalition/metrics";
import { BarChart } from "../BarChart";
import { LineChart } from "../LineChart";
import { scaleUtc, scaleLinear } from "@visx/scale";
import { useTheme } from "@mui/material";
```

**After sort:**

```
import React from "react";

import { useTheme } from "@mui/material";
import { Group } from "@visx/group";
import { scaleLinear, scaleUtc } from "@visx/scale";

import { Timeseries } from "@actnowcoalition/metrics";

import { BarChart } from "../BarChart";
import { LineChart } from "../LineChart";
```