### PR TITLE
Storybook cleanup

### DIFF
--- a/.changeset/angry-moles-smash.md
+++ b/.changeset/angry-moles-smash.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Reorganize storybook

--- a/packages/ui-components/.storybook/preview.tsx
+++ b/packages/ui-components/.storybook/preview.tsx
@@ -65,7 +65,7 @@ export const parameters = {
   options: {
     storySort: {
       method: "alphabetical",
-      order: ["Design System", "Components", "Charts"],
+      order: ["Design System", "Components"],
     },
   },
 };

--- a/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
+++ b/packages/ui-components/src/components/AutoWidth/AutoWidth.stories.tsx
@@ -92,7 +92,7 @@ const region = states.findByRegionIdStrict("12");
 /**
  * Using a real chart this time, we create a Grid with 4 columns.
  */
-export const Sparklines = () => (
+export const WithSparklines = () => (
   <Grid container spacing={2}>
     {[1, 2, 3, 4].map((n) => (
       <StyledGridItem item xs={3} key={`grid-item-${n}`}>

--- a/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
+++ b/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
@@ -9,7 +9,7 @@ import { formatPercent } from "@actnowcoalition/number-format";
 import { AxesTimeseries } from "./AxesTimeseries";
 
 export default {
-  title: "Charts/AxesTimeseries",
+  title: "Components/AxesTimeseries",
 } as ComponentMeta<typeof AxesTimeseries>;
 
 const width = 600;

--- a/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
+++ b/packages/ui-components/src/components/AxesTimeseries/AxesTimeseries.stories.tsx
@@ -41,8 +41,8 @@ const Template: ComponentStory<typeof AxesTimeseries> = (args) => (
   </svg>
 );
 
-export const DefaultSettings = Template.bind({});
-DefaultSettings.args = {
+export const Default = Template.bind({});
+Default.args = {
   height: chartHeight,
   xScale,
   yScale,
@@ -58,8 +58,8 @@ CustomNumYTicks.args = {
   },
 };
 
-export const CustomTickFormat = Template.bind({});
-CustomTickFormat.args = {
+export const CustomYTickFormat = Template.bind({});
+CustomYTickFormat.args = {
   height: chartHeight,
   xScale,
   yScale: yScalePercent,

--- a/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
@@ -60,41 +60,41 @@ const Template: ComponentStory<typeof AxisBottom> = (args) => (
   </Box>
 );
 
-export const Units = Template.bind({});
-Units.args = {
+export const Numbers = Template.bind({});
+Numbers.args = {
   scale: scaleLinear({ domain: [0, 10] }),
 };
 
-export const TwoYears = Template.bind({});
-TwoYears.args = {
+export const Time2Years = Template.bind({});
+Time2Years.args = {
   scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2022-12-31")],
   }),
 };
 
-export const OneYear = Template.bind({});
-OneYear.args = {
+export const Time1Year = Template.bind({});
+Time1Year.args = {
   scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2021-12-31")],
   }),
 };
 
-export const SixMonths = Template.bind({});
-SixMonths.args = {
+export const Time6Months = Template.bind({});
+Time6Months.args = {
   scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2021-06-30")],
   }),
 };
 
-export const OneMonth = Template.bind({});
-OneMonth.args = {
+export const Time1Month = Template.bind({});
+Time1Month.args = {
   scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2021-01-31")],
   }),
 };
 
-export const TenDays = Template.bind({});
-TenDays.args = {
+export const Time10Days = Template.bind({});
+Time10Days.args = {
   scale: scaleUtc({
     domain: [new Date("2021-01-01"), new Date("2021-01-10")],
   }),

--- a/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisBottom.stories.tsx
@@ -9,7 +9,7 @@ import { AutoWidth } from "../AutoWidth";
 import { formatDateTick, getNumTicks, isOverTwoMonths } from "./utils";
 
 export default {
-  title: "Charts/Axis Bottom",
+  title: "Components/AxisBottom",
 } as ComponentMeta<typeof AxisBottom>;
 
 const height = 400;

--- a/packages/ui-components/src/components/Axis/AxisLeft.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisLeft.stories.tsx
@@ -24,24 +24,20 @@ const DefaultTemplateLeftAxis: ComponentStory<typeof AxisLeft> = (args) => (
   </svg>
 );
 
-export const DefaultLeftAxis = DefaultTemplateLeftAxis.bind({});
-DefaultLeftAxis.args = {
+export const Default = DefaultTemplateLeftAxis.bind({});
+Default.args = {
   scale,
 };
 
 const TemplateLeftAxis: ComponentStory<typeof AxisLeft> = (args) => (
   <svg width={width} height={height}>
-    <AxisLeft
-      {...args}
-      left={padding}
-      top={padding}
-      // Approximate (More info: https://airbnb.io/visx/docs/axis#Axis_numTicks)
-      numTicks={10}
-    />
+    <AxisLeft {...args} left={padding} top={padding} />
   </svg>
 );
 
-export const LeftAxis = TemplateLeftAxis.bind({});
-LeftAxis.args = {
+export const CustomNumTicks = TemplateLeftAxis.bind({});
+CustomNumTicks.args = {
   scale,
+  // Approximate (More info: https://airbnb.io/visx/docs/axis#Axis_numTicks)
+  numTicks: 10,
 };

--- a/packages/ui-components/src/components/Axis/AxisLeft.stories.tsx
+++ b/packages/ui-components/src/components/Axis/AxisLeft.stories.tsx
@@ -6,7 +6,7 @@ import { scaleLinear } from "@visx/scale";
 import { AxisLeft } from ".";
 
 export default {
-  title: "Charts/Axis Left",
+  title: "Components/AxisLeft",
 } as ComponentMeta<typeof AxisLeft>;
 
 const width = 600;

--- a/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
+++ b/packages/ui-components/src/components/BarChart/BarChart.stories.tsx
@@ -11,7 +11,7 @@ import { appleStockTimeseries } from "../../stories/mockData";
 import { LineChart } from "../LineChart";
 
 export default {
-  title: "Charts/BarChart",
+  title: "Components/BarChart",
   component: BarChart,
 } as ComponentMeta<typeof BarChart>;
 

--- a/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.stories.tsx
@@ -10,7 +10,7 @@ import { ChartOverlayX } from ".";
 import { AxisBottom } from "../Axis";
 
 export default {
-  title: "Charts/ChartOverlayX",
+  title: "Components/ChartOverlayX",
   component: ChartOverlayX,
 } as ComponentMeta<typeof ChartOverlayX>;
 

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.stories.tsx
@@ -11,7 +11,7 @@ import { AxisBottom, AxisLeft } from "../Axis";
 import { LineChart } from "../LineChart";
 
 export default {
-  title: "Charts/ChartOverlayXY",
+  title: "Components/ChartOverlayXY",
   component: ChartOverlayXY,
 } as ComponentMeta<typeof ChartOverlayXY>;
 

--- a/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.stories.tsx
@@ -7,7 +7,7 @@ import { ColumnHeader } from ".";
 import { SortDirection, Table, TableHead, TableRow } from "..";
 
 export default {
-  title: "Table/ColumnHeader",
+  title: "Components/ColumnHeader",
   component: ColumnHeader,
 } as ComponentMeta<typeof ColumnHeader>;
 

--- a/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.stories.tsx
@@ -26,8 +26,8 @@ const Template: ComponentStory<typeof ColumnHeader> = (args) => (
 const onClickSort = (direction: SortDirection) =>
   console.log(`Sort direction: ${direction}`);
 
-export const NotSortable = Template.bind({});
-NotSortable.args = {
+export const DefaultNotSortable = Template.bind({});
+DefaultNotSortable.args = {
   label: "Location",
 };
 

--- a/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.stories.tsx
@@ -17,7 +17,7 @@ import {
 } from ".";
 
 export default {
-  title: "Table/CompareTable",
+  title: "Components/CompareTable",
   component: CompareTable,
 } as ComponentMeta<typeof CompareTable>;
 

--- a/packages/ui-components/src/components/CompareTable/SortControls/SortControls.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/SortControls/SortControls.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { SortControls, SortDirection } from "..";
 
 export default {
-  title: "Table/SortControls",
+  title: "Components/SortControls",
   component: SortControls,
 } as ComponentMeta<typeof SortControls>;
 

--- a/packages/ui-components/src/components/CompareTable/SortControls/SortControls.stories.tsx
+++ b/packages/ui-components/src/components/CompareTable/SortControls/SortControls.stories.tsx
@@ -13,13 +13,13 @@ const Template: ComponentStory<typeof SortControls> = (args) => (
   <SortControls {...args} />
 );
 
-export const ActiveAsc = Template.bind({});
-ActiveAsc.args = {
+export const ActiveAscending = Template.bind({});
+ActiveAscending.args = {
   sortDirection: SortDirection.ASC,
 };
 
-export const ActiveDesc = Template.bind({});
-ActiveDesc.args = {
+export const ActiveDescending = Template.bind({});
+ActiveDescending.args = {
   sortDirection: SortDirection.DESC,
 };
 

--- a/packages/ui-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/ui-components/src/components/Grid/Grid.stories.tsx
@@ -7,7 +7,7 @@ import { GridColumns, GridRows } from ".";
 import { AxisBottom, AxisLeft } from "../Axis";
 
 export default {
-  title: "Charts/Grid",
+  title: "Components/Grid",
 } as ComponentMeta<typeof GridRows>;
 
 const width = 600;

--- a/packages/ui-components/src/components/InfoTooltip/InfoTooltip.stories.tsx
+++ b/packages/ui-components/src/components/InfoTooltip/InfoTooltip.stories.tsx
@@ -29,13 +29,13 @@ const Template: ComponentStory<typeof InfoTooltip> = (args) => {
   );
 };
 
-export const DefaultProps = Template.bind({});
-DefaultProps.args = {
+export const Default = Template.bind({});
+Default.args = {
   title: <TooltipTitle />,
 };
 
-export const AddedOpenAndCloseFunctionality = Template.bind({});
-AddedOpenAndCloseFunctionality.args = {
+export const WithAddedOnOpenOnClose = Template.bind({});
+WithAddedOnOpenOnClose.args = {
   title: <TooltipTitle />,
   onOpen: () => {
     console.log("onOpen, optional tracking functionality");

--- a/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
+++ b/packages/ui-components/src/components/LabelIcon/LabelIcon.stories.tsx
@@ -17,11 +17,13 @@ const Template: ComponentStory<typeof LabelIcon> = (args) => (
 export const Example = Template.bind({});
 Example.args = { children: "Weekly new cases" };
 
-export const LongName = Template.bind({});
-LongName.args = { children: "Super long metric name to test text wrapping" };
+export const WithLongText = Template.bind({});
+WithLongText.args = {
+  children: "Super long metric name to test text wrapping",
+};
 
-export const Custom = Template.bind({});
-Custom.args = {
+export const WithCustomIcon = Template.bind({});
+WithCustomIcon.args = {
   children: "Learn more",
   color: "primary",
   variant: "labelSmall",

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.stories.tsx
@@ -53,14 +53,6 @@ HorizontalWithoutLabels.args = {
   showLabels: false,
 };
 
-export const HorizontalRounded = Template.bind({});
-HorizontalRounded.args = {
-  ...HorizontalDefault.args,
-  height: horizontalHeight,
-  borderRadius: horizontalHeight / 2,
-  showLabels: false,
-};
-
 export const HorizontalSquared = Template.bind({});
 HorizontalSquared.args = {
   ...HorizontalDefault.args,
@@ -76,22 +68,16 @@ VerticalDefault.args = {
   getItemSublabel,
 };
 
-export const VerticalRounded = Template.bind({});
-VerticalRounded.args = {
-  borderRadius: 8,
+export const VerticalWithoutLabels = Template.bind({});
+VerticalWithoutLabels.args = {
   ...VerticalDefault.args,
-};
-
-export const VerticalNoLabel = Template.bind({});
-VerticalNoLabel.args = {
   showLabels: false,
-  ...VerticalDefault.args,
 };
 
 export const VerticalSmall = Template.bind({});
 VerticalSmall.args = {
+  ...VerticalDefault.args,
   height: 72,
   borderRadius: 8,
   showLabels: false,
-  ...VerticalDefault.args,
 };

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -23,8 +23,8 @@ const Template: ComponentStory<typeof LineChart> = (args) => (
 
 const { xScale, yScale } = createTimeseriesScales(timeseries, width, height);
 
-export const SolidLine = Template.bind({});
-SolidLine.args = {
+export const DefaultSolidLine = Template.bind({});
+DefaultSolidLine.args = {
   timeseries,
   xScale,
   yScale,

--- a/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/ui-components/src/components/LineChart/LineChart.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../stories/mockData";
 
 export default {
-  title: "Charts/LineChart",
+  title: "Components/LineChart",
   component: LineChart,
 } as ComponentMeta<typeof LineChart>;
 

--- a/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.stories.tsx
+++ b/packages/ui-components/src/components/LineIntervalChart/LineIntervalChart.stories.tsx
@@ -10,7 +10,7 @@ import {
 import { theme } from "../../styles";
 
 export default {
-  title: "Charts/LineIntervalChart",
+  title: "Components/LineIntervalChart",
   component: LineIntervalChart,
 } as ComponentMeta<typeof LineIntervalChart>;
 

--- a/packages/ui-components/src/components/Markdown/Markdown.stories.tsx
+++ b/packages/ui-components/src/components/Markdown/Markdown.stories.tsx
@@ -23,8 +23,8 @@ const StyledTemplate: ComponentStory<typeof StyledMarkdown> = (args) => (
   <StyledMarkdown {...args} />
 );
 
-export const StyledExample = StyledTemplate.bind({});
-StyledExample.args = { children: "Styled markdown example!" };
+export const WithColoredText = StyledTemplate.bind({});
+WithColoredText.args = { children: "Styled markdown example with green text!" };
 
 // Headings example
 const headings = `
@@ -39,8 +39,8 @@ I am **bold!**
 I am *italicized!*  
 `;
 
-export const HeadingExample = Template.bind({});
-HeadingExample.args = { children: headings };
+export const WithHeadings = Template.bind({});
+WithHeadings.args = { children: headings };
 
 // Quote example
 const quote = `
@@ -56,8 +56,8 @@ const quote = `
 
 >> ![Cat](https://pbs.twimg.com/profile_images/664169149002874880/z1fmxo00_400x400.jpg)`;
 
-export const QuoteExample = Template.bind({});
-QuoteExample.args = { children: quote };
+export const WithQuoteAndImage = Template.bind({});
+WithQuoteAndImage.args = { children: quote };
 
 // Table example
 const tableContent = `
@@ -67,13 +67,13 @@ const tableContent = `
 | Content 4 | Content 5 | Content 6 |
 `;
 
-export const TableExample = Template.bind({});
-TableExample.args = { children: tableContent };
+export const WithTable = Template.bind({});
+WithTable.args = { children: tableContent };
 
 // Inline markdown example
 const InlineTemplate: ComponentStory<typeof InlineMarkdown> = (args) => (
   <InlineMarkdown {...args} />
 );
 
-export const InlineExample = InlineTemplate.bind({});
-InlineExample.args = { children: "Inline **markdown** example!" };
+export const Inline = InlineTemplate.bind({});
+Inline.args = { children: "Inline **markdown** example!" };

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -68,6 +68,6 @@ Static.args = {
 // This story is not directly wrapped on MetricCatalogProvider, so is
 // using the MetricCatalogProvider setup as a decorator in
 // .storybook/preview.tsx
-export const UsingDecorator = () => (
+export const WithDecorator = () => (
   <MetricAwareDemo metric={MetricId.PI} region={washingtonState} />
 );

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.stories.tsx
@@ -14,7 +14,7 @@ import MetricAwareDemo from "./MetricAwareDemo";
 import { MetricCatalogProvider } from "./MetricCatalogContext";
 
 export default {
-  title: "Metrics/MetricCatalogContext",
+  title: "Components/MetricCatalogContext",
   component: MetricCatalogProvider,
 } as ComponentMeta<typeof MetricCatalogProvider>;
 

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.stories.tsx
@@ -13,7 +13,7 @@ const regionDB = new RegionDB(states.all, {
 });
 
 export default {
-  title: "Metrics/MetricCompareTable",
+  title: "Components/MetricCompareTable",
   component: MetricCompareTable,
 } as ComponentMeta<typeof MetricCompareTable>;
 

--- a/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
+++ b/packages/ui-components/src/components/MetricDot/MetricDot.stories.tsx
@@ -8,7 +8,7 @@ import { MetricDot } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Metrics/MetricDot",
+  title: "Components/MetricDot",
   component: MetricDot,
 } as ComponentMeta<typeof MetricDot>;
 

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
@@ -16,26 +16,26 @@ const Template: ComponentStory<typeof MetricLegendCategorical> = (args) => (
   </div>
 );
 
-export const Horizontal = Template.bind({});
-Horizontal.args = {
+export const HorizontalWithExtendedName = Template.bind({});
+HorizontalWithExtendedName.args = {
   metric: MetricId.PASS_FAIL,
   orientation: "horizontal",
 };
 
-export const Vertical = Template.bind({});
-Vertical.args = {
+export const VerticalWithExtendedName = Template.bind({});
+VerticalWithExtendedName.args = {
   metric: MetricId.PASS_FAIL,
   orientation: "vertical",
 };
 
-export const HorizontalNoExtendedName = Template.bind({});
-HorizontalNoExtendedName.args = {
+export const HorizontalWithoutExtendedName = Template.bind({});
+HorizontalWithoutExtendedName.args = {
   metric: MetricId.PASS_FAIL_NO_EXTENDED_NAME,
   orientation: "horizontal",
 };
 
-export const VerticalNoExtendedName = Template.bind({});
-VerticalNoExtendedName.args = {
+export const VerticalWithoutExtendedName = Template.bind({});
+VerticalWithoutExtendedName.args = {
   metric: MetricId.PASS_FAIL_NO_EXTENDED_NAME,
   orientation: "vertical",
 };

--- a/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendCategorical/MetricLegendCategorical.stories.tsx
@@ -6,7 +6,7 @@ import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLegendCategorical } from "./MetricLegendCategorical";
 
 export default {
-  title: "Metrics/MetricLegendCategorical",
+  title: "Components/MetricLegendCategorical",
   component: MetricLegendCategorical,
 } as ComponentMeta<typeof MetricLegendCategorical>;
 

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -7,7 +7,7 @@ import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricLegendThreshold } from "./MetricLegendThreshold";
 
 export default {
-  title: "Metrics/MetricLegendThreshold",
+  title: "Components/MetricLegendThreshold",
   component: MetricLegendThreshold,
 } as ComponentMeta<typeof MetricLegendThreshold>;
 

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -27,15 +27,15 @@ HorizontalDefault.args = {
   metric: MetricId.MOCK_CASES,
 };
 
-export const HorizontalNoExtendedName = Template.bind({});
-HorizontalNoExtendedName.args = {
+export const HorizontalWithoutExtendedName = Template.bind({});
+HorizontalWithoutExtendedName.args = {
   orientation: "horizontal",
   height: horizontalBarHeight,
   metric: MetricId.MOCK_CASES_NO_EXTENDED_NAME,
 };
 
-export const HorizontalNoLabels = Template.bind({});
-HorizontalNoLabels.args = {
+export const HorizontalWithoutLabels = Template.bind({});
+HorizontalWithoutLabels.args = {
   ...HorizontalDefault.args,
   showLabels: false,
 };
@@ -62,20 +62,14 @@ VerticalDefault.args = {
   metric: MetricId.MOCK_CASES,
 };
 
-export const VerticalNoExtendedName = Template.bind({});
-VerticalNoExtendedName.args = {
+export const VerticalWithoutExtendedName = Template.bind({});
+VerticalWithoutExtendedName.args = {
   orientation: "vertical",
   metric: MetricId.MOCK_CASES_NO_EXTENDED_NAME,
 };
 
-export const VerticalCategories = Template.bind({});
-VerticalCategories.args = {
-  orientation: "vertical",
-  metric: MetricId.PASS_FAIL,
-};
-
-export const VerticalNoLabel = Template.bind({});
-VerticalNoLabel.args = {
+export const VerticalWithoutLabels = Template.bind({});
+VerticalWithoutLabels.args = {
   showLabels: false,
   ...VerticalDefault.args,
 };
@@ -86,6 +80,12 @@ VerticalOnlySideLabels.args = {
   showLabels: false,
   startLabel: <Typography>lower</Typography>,
   endLabel: <Typography>higher</Typography>,
+};
+
+export const VerticalCategories = Template.bind({});
+VerticalCategories.args = {
+  orientation: "vertical",
+  metric: MetricId.PASS_FAIL,
 };
 
 export const VerticalSmall = Template.bind({});

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
@@ -11,7 +11,7 @@ const [width, height] = [600, 400];
 const newYork = states.findByRegionIdStrict("36");
 
 export default {
-  title: "Charts/MetricLineChart",
+  title: "Components/MetricLineChart",
   component: MetricLineChart,
 } as ComponentMeta<typeof MetricLineChart>;
 

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.stories.tsx
@@ -19,8 +19,8 @@ const Template: ComponentStory<typeof MetricLineChart> = (args) => (
   <MetricLineChart {...args} />
 );
 
-export const AppleStock = Template.bind({});
-AppleStock.args = {
+export const Example = Template.bind({});
+Example.args = {
   width,
   height,
   metric: MetricId.APPLE_STOCK,
@@ -29,12 +29,12 @@ AppleStock.args = {
 
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
-  ...AppleStock.args,
+  ...Example.args,
   metric: MetricId.MOCK_CASES_DELAY_1S,
 };
 
 export const LoadingError = Template.bind({});
 LoadingError.args = {
-  ...AppleStock.args,
+  ...Example.args,
   metric: MetricId.MOCK_CASES_ERROR,
 };

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
@@ -19,34 +19,28 @@ const Template: ComponentStory<typeof MetricLineThresholdChart> = (args) => (
   <MetricLineThresholdChart {...args} />
 );
 
-export const AppleStock = Template.bind({});
-AppleStock.args = {
+export const WithMinYZero = Template.bind({});
+WithMinYZero.args = {
   width,
   height,
   metric: MetricId.APPLE_STOCK,
   region: newYork,
 };
 
-export const NewYorkCityTemperature = Template.bind({});
-NewYorkCityTemperature.args = {
-  ...AppleStock.args,
+export const WithNegativeYValues = Template.bind({});
+WithNegativeYValues.args = {
+  ...WithMinYZero.args,
   metric: MetricId.NYC_TEMPERATURE,
-};
-
-export const YAxisStartsAtZero = Template.bind({});
-YAxisStartsAtZero.args = {
-  ...AppleStock.args,
-  metric: MetricId.APPLE_STOCK_LOW_THRESHOLDS,
 };
 
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
-  ...AppleStock.args,
+  ...WithMinYZero.args,
   metric: MetricId.MOCK_CASES_DELAY_1S,
 };
 
 export const LoadingError = Template.bind({});
 LoadingError.args = {
-  ...AppleStock.args,
+  ...WithMinYZero.args,
   metric: MetricId.MOCK_CASES_ERROR,
 };

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.stories.tsx
@@ -11,7 +11,7 @@ const [width, height] = [600, 400];
 const newYork = states.findByRegionIdStrict("36");
 
 export default {
-  title: "Charts/MetricLineThresholdChart",
+  title: "Components/MetricLineThresholdChart",
   component: MetricLineThresholdChart,
 } as ComponentMeta<typeof MetricLineThresholdChart>;
 

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
@@ -8,7 +8,7 @@ import { MetricMultiProgressBar } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Metrics/MetricMultiProgressBar",
+  title: "Components/MetricMultiProgressBar",
   component: MetricMultiProgressBar,
 } as ComponentMeta<typeof MetricMultiProgressBar>;
 

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.stories.tsx
@@ -21,8 +21,8 @@ const newYorkRegion = states.findByRegionIdStrict("36");
 export const Example = Template.bind({});
 Example.args = {
   region: newYorkRegion,
-  metrics: [MetricId.MOCK_CASES, MetricId.PASS_FAIL],
-  maxValue: 500,
+  metrics: [MetricId.MOCK_CASES, MetricId.APPLE_STOCK_LOW_THRESHOLDS],
+  maxValue: 900,
 };
 
 export const LoadingDelay = Template.bind({});

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
@@ -9,7 +9,7 @@ import { MetricOverview } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Metrics/MetricOverview",
+  title: "Components/MetricOverview",
   component: MetricOverview,
 } as ComponentMeta<typeof MetricOverview>;
 

--- a/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricOverview/MetricOverview.stories.tsx
@@ -41,14 +41,14 @@ const ChartPlaceholder = () => (
 
 const newYorkState = states.findByRegionIdStrict("36");
 
-export const DefaultProps = Template.bind({});
-DefaultProps.args = {
+export const Vertical = Template.bind({});
+Vertical.args = {
   region: newYorkState,
   metric: MetricId.MOCK_CASES,
 };
 
-export const NoExtendedName = Template.bind({});
-NoExtendedName.args = {
+export const VerticalWithoutExtendedName = Template.bind({});
+VerticalWithoutExtendedName.args = {
   region: newYorkState,
   metric: MetricId.MOCK_CASES_NO_EXTENDED_NAME,
 };
@@ -60,15 +60,15 @@ VerticalWithChart.args = {
   metricChart: <ChartPlaceholder />,
 };
 
-export const DefaultHorizontal = Template.bind({});
-DefaultHorizontal.args = {
+export const Horizontal = Template.bind({});
+Horizontal.args = {
   region: newYorkState,
   metric: MetricId.MOCK_CASES,
   orientation: "horizontal",
 };
 
-export const HorizontalNoExtendedName = Template.bind({});
-HorizontalNoExtendedName.args = {
+export const HorizontalWithoutExtendedName = Template.bind({});
+HorizontalWithoutExtendedName.args = {
   region: newYorkState,
   metric: MetricId.MOCK_CASES_NO_EXTENDED_NAME,
   orientation: "horizontal",

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
@@ -8,7 +8,7 @@ import { MetricScoreOverview } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Metrics/MetricScoreOverview",
+  title: "Components/MetricScoreOverview",
   component: MetricScoreOverview,
 } as ComponentMeta<typeof MetricScoreOverview>;
 

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.stories.tsx
@@ -23,13 +23,13 @@ const defaultArgs = {
     "This is a tooltip. It is very useful. It is very helpful. It is very informative.",
 };
 
-export const Default = Template.bind({});
-Default.args = {
+export const Example = Template.bind({});
+Example.args = {
   ...defaultArgs,
 };
 
-export const NoTooltip = Template.bind({});
-NoTooltip.args = {
+export const WithoutTooltip = Template.bind({});
+WithoutTooltip.args = {
   ...defaultArgs,
   tooltipTitle: undefined,
 };

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -46,8 +46,8 @@ Vaccination.args = {
   ],
 };
 
-export const NegativeMinValue = Template.bind({});
-NegativeMinValue.args = {
+export const WithNegativeYValues = Template.bind({});
+WithNegativeYValues.args = {
   width,
   height,
   minValue: -10,

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -11,7 +11,7 @@ import { theme } from "../../styles";
 import { SeriesType } from "../SeriesChart";
 
 export default {
-  title: "Charts/MetricSeriesChart",
+  title: "Components/MetricSeriesChart",
   component: MetricSeriesChart,
 } as ComponentMeta<typeof MetricSeriesChart>;
 

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.stories.tsx
@@ -8,7 +8,7 @@ import { MetricSparklines } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Metrics/MetricSparklines",
+  title: "Components/MetricSparklines",
   component: MetricSparklines,
 } as ComponentMeta<typeof MetricSparklines>;
 

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -40,8 +40,8 @@ const Template: ComponentStory<typeof MetricTooltip> = (args) => (
   </svg>
 );
 
-export const TooltipExample = Template.bind({});
-TooltipExample.args = {
+export const Example = Template.bind({});
+Example.args = {
   region,
   metric,
   point,

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltip.stories.tsx
@@ -10,7 +10,7 @@ import { MetricTooltip } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Charts/MetricTooltip",
+  title: "Components/MetricTooltip",
   component: MetricTooltip,
 } as ComponentMeta<typeof MetricTooltip>;
 

--- a/packages/ui-components/src/components/MetricTooltip/MetricTooltipContent.stories.tsx
+++ b/packages/ui-components/src/components/MetricTooltip/MetricTooltipContent.stories.tsx
@@ -9,7 +9,7 @@ import { MetricTooltipContent } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Charts/MetricTooltipContent",
+  title: "Components/MetricTooltipContent",
   component: MetricTooltipContent,
 } as ComponentMeta<typeof MetricTooltipContent>;
 

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
@@ -8,7 +8,7 @@ import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricUSNationalMap } from "./MetricUSNationalMap";
 
 export default {
-  title: "Components/US National Map",
+  title: "Components/MetricUSNationalMap",
   component: MetricUSNationalMap,
 } as ComponentMeta<typeof MetricUSNationalMap>;
 
@@ -24,17 +24,15 @@ const renderTooltip = (regionId: string) => {
   return regionDB.findByRegionIdStrict(regionId).fullName;
 };
 
-/** States colored by mock metric data */
-export const MetricAwareStates = Template.bind({});
-MetricAwareStates.args = {
+export const States = Template.bind({});
+States.args = {
   renderTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
 };
 
-/** Counties colored by mock metric data */
-export const MetricAwareCounties = Template.bind({});
-MetricAwareCounties.args = {
+export const Counties = Template.bind({});
+Counties.args = {
   renderTooltip,
   metric: MetricId.MOCK_CASES,
   showCounties: true,
@@ -43,12 +41,12 @@ MetricAwareCounties.args = {
 
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
-  ...MetricAwareStates.args,
+  ...States.args,
   metric: MetricId.MOCK_CASES_DELAY_1S,
 };
 
 export const LoadingError = Template.bind({});
 LoadingError.args = {
-  ...MetricAwareStates.args,
+  ...States.args,
   metric: MetricId.MOCK_CASES_ERROR,
 };

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
@@ -8,7 +8,7 @@ import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricUSNationalMap } from "./MetricUSNationalMap";
 
 export default {
-  title: "Maps/US National Map",
+  title: "Components/US National Map",
   component: MetricUSNationalMap,
 } as ComponentMeta<typeof MetricUSNationalMap>;
 

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
@@ -13,7 +13,7 @@ const regionDB = new RegionDB([...states.all, ...counties.all], {
 const herkimerCountyNewYorkRegion = counties.findByRegionIdStrict("36043");
 
 export default {
-  title: "Components/US State Map",
+  title: "Components/MetricUSStateMap",
   component: MetricUSStateMap,
 } as ComponentMeta<typeof MetricUSStateMap>;
 
@@ -25,25 +25,24 @@ const renderTooltip = (regionId: string) => {
   return regionDB.findByRegionIdStrict(regionId).fullName;
 };
 
-/** New York colored by mock metric data */
-export const MetricAwareNewYork = Template.bind({});
-MetricAwareNewYork.args = {
+export const NewYork = Template.bind({});
+NewYork.args = {
   stateRegionId: "36",
   renderTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
 };
 
-export const MetricAwareAlaska = Template.bind({});
-MetricAwareAlaska.args = {
+export const Alaska = Template.bind({});
+Alaska.args = {
   stateRegionId: "02",
   renderTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
 };
 
-export const MetricAwareNewYorkWithHighlightedCounty = Template.bind({});
-MetricAwareNewYorkWithHighlightedCounty.args = {
+export const NewYorkWithHighlightedCounty = Template.bind({});
+NewYorkWithHighlightedCounty.args = {
   stateRegionId: "36",
   highlightedRegion: herkimerCountyNewYorkRegion,
   renderTooltip,
@@ -53,12 +52,12 @@ MetricAwareNewYorkWithHighlightedCounty.args = {
 
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
-  ...MetricAwareNewYork.args,
+  ...NewYork.args,
   metric: MetricId.MOCK_CASES_DELAY_1S,
 };
 
 export const LoadingError = Template.bind({});
 LoadingError.args = {
-  ...MetricAwareNewYork.args,
+  ...NewYork.args,
   metric: MetricId.MOCK_CASES_ERROR,
 };

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
@@ -13,7 +13,7 @@ const regionDB = new RegionDB([...states.all, ...counties.all], {
 const herkimerCountyNewYorkRegion = counties.findByRegionIdStrict("36043");
 
 export default {
-  title: "Maps/US State Map",
+  title: "Components/US State Map",
   component: MetricUSStateMap,
 } as ComponentMeta<typeof MetricUSStateMap>;
 

--- a/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
@@ -18,23 +18,23 @@ const Template: ComponentStory<typeof MetricValue> = (args) => (
 
 const washingtonState = states.findByRegionIdStrict("53");
 
-export const Default = Template.bind({});
-Default.args = {
+export const Example = Template.bind({});
+Example.args = {
   region: washingtonState,
   metric: MetricId.MOCK_CASES,
 };
 
 export const DataTabularVariant = Template.bind({});
-DataTabularVariant.args = { ...Default.args, variant: "dataTabular" };
+DataTabularVariant.args = { ...Example.args, variant: "dataTabular" };
 
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
-  ...Default.args,
+  ...Example.args,
   metric: MetricId.MOCK_CASES_DELAY_1S,
 };
 
 export const LoadingError = Template.bind({});
 LoadingError.args = {
-  ...Default.args,
+  ...Example.args,
   metric: MetricId.MOCK_CASES_ERROR,
 };

--- a/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.stories.tsx
@@ -8,7 +8,7 @@ import { MetricValue } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Metrics/MetricValue",
+  title: "Components/MetricValue",
   component: MetricValue,
 } as ComponentMeta<typeof MetricValue>;
 

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -41,9 +41,11 @@ export const MetricValue = ({
     ? "\u00A0"
     : metric.formatValue(data.currentValue, "---");
 
+  const showMetricDot = data && data.currentValue !== null;
+
   return (
     <Stack direction="row" spacing={1} alignItems="center" width="fit-content">
-      <MetricDot region={region} metric={metric} />
+      {showMetricDot && <MetricDot region={region} metric={metric} />}
       <Typography variant={variant}>{formattedValue}</Typography>
     </Stack>
   );

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
@@ -8,7 +8,7 @@ import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricWorldMap } from "./MetricWorldMap";
 
 export default {
-  title: "Maps/World Map",
+  title: "Components/World Map",
   component: MetricWorldMap,
 } as ComponentMeta<typeof MetricWorldMap>;
 

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
@@ -8,7 +8,7 @@ import { MetricId } from "../../stories/mockMetricCatalog";
 import { MetricWorldMap } from "./MetricWorldMap";
 
 export default {
-  title: "Components/World Map",
+  title: "Components/MetricWorldMap",
   component: MetricWorldMap,
 } as ComponentMeta<typeof MetricWorldMap>;
 
@@ -25,8 +25,8 @@ const renderTooltip = (regionId: string) => {
 };
 
 /** Nations colored by mock metric data */
-export const MetricAwareWorld = Template.bind({});
-MetricAwareWorld.args = {
+export const World = Template.bind({});
+World.args = {
   renderTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
@@ -34,12 +34,12 @@ MetricAwareWorld.args = {
 
 export const LoadingDelay = Template.bind({});
 LoadingDelay.args = {
-  ...MetricAwareWorld.args,
+  ...World.args,
   metric: MetricId.MOCK_CASES_DELAY_1S,
 };
 
 export const LoadingError = Template.bind({});
 LoadingError.args = {
-  ...MetricAwareWorld.args,
+  ...World.args,
   metric: MetricId.MOCK_CASES_ERROR,
 };

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.stories.tsx
@@ -8,7 +8,7 @@ import { MultiMetricUSStateMap } from ".";
 import { MetricId } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Maps/MultiMetric US State Map",
+  title: "Components/MultiMetricUSStateMap",
   component: MultiMetricUSStateMap,
 } as ComponentMeta<typeof MultiMetricUSStateMap>;
 

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentMeta, Story } from "@storybook/react";
 import { MultiProgressBar, MultiProgressBarProps } from "./MultiProgressBar";
 
 export default {
-  title: "Charts/MultiProgressBar",
+  title: "Components/MultiProgressBar",
   component: MultiProgressBar,
 } as ComponentMeta<typeof MultiProgressBar>;
 

--- a/packages/ui-components/src/components/PointMarker/PointMarker.stories.tsx
+++ b/packages/ui-components/src/components/PointMarker/PointMarker.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { PointMarker } from ".";
 
 export default {
-  title: "Charts/PointMarker",
+  title: "Components/PointMarker",
   component: PointMarker,
 } as ComponentMeta<typeof PointMarker>;
 

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { ProgressBar } from ".";
 
 export default {
-  title: "Charts/ProgressBar",
+  title: "Components/ProgressBar",
   component: ProgressBar,
 } as ComponentMeta<typeof ProgressBar>;
 

--- a/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/ui-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -16,8 +16,8 @@ const Template: ComponentStory<typeof ProgressBar> = (args) => (
   </>
 );
 
-export const DefaultProps = Template.bind({});
-DefaultProps.args = {
+export const Example = Template.bind({});
+Example.args = {
   maxValue: 100,
   value: 39,
   color: "#5936B6",

--- a/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
+++ b/packages/ui-components/src/components/RectClipGroup/RectClipGroup.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentMeta } from "@storybook/react";
 import { RectClipGroup } from ".";
 
 export default {
-  title: "Charts/RectClipGroup",
+  title: "Components/RectClipGroup",
   component: RectClipGroup,
 } as ComponentMeta<typeof RectClipGroup>;
 

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.stories.tsx
@@ -28,15 +28,29 @@ const Template: ComponentStory<typeof RegionSearch> = (args) => (
   <RegionSearch {...args} />
 );
 
-export const StatesOnly = Template.bind({});
-StatesOnly.args = {
+export const States = Template.bind({});
+States.args = {
   regionDB,
   options: states.all,
   inputLabel: "States",
 };
 
-export const CustomRenderInput = Template.bind({});
-CustomRenderInput.args = {
+export const Counties = Template.bind({});
+Counties.args = {
+  regionDB,
+  options: sortBy(counties.all, (county) => county.population * -1),
+  inputLabel: "Counties",
+};
+
+const allUSRegions = [...states.all, ...counties.all, ...metros.all];
+export const AllUSRegions = Template.bind({});
+AllUSRegions.args = {
+  regionDB,
+  options: allUSRegions,
+};
+
+export const WithCustomRenderInput = Template.bind({});
+WithCustomRenderInput.args = {
   regionDB,
   options: states.all,
   inputLabel: "States",
@@ -55,18 +69,4 @@ CustomRenderInput.args = {
       }}
     />
   ),
-};
-
-export const CountiesOnly = Template.bind({});
-CountiesOnly.args = {
-  regionDB,
-  options: sortBy(counties.all, (county) => county.population * -1),
-  inputLabel: "Counties",
-};
-
-const allRegions = [...states.all, ...counties.all, ...metros.all];
-export const AllRegions = Template.bind({});
-AllRegions.args = {
-  regionDB,
-  options: allRegions,
 };

--- a/packages/ui-components/src/components/ShareButton/ShareButton.stories.tsx
+++ b/packages/ui-components/src/components/ShareButton/ShareButton.stories.tsx
@@ -28,26 +28,20 @@ const args: ShareButtonProps = {
 export const Default = Template.bind({});
 Default.args = args;
 
-export const SmallMainShareButton = Template.bind({});
-SmallMainShareButton.args = {
+export const WithSmallAnchorButton = Template.bind({});
+WithSmallAnchorButton.args = {
   ...args,
   size: "small",
 };
 
-export const LargeMainShareButton = Template.bind({});
-LargeMainShareButton.args = {
-  ...args,
-  size: "large",
-};
-
-export const CenterMenuOrigin = Template.bind({});
-CenterMenuOrigin.args = {
+export const WithCenterMenuOrigin = Template.bind({});
+WithCenterMenuOrigin.args = {
   ...args,
   menuOrigin: "center",
 };
 
-export const RightMenuOrigin = Template.bind({});
-RightMenuOrigin.args = {
+export const WithRightMenuOrigin = Template.bind({});
+WithRightMenuOrigin.args = {
   ...args,
   menuOrigin: "right",
 };

--- a/packages/ui-components/src/components/SparkLine/SparkLine.stories.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.stories.tsx
@@ -8,7 +8,7 @@ import { SparkLine } from ".";
 import { appleStockTimeseries } from "../../stories/mockData";
 
 export default {
-  title: "Charts/SparkLine",
+  title: "Components/SparkLine",
   component: SparkLine,
 } as ComponentMeta<typeof SparkLine>;
 

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
@@ -20,8 +20,8 @@ const Template: ComponentStory<typeof TimeseriesLineChart> = (args) => (
   <TimeseriesLineChart {...args} />
 );
 
-export const AppleStockExample = Template.bind({});
-AppleStockExample.args = {
+export const Example = Template.bind({});
+Example.args = {
   width,
   height,
   timeseries: appleStockTimeseries,

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.stories.tsx
@@ -12,7 +12,7 @@ const [width, height] = [600, 400];
 assert(appleStockTimeseries.hasData(), `Timeseries cannot be empty`);
 
 export default {
-  title: "Charts/TimeseriesLineChart",
+  title: "Components/TimeseriesLineChart",
   component: TimeseriesLineChart,
 } as ComponentMeta<typeof TimeseriesLineChart>;
 

--- a/packages/ui-components/src/components/USNationalMap/USNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/USNationalMap/USNationalMap.stories.tsx
@@ -10,7 +10,7 @@ import { Region, RegionDB, counties, states } from "@actnowcoalition/regions";
 import { USNationalMap } from "./USNationalMap";
 
 export default {
-  title: "Maps/US National Map",
+  title: "Components/USNationalMap",
   component: USNationalMap,
 } as ComponentMeta<typeof USNationalMap>;
 

--- a/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
@@ -14,7 +14,7 @@ const regionDB = new RegionDB([...states.all, ...counties.all], {
 const herkimerCountyNewYorkRegion = counties.findByRegionIdStrict("36043");
 
 export default {
-  title: "Maps/US State Map",
+  title: "Components/USStateMap",
   component: USStateMap,
 } as ComponentMeta<typeof USStateMap>;
 

--- a/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.stories.tsx
@@ -33,20 +33,27 @@ const getRegionUrl = (regionId: string): string => {
   return url;
 };
 
-export const NewYorkWithoutBorderingStates = Template.bind({});
-NewYorkWithoutBorderingStates.args = {
+export const NewYork = Template.bind({});
+NewYork.args = {
+  stateRegionId: "36",
+  renderTooltip,
+  getRegionUrl,
+};
+
+export const NewYorkWithoutCounties = Template.bind({});
+NewYorkWithoutCounties.args = {
+  stateRegionId: "36",
+  renderTooltip,
+  getRegionUrl,
+  showCounties: false,
+};
+
+export const NewYorkWithoutBorderingStatesAndCounties = Template.bind({});
+NewYorkWithoutBorderingStatesAndCounties.args = {
   stateRegionId: "36",
   renderTooltip,
   getRegionUrl,
   showBorderingStates: false,
-  showCounties: false,
-};
-
-export const NewYorkWithBorderingStates = Template.bind({});
-NewYorkWithBorderingStates.args = {
-  stateRegionId: "36",
-  renderTooltip,
-  getRegionUrl,
   showCounties: false,
 };
 
@@ -58,15 +65,8 @@ NewYorkCountiesWithoutBorderingStates.args = {
   showBorderingStates: false,
 };
 
-export const NewYorkCountiesWithBorderingStates = Template.bind({});
-NewYorkCountiesWithBorderingStates.args = {
-  stateRegionId: "36",
-  renderTooltip,
-  getRegionUrl,
-};
-
-export const NewYorkCountiesWithHighlightedCounty = Template.bind({});
-NewYorkCountiesWithHighlightedCounty.args = {
+export const NewYorkWithHighlightedCounty = Template.bind({});
+NewYorkWithHighlightedCounty.args = {
   stateRegionId: "36",
   highlightedRegion: herkimerCountyNewYorkRegion,
   renderTooltip,

--- a/packages/ui-components/src/components/WorldMap/WorldMap.stories.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import WorldMap from "./WorldMap";
 
 export default {
-  title: "Maps/World Map",
+  title: "Components/WorldMap",
   component: WorldMap,
 } as ComponentMeta<typeof WorldMap>;
 

--- a/packages/ui-components/src/components/WorldMap/WorldMap.stories.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.stories.tsx
@@ -18,8 +18,8 @@ const getFillColor = (geoId: string) =>
 
 const renderTooltip = (geoId: string) => geoId;
 
-export const Example = Template.bind({});
-Example.args = {
+export const World = Template.bind({});
+World.args = {
   getFillColor,
   renderTooltip,
 };

--- a/packages/ui-components/src/stories/Palette.stories.tsx
+++ b/packages/ui-components/src/stories/Palette.stories.tsx
@@ -6,7 +6,7 @@ import isObject from "lodash/isObject";
 import theme from "../styles/theme";
 
 export default {
-  title: "Design System/Colors",
+  title: "Design System/Palette",
 };
 
 // Filter out the palette attributes that don't correspond to colors,


### PR DESCRIPTION
Cleans up our `ui-components` storybook 🧹

[Before](https://act-now-packages.web.app/storybook/) -> [After](https://act-now-packages--pr469-casulin-storybook-cl-wrzve4et.web.app/storybook/index.html)

Changes:
- Flattens our storybook file structure into 2 folders, **Design System** and **Components**. This felt more straightforward + navigate-able than what we previously had
- Gets rid of redundant stories
- Streamlines naming of our stories
- For metric-aware components that previously had the metric as the name of the story, ie. `AppleStock`-- i changed these story names to be more descriptive, ie. `WithMinYZero`. You're still able to see which metric is being used by looking at the Controls tab in storybook and seeing the prop settings:
<img width="651" alt="Screen Shot 2022-12-01 at 3 15 02 PM" src="https://user-images.githubusercontent.com/44076375/205150907-eed42b32-b052-4221-8af0-5ccebeedf922.png">