### PR TITLE
Fix #421: Render placeholder text in MetricOverview while data is loading to avoid layout shift.

### DIFF
--- a/.changeset/brave-files-heal.md
+++ b/.changeset/brave-files-heal.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix #421: Render placeholder text in MetricOverview while waiting for data to load to avoid layout shift.

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -29,6 +29,10 @@ export const MetricValue = ({
 
   const { data, error } = useData(region, metric, /*includeTimeseries=*/ false);
 
+  // If there's an error we render "---" to match when there's no data.
+  // While we are waiting for data to load we render "\u00A0" (a non-breaking
+  // space) just so the height renders correctly and we don't get a layout shift
+  // when the data is available.
   const formattedValue = error
     ? "---"
     : !data

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -29,16 +29,16 @@ export const MetricValue = ({
 
   const { data, error } = useData(region, metric, /*includeTimeseries=*/ false);
 
-  if (!data || error) {
-    return <Typography variant={variant} />;
-  }
+  const formattedValue = error
+    ? "---"
+    : !data
+    ? "\u00A0"
+    : metric.formatValue(data.currentValue, "---");
 
   return (
     <Stack direction="row" spacing={1} alignItems="center" {...stackProps}>
       <MetricDot region={region} metric={metric} />
-      <Typography variant={variant}>
-        {metric.formatValue(data.currentValue, "---")}
-      </Typography>
+      <Typography variant={variant}>{formattedValue}</Typography>
     </Stack>
   );
 };


### PR DESCRIPTION
See:
* https://act-now-packages--pr463-mikelehen-metric-ove-844e7efn.web.app/storybook/index.html?path=/story/metrics-metricvalue--loading-delay
* https://act-now-packages--pr463-mikelehen-metric-ove-844e7efn.web.app/storybook/index.html?path=/story/metrics-metricoverview--loading-delay
* https://act-now-packages--pr463-mikelehen-metric-ove-844e7efn.web.app/storybook/index.html?path=/story/metrics-metricscoreoverview--loading-delay