### PR TITLE
Fix #422: Make MetricMultiProgressBar render Skeleton while data is loading to avoid layout shift.

### DIFF
--- a/.changeset/breezy-cooks-perform.md
+++ b/.changeset/breezy-cooks-perform.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix #422: Make MetricMultiProgressBar render Skeleton while data is loading to avoid layout shift.

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -4,6 +4,8 @@ import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
 import {
   MultiProgressBar,
   BaseMultiProgressBarProps,
+  DEFAULT_WIDTH,
+  DEFAULT_HEIGHT,
 } from "../MultiProgressBar";
 import { useDataForMetrics } from "../../common/hooks";
 import { Skeleton } from "@mui/material";
@@ -20,8 +22,8 @@ export interface MetricMultiProgressBarProps extends BaseMultiProgressBarProps {
 export const MetricMultiProgressBar = ({
   region,
   metrics,
-  width = 100,
-  height = 16,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   ...otherProgressBarProps
 }: MetricMultiProgressBarProps) => {
   const { data } = useDataForMetrics(region, metrics, false);

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -6,6 +6,7 @@ import {
   BaseMultiProgressBarProps,
 } from "../MultiProgressBar";
 import { useDataForMetrics } from "../../common/hooks";
+import { Skeleton } from "@mui/material";
 
 type MetricProp = Metric | string;
 
@@ -19,12 +20,14 @@ export interface MetricMultiProgressBarProps extends BaseMultiProgressBarProps {
 export const MetricMultiProgressBar = ({
   region,
   metrics,
+  width = 100,
+  height = 16,
   ...otherProgressBarProps
 }: MetricMultiProgressBarProps) => {
   const { data } = useDataForMetrics(region, metrics, false);
 
   if (!data) {
-    return null;
+    return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 
   const [firstItem, secondItem] = getProgressBarItems(data, metrics);
@@ -34,6 +37,8 @@ export const MetricMultiProgressBar = ({
       items={[firstItem, secondItem]}
       getItemValue={(item) => item.currentValue}
       getItemLabel={(item) => item.label}
+      width={width}
+      height={height}
       {...otherProgressBarProps}
     />
   );

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
@@ -23,13 +23,16 @@ export interface MultiProgressBarProps<T> extends BaseMultiProgressBarProps {
   getItemValue: (item: T) => number;
 }
 
+export const DEFAULT_WIDTH = 100;
+export const DEFAULT_HEIGHT = 16;
+
 export const MultiProgressBar = <T,>({
   items,
   getItemValue,
   getItemLabel,
   maxValue,
-  width = 100,
-  height = 16,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
   barColor = "#000000",
   bgColor,
   borderRadius = 4,

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
@@ -54,7 +54,13 @@ export const MultiProgressBar = <T,>({
   );
 
   return (
-    <svg width={width} height={height} aria-labelledby={titleId} role="meter">
+    <svg
+      width={width}
+      height={height}
+      aria-labelledby={titleId}
+      role="meter"
+      style={{ display: "block" }}
+    >
       <title id={titleId}>
         {title
           ? title


### PR DESCRIPTION
See https://act-now-packages--pr462-mikelehen-progressba-64no4ucj.web.app/storybook/index.html?path=/story/metrics-metricmultiprogressbar--loading-delay