### PR TITLE
Fix the initial sorting state of MetricCompareTable

### DIFF
--- a/.changeset/dry-ravens-brake.md
+++ b/.changeset/dry-ravens-brake.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": minor
+---
+
+Removing sortColumnId and sortDirection from CompareTable

--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -14,6 +14,7 @@ import {
   TableCell,
   TableContainer,
   compare,
+  sortTableRows,
 } from ".";
 
 export default {
@@ -136,27 +137,23 @@ const StatefulCompareTable = ({ rows }: { rows: RowItem[] }) => {
     },
   ];
 
-  const [sortColumnId, setSortColumnId] = useState(columns[0].columnId);
-  const [sortDirection, setSortDirection] = useState(SortDirection.ASC);
+  const [sortState, setSortState] = useState({
+    sortColumnId: columns[0].columnId,
+    sortDirection: SortDirection.ASC,
+  });
+  const { sortColumnId, sortDirection } = sortState;
 
   const onClickSort = (direction: SortDirection, columnId: string) => {
-    setSortColumnId(columnId);
-    setSortDirection(direction);
+    setSortState({ sortColumnId: columnId, sortDirection: direction });
   };
 
-  return (
-    <CompareTable
-      rows={rows}
-      columns={columns}
-      sortColumnId={sortColumnId}
-      sortDirection={sortDirection}
-    />
-  );
+  const sortedRows = sortTableRows(rows, columns, sortState);
+  return <CompareTable rows={sortedRows} columns={columns} />;
 };
 
 export const Example = () => {
   return (
-    <TableContainer sx={{ maxWidth: 400, height: 600 }}>
+    <TableContainer sx={{ maxWidth: 700, height: 600 }}>
       <StatefulCompareTable rows={rows} />
     </TableContainer>
   );

--- a/packages/ui-components/src/components/CompareTable/CompareTable.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.tsx
@@ -1,13 +1,7 @@
 import React, { Fragment } from "react";
 
-import {
-  CompareTableProps,
-  SortDirection,
-  Table,
-  TableBody,
-  TableHead,
-  TableRow,
-} from ".";
+import { Table, TableBody, TableHead, TableRow } from "./CompareTable.style";
+import { CompareTableProps } from "./interfaces";
 
 export interface CompareTableRowBase {
   /** A unique ID that identifies this row. */
@@ -17,13 +11,8 @@ export interface CompareTableRowBase {
 export const CompareTable = <R extends CompareTableRowBase>({
   rows,
   columns,
-  sortColumnId,
-  sortDirection = SortDirection.DESC,
   ...muiTableProps
 }: CompareTableProps<R>) => {
-  const sortColumn = columns.find((column) => column.columnId === sortColumnId);
-  const sortedRows = sortRows(rows, sortDirection, sortColumn?.sorterAsc);
-
   return (
     <Table {...muiTableProps}>
       <TableHead>
@@ -36,7 +25,7 @@ export const CompareTable = <R extends CompareTableRowBase>({
         </TableRow>
       </TableHead>
       <TableBody>
-        {sortedRows.map((row, rowIndex) => (
+        {rows.map((row, rowIndex) => (
           <TableRow key={`table-row-${row.rowId}`} hover>
             {columns.map((column, columnIndex) => (
               <Fragment key={`cell-${row.rowId}-${column.columnId}`}>
@@ -49,40 +38,3 @@ export const CompareTable = <R extends CompareTableRowBase>({
     </Table>
   );
 };
-
-/**
- * Sort the rows using the given sorter function and direction
- */
-export function sortRows<R>(
-  rows: R[],
-  sortDirection: SortDirection,
-  sorterAsc?: (a: R, b: R) => number
-): R[] {
-  if (!sorterAsc) {
-    return rows;
-  }
-
-  const sortedAsc = [...rows].sort(sorterAsc);
-  return sortDirection === SortDirection.ASC ? sortedAsc : sortedAsc.reverse();
-}
-
-/**
- * Function that compares two items for sorting (ascending).
- *
- * @example
- * ```tsx
- * compare("a", "b") // -1
- * compare("a", "a") // 0
- * compare(1, 2) // -1
- * [3, 2, 4, 1].sort(compare) // [1, 2, 3, 4]
- * ```
- */
-export function compare<T>(a: T, b: T): number {
-  if (a < b) {
-    return -1;
-  } else if (a > b) {
-    return 1;
-  } else {
-    return 0;
-  }
-}

--- a/packages/ui-components/src/components/CompareTable/index.ts
+++ b/packages/ui-components/src/components/CompareTable/index.ts
@@ -3,3 +3,4 @@ export * from "./CompareTable.style";
 export * from "./SortControls";
 export * from "./ColumnHeader";
 export * from "./interfaces";
+export * from "./utils";

--- a/packages/ui-components/src/components/CompareTable/interfaces.ts
+++ b/packages/ui-components/src/components/CompareTable/interfaces.ts
@@ -1,17 +1,5 @@
 import { TableProps as MuiTableProps } from "@mui/material";
 
-/**
- * Represents sorting directions for a column.
- *
- * Note: It will be better to use "ascending" and "descending" as values for
- * the enum so we can use the value for the aria-sort property, but MUI's
- * SortDirection uses "asc" and "desc".
- * */
-export enum SortDirection {
-  ASC = "asc",
-  DESC = "desc",
-}
-
 export interface ColumnDefinition<R> {
   /** A unique ID that identifies this column. */
   columnId: string;
@@ -38,8 +26,4 @@ export interface CompareTableProps<R> extends MuiTableProps {
   rows: R[];
   /** List of column definitions. */
   columns: ColumnDefinition<R>[];
-  /** ID of the column to sort by. */
-  sortColumnId?: string;
-  /** Sort direction. */
-  sortDirection?: SortDirection;
 }

--- a/packages/ui-components/src/components/CompareTable/utils.ts
+++ b/packages/ui-components/src/components/CompareTable/utils.ts
@@ -1,0 +1,76 @@
+import { ColumnDefinition } from "./interfaces";
+
+/**
+ * Represents sorting directions for a column.
+ *
+ * Note: It will be better to use "ascending" and "descending" as values for
+ * the enum so we can use the value for the aria-sort property, but MUI's
+ * SortDirection uses "asc" and "desc".
+ * */
+export enum SortDirection {
+  ASC = "asc",
+  DESC = "desc",
+}
+
+/**
+ * Interface to represent the sorting state of the table.
+ */
+export interface TableSortState {
+  sortColumnId: string;
+  sortDirection: SortDirection;
+}
+
+/**
+ * Sort the rows using the given sorter function and direction
+ */
+export function sortRows<R>(
+  rows: R[],
+  sortDirection: SortDirection,
+  sorterAsc?: (a: R, b: R) => number
+): R[] {
+  if (!sorterAsc) {
+    return rows;
+  }
+
+  const sortedAsc = [...rows].sort(sorterAsc);
+  return sortDirection === SortDirection.ASC ? sortedAsc : sortedAsc.reverse();
+}
+
+/**
+ * Function that compares two items for sorting (ascending).
+ *
+ * @example
+ * ```tsx
+ * compare("a", "b") // -1
+ * compare("a", "a") // 0
+ * compare(1, 2) // -1
+ * [3, 2, 4, 1].sort(compare) // [1, 2, 3, 4]
+ * ```
+ */
+export function compare<T>(a: T, b: T): number {
+  if (a < b) {
+    return -1;
+  } else if (a > b) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+/**
+ * Sort the rows using the sorting column and
+ *
+ * @param rows
+ * @param columns
+ * @param sortState
+ * @returns
+ */
+export function sortTableRows<R>(
+  rows: R[],
+  columns: ColumnDefinition<R>[],
+  sortState: TableSortState
+) {
+  const { sortColumnId, sortDirection } = sortState;
+  const sortColumn = columns.find((column) => column.columnId === sortColumnId);
+  return sortRows(rows, sortDirection, sortColumn?.sorterAsc);
+}

--- a/packages/ui-components/src/components/CompareTable/utils.ts
+++ b/packages/ui-components/src/components/CompareTable/utils.ts
@@ -58,12 +58,13 @@ export function compare<T>(a: T, b: T): number {
 }
 
 /**
- * Sort the rows using the sorting column and
+ * Sort the rows using the sorting column and direction provided in the
+ * sortState parameter.
  *
  * @param rows
  * @param columns
  * @param sortState
- * @returns
+ * @returns A sorted copy of the rows.
  */
 export function sortTableRows<R>(
   rows: R[],

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -6,7 +6,7 @@ import { Region, RegionDB, states } from "@actnowcoalition/regions";
 
 import { MetricCompareTable } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
-import { TableContainer } from "../CompareTable";
+import { SortDirection, TableContainer } from "../CompareTable";
 
 const regionDB = new RegionDB(states.all, {
   getRegionUrl: (region: Region) => `/us/${region.slug}`,
@@ -23,21 +23,30 @@ const Template: ComponentStory<typeof MetricCompareTable> = (args) => (
   </TableContainer>
 );
 
-export const Example = Template.bind({});
-Example.args = {
+export const DefaultSortOrder = Template.bind({});
+DefaultSortOrder.args = {
   regionDB,
   regions: regionDB.all,
   metrics: [MetricId.PI, MetricId.MOCK_CASES, MetricId.PASS_FAIL],
 };
 
+export const InitialSortOrder = Template.bind({});
+InitialSortOrder.args = {
+  regionDB,
+  regions: regionDB.all,
+  metrics: [MetricId.PI, MetricId.MOCK_CASES, MetricId.PASS_FAIL],
+  sortColumnId: MetricId.MOCK_CASES,
+  sortDirection: SortDirection.ASC,
+};
+
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
-  ...Example.args,
+  ...DefaultSortOrder.args,
   metrics: [MetricId.PI, MetricId.MOCK_CASES_DELAY_1S, MetricId.PASS_FAIL],
 };
 
 export const LoadingError = Template.bind({});
 LoadingError.args = {
-  ...Example.args,
+  ...DefaultSortOrder.args,
   metrics: [MetricId.PI, MetricId.MOCK_CASES_ERROR, MetricId.PASS_FAIL],
 };

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -23,9 +23,9 @@ export interface MetricCompareTableProps
   regions: Region[];
   /** List of metrics or metricID - order of the columns will match */
   metrics: (Metric | string)[];
-
-  /** Id  */
+  /** Initial sorting column. By default, it will use the location column. */
   sortColumnId?: string;
+  /** Initial sort direction. Ascending by default. */
   sortDirection?: SortDirection;
 }
 
@@ -39,7 +39,7 @@ export const MetricCompareTable = ({
 }: MetricCompareTableProps) => {
   const initialState = {
     sortColumnId: initialSortColumnId ?? "location",
-    sortDirection: initialSortDirection ?? SortDirection.DESC,
+    sortDirection: initialSortDirection ?? SortDirection.ASC,
   };
 
   const [sortState, setSortState] = useState<TableSortState>(initialState);

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -9,7 +9,8 @@ import {
   CompareTable,
   CompareTableProps,
   SortDirection,
-  sortRows,
+  TableSortState,
+  sortTableRows,
 } from "../CompareTable";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { Row, createLocationColumn, createMetricColumn } from "./utils";
@@ -22,22 +23,30 @@ export interface MetricCompareTableProps
   regions: Region[];
   /** List of metrics or metricID - order of the columns will match */
   metrics: (Metric | string)[];
+
+  /** Id  */
+  sortColumnId?: string;
+  sortDirection?: SortDirection;
 }
 
 export const MetricCompareTable = ({
   regionDB,
   regions,
   metrics: metricOrIds,
+  sortColumnId: initialSortColumnId,
+  sortDirection: initialSortDirection,
   ...otherCompareTableProps
 }: MetricCompareTableProps) => {
-  // TODO(Pablo): It might be better to define and set a context to control the
-  // state of the table if we need to control it from a parent component.
-  const [sortDirection, setSortDirection] = useState(SortDirection.DESC);
-  const [sortColumnId, setSortColumnId] = useState("location");
+  const initialState = {
+    sortColumnId: initialSortColumnId ?? "location",
+    sortDirection: initialSortDirection ?? SortDirection.DESC,
+  };
+
+  const [sortState, setSortState] = useState<TableSortState>(initialState);
+  const { sortColumnId, sortDirection } = sortState;
 
   const onClickSort = (direction: SortDirection, columnId: string) => {
-    setSortDirection(direction);
-    setSortColumnId(columnId);
+    setSortState({ sortDirection: direction, sortColumnId: columnId });
   };
 
   const metricCatalog = useMetricCatalog();
@@ -72,8 +81,7 @@ export const MetricCompareTable = ({
     ),
   ];
 
-  const sortColumn = columns.find((col) => col.columnId === sortColumnId);
-  const sortedRows = sortRows<Row>(rows, sortDirection, sortColumn?.sorterAsc);
+  const sortedRows = sortTableRows<Row>(rows, columns, sortState);
 
   return (
     <CompareTable


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/392 - Fix MetricCompareTable so its sorting state can be set initially (and the the table remains sortable after) 

The bug was happening because:

- `MetricCompareTable` wasn't initializing the sorting state using the `sortColumnId` and `sortDirection` passed as props (but it was still passing them down to `CompareTable`).
- The `CompareTable` was sorting the table using the `sortColumnId` and `sortDirection` props (which were not connected to the sorting state of `MetricCompareTable`).

Since the `CompareTable` doesn't have a sorting state (or any sorting logic really), it doesn't make sense that it will sort the rows. I removed `sortColumnId` and `sortDirection` from `CompareTableProps` and added them to `MetricCompareTable`.

**Storybook**
- [CompareTable](https://act-now-packages--pr460-pablo-compare-table-fz3lmhdc.web.app/storybook/index.html?path=/story/table-comparetable--example)
- [MetricCompareTable - Default Sort Order](https://act-now-packages--pr460-pablo-compare-table-fz3lmhdc.web.app/storybook/index.html?path=/story/metrics-metriccomparetable--default-sort-order) 
- [MetricCompareTable - Initial Sort State](https://act-now-packages--pr460-pablo-compare-table-fz3lmhdc.web.app/storybook/index.html?path=/story/metrics-metriccomparetable--initial-sort-order)

I also moved some functions to `components/CompareTable/utils.ts` since they are not being used in the `CompareTable` component anymore. I will cleanup a bit more (get rid of `interfaces.ts`) on a follow up PR. 