### PR TITLE
Add default metric format options

### DIFF
--- a/.changeset/empty-carrots-learn.md
+++ b/.changeset/empty-carrots-learn.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Add default metric format options and decimal points mock data

--- a/packages/metrics/src/Metric/Metric.test.ts
+++ b/packages/metrics/src/Metric/Metric.test.ts
@@ -185,6 +185,28 @@ describe("Metric", () => {
     expect(metric.formatValue(123.123)).toBe("123.1");
   });
 
+  test("formatValue() as integer", () => {
+    const metric = new Metric(
+      {
+        ...testMetricDef,
+        formatOptions: { maximumFractionDigits: 0 },
+      },
+      testCatalogOptions
+    );
+    expect(metric.formatValue(123.123)).toBe("123");
+  });
+
+  test("formatValue() with one decimal point", () => {
+    const metric = new Metric(
+      {
+        ...testMetricDef,
+        formatOptions: { minimumFractionDigits: 1, maximumFractionDigits: 1 },
+      },
+      testCatalogOptions
+    );
+    expect(metric.formatValue(0.1234)).toBe("0.1");
+  });
+
   test("formatValue() with custom options", () => {
     const metric = new Metric(
       {

--- a/packages/metrics/src/Metric/Metric.test.ts
+++ b/packages/metrics/src/Metric/Metric.test.ts
@@ -194,6 +194,7 @@ describe("Metric", () => {
       testCatalogOptions
     );
     expect(metric.formatValue(123.123)).toBe("123");
+    expect(metric.formatValue(0.123)).toBe("0");
   });
 
   test("formatValue() with one decimal point", () => {
@@ -204,7 +205,8 @@ describe("Metric", () => {
       },
       testCatalogOptions
     );
-    expect(metric.formatValue(0.1234)).toBe("0.1");
+    expect(metric.formatValue(123.123)).toBe("123.1");
+    expect(metric.formatValue(0.123)).toBe("0.1");
   });
 
   test("formatValue() with custom options", () => {

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
@@ -36,6 +36,12 @@ YAxisStartsAtZero.args = {
   metric: MetricId.APPLE_STOCK_LOW_THRESHOLDS,
 };
 
+export const PointsBetweenZeroAndOne = Template.bind({});
+PointsBetweenZeroAndOne.args = {
+  ...AppleStock.args,
+  metric: MetricId.RANDOM_POINTS_BETWEEN_ZERO_AND_ONE,
+};
+
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
   ...AppleStock.args,

--- a/packages/ui-components/src/stories/RandomPointsBetweenZeroAndOneDataProvider.ts
+++ b/packages/ui-components/src/stories/RandomPointsBetweenZeroAndOneDataProvider.ts
@@ -1,0 +1,38 @@
+import { assert } from "@actnowcoalition/assert";
+import { Region } from "@actnowcoalition/regions";
+import {
+  SimpleMetricDataProviderBase,
+  MetricData,
+  Metric,
+} from "@actnowcoalition/metrics";
+import { randomPointsBetweenZeroAndOneTimeseries } from "./mockData";
+
+/**
+ * Mock data provider with random points between zero and one.
+ * Useful for charts illustrating decimal points or percentage values.
+ *
+ * @example
+ * ```
+ * dataReference: {
+ *   providerId: "random_points_between_zero_and_one"
+ * },
+ * ```
+ */
+export class RandomPointsBetweenZeroAndOneDataProvider extends SimpleMetricDataProviderBase {
+  constructor(providerId: string) {
+    super(providerId);
+  }
+
+  async fetchDataForRegionAndMetric(
+    region: Region,
+    metric: Metric
+  ): Promise<MetricData<unknown>> {
+    const timeseries = randomPointsBetweenZeroAndOneTimeseries;
+
+    // Use last value of timeseries as current value.
+    assert(timeseries.hasData());
+    const currentValue = timeseries.last.value;
+
+    return new MetricData(metric, region, currentValue, timeseries);
+  }
+}

--- a/packages/ui-components/src/stories/mockData.ts
+++ b/packages/ui-components/src/stories/mockData.ts
@@ -3,6 +3,22 @@ import { scaleLinear, scaleUtc } from "@visx/scale";
 import { assert } from "@actnowcoalition/assert";
 import { Timeseries, TimeseriesPoint } from "@actnowcoalition/metrics";
 
+// We generate random decimal points in TimeseriesPoint<number>
+// format so we can use them to initialize Timeseries.
+const randomPointsBetweenZeroAndOne = appleStock.map(
+  (p: { date: string; close: number }): TimeseriesPoint<number> => ({
+    date: new Date(p.date.substring(0, 10)),
+    value: Math.random(),
+  })
+);
+
+export const randomPointsBetweenZeroAndOneTimeseries = new Timeseries(
+  randomPointsBetweenZeroAndOne
+).filterToDateRange({
+  startAt: new Date("2012-01-01"),
+  endAt: new Date("2012-01-31"),
+});
+
 // We format the points from appleStock to match TimeseriesPoint<number>
 // so we can use them to initialize Timeseries.
 const appleStockPoints = appleStock.map(

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -37,6 +37,7 @@ const defaultIntegerFormat: Intl.NumberFormatOptions = {
 
 const defaultDecimalFormat: Intl.NumberFormatOptions = {
   minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
 };
 
 const testMetricDefs: MetricDefinition[] = [

--- a/packages/ui-components/src/stories/mockMetricCatalog.ts
+++ b/packages/ui-components/src/stories/mockMetricCatalog.ts
@@ -7,6 +7,7 @@ import {
 import { theme } from "../styles";
 import { AppleStockDataProvider } from "./MockAppleStockDataProvider";
 import { NycTemperatureDataProvider } from "./NycTemperatureDataProvider";
+import { RandomPointsBetweenZeroAndOneDataProvider } from "./RandomPointsBetweenZeroAndOneDataProvider";
 
 export enum MetricId {
   APPLE_STOCK = "apple_stock",
@@ -19,6 +20,7 @@ export enum MetricId {
   MOCK_CASES_ERROR = "mock_cases_error",
   PASS_FAIL = "pass_fail",
   PASS_FAIL_NO_EXTENDED_NAME = "pass_fail_no_extended_name",
+  RANDOM_POINTS_BETWEEN_ZERO_AND_ONE = "random_points_between_zero_and_one",
 }
 
 export enum ProviderId {
@@ -26,7 +28,16 @@ export enum ProviderId {
   STATIC = "static",
   APPLE_STOCK = "apple_stock",
   NYC_TEMPERATURE = "nyc_temperature",
+  RANDOM_POINTS_BETWEEN_ZERO_AND_ONE = "random_points_between_zero_and_one",
 }
+
+const defaultIntegerFormat: Intl.NumberFormatOptions = {
+  maximumFractionDigits: 0,
+};
+
+const defaultDecimalFormat: Intl.NumberFormatOptions = {
+  minimumFractionDigits: 1,
+};
 
 const testMetricDefs: MetricDefinition[] = [
   {
@@ -38,6 +49,7 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categoryThresholds: [100, 200, 400, 800],
     categorySetId: "5_risk_categories",
+    formatOptions: defaultIntegerFormat,
   },
   {
     id: MetricId.APPLE_STOCK_LOW_THRESHOLDS,
@@ -48,6 +60,7 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categoryThresholds: [0, 100, 200, 400],
     categorySetId: "5_risk_categories",
+    formatOptions: defaultIntegerFormat,
   },
   {
     id: MetricId.NYC_TEMPERATURE,
@@ -58,6 +71,7 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categoryThresholds: [-20, 0, 10, 30],
     categorySetId: "5_risk_categories",
+    formatOptions: defaultIntegerFormat,
   },
   {
     id: MetricId.PI,
@@ -78,6 +92,7 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categoryThresholds: [40, 100],
     categorySetId: "cases_mock",
+    formatOptions: defaultIntegerFormat,
   },
   {
     id: MetricId.MOCK_CASES_NO_EXTENDED_NAME,
@@ -88,6 +103,7 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categoryThresholds: [10, 100],
     categorySetId: "cases_mock",
+    formatOptions: defaultIntegerFormat,
   },
   {
     id: MetricId.MOCK_CASES_DELAY_1S,
@@ -100,6 +116,7 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categoryThresholds: [10, 100],
     categorySetId: "cases_mock",
+    formatOptions: defaultIntegerFormat,
   },
   {
     id: MetricId.MOCK_CASES_ERROR,
@@ -112,6 +129,7 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categoryThresholds: [10, 100],
     categorySetId: "cases_mock",
+    formatOptions: defaultIntegerFormat,
   },
   {
     id: MetricId.PASS_FAIL,
@@ -123,6 +141,7 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categorySetId: "pass_fail",
     categoryValues: [0, 1],
+    formatOptions: defaultIntegerFormat,
   },
   {
     id: MetricId.PASS_FAIL_NO_EXTENDED_NAME,
@@ -133,6 +152,18 @@ const testMetricDefs: MetricDefinition[] = [
     },
     categorySetId: "pass_fail",
     categoryValues: [0, 1],
+    formatOptions: defaultIntegerFormat,
+  },
+  {
+    id: MetricId.RANDOM_POINTS_BETWEEN_ZERO_AND_ONE,
+    name: "Random decimal points",
+    extendedName: "Random decimal points between zero and one",
+    dataReference: {
+      providerId: ProviderId.RANDOM_POINTS_BETWEEN_ZERO_AND_ONE,
+    },
+    categoryThresholds: [0.2, 0.4, 0.6, 0.8],
+    categorySetId: "5_risk_categories",
+    formatOptions: defaultDecimalFormat,
   },
 ];
 
@@ -141,6 +172,9 @@ export const dataProviders = [
   new StaticValueDataProvider(ProviderId.STATIC),
   new AppleStockDataProvider(ProviderId.APPLE_STOCK),
   new NycTemperatureDataProvider(ProviderId.NYC_TEMPERATURE),
+  new RandomPointsBetweenZeroAndOneDataProvider(
+    ProviderId.RANDOM_POINTS_BETWEEN_ZERO_AND_ONE
+  ),
 ];
 
 const metricCategorySets = [
@@ -229,6 +263,7 @@ const metricDefsB: MetricDefinition[] = [
       providerId: ProviderId.MOCK,
       startDate: "2020-01-01",
     },
+    formatOptions: defaultIntegerFormat,
   },
 ];
 


### PR DESCRIPTION
Closes https://github.com/covid-projections/act-now-packages/issues/326

This PR adds a default format option for each metric.