### PR TITLE
Fix #417: Render Skeleton component in charts while data is loading to avoid layout shift.

### DIFF
--- a/.changeset/sweet-queens-impress.md
+++ b/.changeset/sweet-queens-impress.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Render Skeleton component in charts while data is loading to avoid layout shift.

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -11,6 +11,7 @@ import { PointMarker } from "../PointMarker";
 import { BaseChartProps } from "../../common/utils/charts";
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
+import { Skeleton } from "@mui/material";
 
 export interface MetricLineChartProps extends BaseChartProps {
   metric: Metric | string;
@@ -37,7 +38,7 @@ export const MetricLineChart = ({
     useHoveredDate(timeseries);
 
   if (!data || !timeseries?.hasData()) {
-    return null;
+    return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 
   const chartHeight = height - marginTop - marginBottom;
@@ -56,7 +57,7 @@ export const MetricLineChart = ({
   });
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} style={{ display: "block" }}>
       <Group left={marginLeft} top={marginTop}>
         <AxesTimeseries
           height={chartHeight}

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -16,6 +16,7 @@ import { BaseChartProps } from "../../common/utils/charts";
 import { PointMarker } from "../PointMarker";
 import { LineIntervalChart } from "../LineIntervalChart";
 import { calculateChartIntervals } from "./utils";
+import { Skeleton } from "@mui/material";
 
 export interface MetricLineThresholdChartProps extends BaseChartProps {
   metric: Metric | string;
@@ -50,7 +51,7 @@ export const MetricLineThresholdChart = ({
     useHoveredDate(timeseries);
 
   if (!timeseries?.hasData?.()) {
-    return null;
+    return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 
   const chartHeight = height - marginTop - marginBottom;
@@ -86,7 +87,7 @@ export const MetricLineThresholdChart = ({
   });
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} style={{ display: "block" }}>
       <Group left={marginLeft} top={marginTop}>
         <AxesTimeseries
           height={chartHeight}

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -111,7 +111,7 @@ export const MetricSeriesChart = ({
   const yAxisFormat = (value: number) => metrics[0].formatValue(value, "---");
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} style={{ display: "block" }}>
       <Group top={marginTop} left={marginLeft}>
         <AxesTimeseries
           yScale={yScale}

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -58,7 +58,7 @@ export const SparkLine = ({
   });
 
   return (
-    <svg width={width} height={height}>
+    <svg width={width} height={height} style={{ display: "block" }}>
       <Group left={padding} top={padding}>
         <Group left={-0.5 * barWidth}>
           <BarChart


### PR DESCRIPTION
See:
* https://act-now-packages--pr461-mikelehen-chart-load-s1kw1ydm.web.app/storybook/index.html?path=/story/charts-metriclinechart--loading-delay
* https://act-now-packages--pr461-mikelehen-chart-load-s1kw1ydm.web.app/storybook/index.html?path=/story/charts-metriclinethresholdchart--loading-delay
* https://act-now-packages--pr461-mikelehen-chart-load-s1kw1ydm.web.app/storybook/index.html?path=/story/charts-metricserieschart--loading-delay
* https://act-now-packages--pr461-mikelehen-chart-load-s1kw1ydm.web.app/storybook/index.html?path=/story/metrics-metricsparklines--loading-delay