### PR TITLE
Fixes #450: Adds theming selector to Storybook (and adds an initial dark theme).

### DIFF
--- a/.changeset/lazy-cameras-fail.md
+++ b/.changeset/lazy-cameras-fail.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fixes #450: Adds theming selector to Storybook (and adds an initial dark theme).

--- a/packages/ui-components/.storybook/preview.tsx
+++ b/packages/ui-components/.storybook/preview.tsx
@@ -5,7 +5,36 @@ import { ThemeProvider } from "@mui/material/styles";
 
 import { MetricCatalogProvider } from "../src/components/MetricCatalogContext";
 import { metricCatalog } from "../src/stories/mockMetricCatalog";
-import { theme } from "../src/styles";
+import { darkTheme, theme } from "../src/styles";
+
+enum Theme {
+  LIGHT = "light",
+  DARK = "dark",
+}
+
+const themes = {
+  [Theme.LIGHT]: theme,
+  [Theme.DARK]: darkTheme,
+};
+
+// Adds a "theme" selector to StoryBook that we'll use to choose the theme
+// we render.
+export const globalTypes = {
+  theme: {
+    name: "Theme",
+    title: "Theme",
+    description: "Theme for your components",
+    defaultValue: Theme.LIGHT,
+    toolbar: {
+      icon: "paintbrush",
+      dynamicTitle: true,
+      items: [
+        { value: Theme.LIGHT, left: "️☀️", title: "Light mode" },
+        { value: Theme.DARK, left: "🌙", title: "Dark mode" },
+      ],
+    },
+  },
+};
 
 /**
  * Note (Pablo): It seems that the order of the context providers matter, even
@@ -13,14 +42,17 @@ import { theme } from "../src/styles";
  * outer provider, the styles for variant="paragraphSmall" on Typography are
  * not correctly applied.
  */
-const appDecorator = (Story) => (
-  <MetricCatalogProvider metricCatalog={metricCatalog}>
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Story />
-    </ThemeProvider>
-  </MetricCatalogProvider>
-);
+const appDecorator = (Story, context) => {
+  const selectedTheme = themes[context.globals.theme ?? Theme.LIGHT];
+  return (
+    <MetricCatalogProvider metricCatalog={metricCatalog}>
+      <ThemeProvider theme={selectedTheme}>
+        <CssBaseline />
+        <Story />
+      </ThemeProvider>
+    </MetricCatalogProvider>
+  );
+};
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -1,7 +1,7 @@
 import { Theme } from "@mui/material/styles";
 
 /** Theme variables */
-export { themeConfig } from "./styles";
+export { themeConfig, darkThemeConfig } from "./styles";
 
 /**
  * Material UI Theme extensions

--- a/packages/ui-components/src/styles/index.ts
+++ b/packages/ui-components/src/styles/index.ts
@@ -1,7 +1,8 @@
 import { createStyled } from "@mui/system";
 
 import theme, { themeConfig } from "./theme";
+import { darkTheme, darkThemeConfig } from "./theme";
 
 const styled = createStyled({ defaultTheme: theme });
 
-export { styled, theme, themeConfig };
+export { styled, theme, themeConfig, darkTheme, darkThemeConfig };

--- a/packages/ui-components/src/styles/theme/dark-theme.tsx
+++ b/packages/ui-components/src/styles/theme/dark-theme.tsx
@@ -1,0 +1,125 @@
+import {
+  Theme,
+  colors,
+  createTheme,
+  formControlClasses,
+  linkClasses,
+  responsiveFontSizes,
+  svgIconClasses,
+  tableCellClasses,
+  tableRowClasses,
+  typographyClasses,
+} from "@mui/material";
+import { deepmerge } from "@mui/utils";
+
+import { themeConfig as defaultThemeConfig } from "./theme";
+
+// TODO(#452): Implement a proper dark theme. Michael copy/pasted this from Pablo's
+// hackathon project and it probably has issues / is incomplete / etc. We may also
+// want to refactor this across multiple files (palette, typography, etc.) like the
+// default theme.
+const darkThemeConfig = {
+  palette: {
+    mode: "dark",
+    background: {
+      default: colors.blueGrey[900],
+    },
+    border: {
+      default: colors.grey[400],
+    },
+    primary: {
+      main: colors.grey[200],
+      contrastText: colors.grey[900],
+    },
+    text: {
+      primary: colors.grey[100],
+      secondary: colors.grey[100],
+    },
+    severity: {
+      100: colors.blue[500],
+      200: colors.blue[300],
+      300: colors.blue[100],
+      400: colors.purple[200],
+      500: colors.purple[400],
+    },
+  },
+  typography: {
+    h1: {
+      color: "#fff",
+    },
+    h2: {
+      color: "#fff",
+    },
+    h3: {
+      color: "#fff",
+    },
+    dataEmphasizedSmall: {
+      color: "#fff",
+    },
+    dataEmphasizedLarge: {
+      color: "#fff",
+    },
+    dataTabular: {
+      color: "#fff",
+    },
+    labelLarge: {
+      color: "#fff",
+    },
+    labelSmall: {
+      color: "#fff",
+    },
+    paragraphSmall: {
+      color: "#fff",
+    },
+  },
+  components: {
+    MuiTextField: {
+      styleOverrides: {
+        root: ({ theme }: { theme: Theme }) => ({
+          [`&.${formControlClasses.root}`]: {
+            backgroundColor: colors.blueGrey[700],
+            color: theme.palette.text.primary,
+          },
+        }),
+      },
+    },
+
+    MuiTable: {
+      styleOverrides: {
+        root: ({ theme }: { theme: Theme }) => ({
+          color: theme.palette.text.primary,
+          backgroundColor: theme.palette.background.default,
+          [`& .${tableRowClasses.root}:nth-of-type(odd)`]: {
+            color: theme.palette.text.primary,
+            backgroundColor: colors.blueGrey[700],
+          },
+          [`& .${tableRowClasses.root}:nth-of-type(even)`]: {
+            color: theme.palette.text.primary,
+            backgroundColor: colors.blueGrey[800],
+          },
+          [`& .${tableRowClasses.root}:hover`]: {
+            [`.${linkClasses.root} .${typographyClasses.root}`]: {
+              color: theme.palette.primary.light,
+            },
+          },
+          [`& .${tableCellClasses.root}.${tableCellClasses.head}`]: {
+            verticalAlign: "bottom",
+            color: theme.palette.text.primary,
+            backgroundColor: colors.blueGrey[800],
+          },
+          [`& .${tableCellClasses.root}.${tableCellClasses.head} ${svgIconClasses.root}`]:
+            {
+              color: theme.palette.text.primary,
+            },
+        }),
+      },
+    },
+  },
+};
+
+const darkTheme = responsiveFontSizes(
+  createTheme(deepmerge(defaultThemeConfig, darkThemeConfig))
+);
+
+export { darkThemeConfig };
+export default darkTheme;

--- a/packages/ui-components/src/styles/theme/index.ts
+++ b/packages/ui-components/src/styles/theme/index.ts
@@ -1,1 +1,2 @@
 export { default, themeConfig } from "./theme";
+export { default as darkTheme, darkThemeConfig } from "./dark-theme";


### PR DESCRIPTION
* Adds an initial dark theme (tracked by #452) but it will need much work.
* Adds a theme selector (#450) to storybook:

![image](https://user-images.githubusercontent.com/206364/205112211-efd011ca-1d0d-4df2-9175-9b616f673e26.png)

 