### PR TITLE
Fix #418,#419,#420: Better error states for charts, maps, and compare table.

### DIFF
--- a/.changeset/olive-bananas-travel.md
+++ b/.changeset/olive-bananas-travel.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix #418,#419,#420: Better error states for charts, maps, and compare table.

--- a/packages/ui-components/src/components/ErrorBox/ErrorBox.stories.tsx
+++ b/packages/ui-components/src/components/ErrorBox/ErrorBox.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { ErrorBox } from ".";
+
+export default {
+  title: "Components/ErrorBox",
+  component: ErrorBox,
+} as ComponentMeta<typeof ErrorBox>;
+
+const Template: ComponentStory<typeof ErrorBox> = (args) => (
+  <ErrorBox {...args} />
+);
+
+export const Example = Template.bind({});
+Example.args = {};
+
+export const CustomSizeAndText = Template.bind({});
+CustomSizeAndText.args = {
+  width: 200,
+  height: 100,
+  children: "Something failed.",
+};

--- a/packages/ui-components/src/components/ErrorBox/ErrorBox.tsx
+++ b/packages/ui-components/src/components/ErrorBox/ErrorBox.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { Box, useTheme } from "@mui/material";
+
+export interface ErrorBoxProps {
+  /** Height of error box. */
+  width?: number;
+  /** Width of error box. */
+  height?: number;
+  /** Text to display in error box. */
+  children?: React.ReactNode;
+}
+
+export const ErrorBox = ({ width, height = 200, children }: ErrorBoxProps) => {
+  const theme = useTheme();
+  return (
+    <Box
+      width={width ?? "100%"}
+      height={height}
+      bgcolor={theme.palette.action.disabledBackground}
+      sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
+    >
+      <Box>{children ?? "An error occurred."}</Box>
+    </Box>
+  );
+};

--- a/packages/ui-components/src/components/ErrorBox/index.ts
+++ b/packages/ui-components/src/components/ErrorBox/index.ts
@@ -1,0 +1,1 @@
+export * from "./ErrorBox";

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -12,6 +12,7 @@ import {
   TableSortState,
   sortTableRows,
 } from "../CompareTable";
+import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { Row, createLocationColumn, createMetricColumn } from "./utils";
 
@@ -58,7 +59,10 @@ export const MetricCompareTable = ({
     /*includeTimeseries=*/ false
   );
 
-  if (!data || error) {
+  if (error) {
+    return <ErrorBox>Table could not be loaded.</ErrorBox>;
+  } else if (!data) {
+    // TODO(#473): Better loading state.
     return null;
   }
 

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -11,6 +11,7 @@ import { useData } from "../../common/hooks";
 import { BaseChartProps } from "../../common/utils/charts";
 import { AxesTimeseries } from "../AxesTimeseries";
 import { ChartOverlayX, useHoveredDate } from "../ChartOverlayX";
+import { ErrorBox } from "../ErrorBox";
 import { LineChart } from "../LineChart";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricTooltip } from "../MetricTooltip";
@@ -34,13 +35,19 @@ export const MetricLineChart = ({
   const metricCatalog = useMetricCatalog();
   const metric = metricCatalog.getMetric(metricOrId);
 
-  const { data } = useData(region, metric, /*includeTimeseries=*/ true);
+  const { data, error } = useData(region, metric, /*includeTimeseries=*/ true);
   const timeseries = data && data?.timeseries.assertFiniteNumbers();
 
   const { hoveredPoint, onMouseMove, onMouseLeave } =
     useHoveredDate(timeseries);
 
-  if (!data || !timeseries?.hasData()) {
+  if (error) {
+    return (
+      <ErrorBox width={width} height={height}>
+        Chart could not be loaded.
+      </ErrorBox>
+    );
+  } else if (!data || !timeseries?.hasData()) {
     return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -14,6 +14,7 @@ import { useData } from "../../common/hooks";
 import { BaseChartProps } from "../../common/utils/charts";
 import { AxesTimeseries } from "../AxesTimeseries";
 import { ChartOverlayX, useHoveredDate } from "../ChartOverlayX";
+import { ErrorBox } from "../ErrorBox";
 import { GridRows } from "../Grid";
 import { LineIntervalChart } from "../LineIntervalChart";
 import { useMetricCatalog } from "../MetricCatalogContext";
@@ -47,13 +48,19 @@ export const MetricLineThresholdChart = ({
   const metricCatalog = useMetricCatalog();
   const metric = metricCatalog.getMetric(metricOrId);
 
-  const { data } = useData(region, metric, /*includeTimeseries=*/ true);
+  const { data, error } = useData(region, metric, /*includeTimeseries=*/ true);
   const timeseries = data && data.timeseries.assertFiniteNumbers();
 
   const { hoveredPoint, onMouseMove, onMouseLeave } =
     useHoveredDate(timeseries);
 
-  if (!timeseries?.hasData?.()) {
+  if (error) {
+    return (
+      <ErrorBox width={width} height={height}>
+        Chart could not be loaded.
+      </ErrorBox>
+    );
+  } else if (!timeseries?.hasData?.()) {
     return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -15,6 +15,7 @@ import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { BaseChartProps } from "../../common/utils/charts";
 import { AxesTimeseries } from "../AxesTimeseries";
 import { ChartOverlayXY, useHoveredPoint } from "../ChartOverlayXY";
+import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricTooltip } from "../MetricTooltip";
 import { PointMarker } from "../PointMarker";
@@ -61,7 +62,7 @@ export const MetricSeriesChart = ({
     `The series should have at least one valid metric`
   );
 
-  const { data } = useDataForRegionsAndMetrics(
+  const { data, error } = useDataForRegionsAndMetrics(
     regions,
     metrics,
     /*includeTimeseries=*/ true
@@ -76,7 +77,13 @@ export const MetricSeriesChart = ({
   const { pointInfo, onMouseMove, onMouseLeave } =
     useHoveredPoint(timeseriesList);
 
-  if (!data || !timeseriesList) {
+  if (error) {
+    return (
+      <ErrorBox width={width} height={height}>
+        Chart could not be loaded.
+      </ErrorBox>
+    );
+  } else if (!data || !timeseriesList) {
     return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -6,6 +6,7 @@ import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 
 import { useDataForMetrics } from "../../common/hooks";
+import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { BaseSparkLineProps, SparkLine } from "../SparkLine";
 
@@ -39,18 +40,19 @@ export const MetricSparklines = ({
     [metricLineChart, metricBarChart],
     /*includeTimeseries=*/ true
   );
+  const width = optionalProps.width ?? 150;
+  const height = optionalProps.height ?? 50;
 
   if (error) {
-    throw error;
+    return (
+      // Because the sparklines are too small for much text, we will just render a blank box.
+      <ErrorBox width={width} height={height}>
+        {""}
+      </ErrorBox>
+    );
   } else if (!data) {
     // Render loading placeholder.
-    return (
-      <Skeleton
-        variant="rectangular"
-        width={optionalProps.width ?? 150}
-        height={optionalProps.height ?? 50}
-      />
-    );
+    return <Skeleton variant="rectangular" width={width} height={height} />;
   } else {
     // Render Sparkline.
     const timeseriesLineChart = data

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
@@ -6,6 +6,7 @@ import { Metric } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
+import { ErrorBox } from "../ErrorBox";
 import { USNationalMap, USNationalMapProps } from "../USNationalMap";
 
 export interface MetricUSNationalMapProps extends USNationalMapProps {
@@ -17,10 +18,22 @@ export const MetricUSNationalMap = ({
   metric,
   regionDB,
   showCounties,
+  width,
   ...otherProps
 }: MetricUSNationalMapProps) => {
   const theme = useTheme();
-  const { data } = useDataForRegionsAndMetrics(regionDB.all, [metric], false);
+  const { data, error } = useDataForRegionsAndMetrics(
+    regionDB.all,
+    [metric],
+    false
+  );
+  if (error) {
+    return (
+      <ErrorBox width={width} height={width && width / 2}>
+        Map could not be loaded.
+      </ErrorBox>
+    );
+  }
 
   return (
     <USNationalMap

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
@@ -7,6 +7,7 @@ import { RegionDB } from "@actnowcoalition/regions";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { getCountiesOfState } from "../../common/utils/maps";
+import { ErrorBox } from "../ErrorBox";
 import { USStateMap, USStateMapProps } from "../USStateMap";
 
 export interface MetricUSStateMapProps extends USStateMapProps {
@@ -18,6 +19,7 @@ export const MetricUSStateMap = ({
   metric,
   stateRegionId,
   regionDB,
+  width,
   ...otherProps
 }: MetricUSStateMapProps) => {
   const theme = useTheme();
@@ -25,7 +27,18 @@ export const MetricUSStateMap = ({
   const countiesOfState = getCountiesOfState(regionDB, stateRegionId);
   const mapRegions = [...countiesOfState, state];
 
-  const { data } = useDataForRegionsAndMetrics(mapRegions, [metric], false);
+  const { data, error } = useDataForRegionsAndMetrics(
+    mapRegions,
+    [metric],
+    false
+  );
+  if (error) {
+    return (
+      <ErrorBox width={width} height={width && width / 2}>
+        Map could not be loaded.
+      </ErrorBox>
+    );
+  }
 
   return (
     <USStateMap

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
@@ -6,6 +6,7 @@ import { Metric } from "@actnowcoalition/metrics";
 import { RegionDB } from "@actnowcoalition/regions";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
+import { ErrorBox } from "../ErrorBox";
 import WorldMap, { WorldMapProps } from "../WorldMap";
 
 export interface MetricWorldMapProps extends WorldMapProps {
@@ -16,10 +17,23 @@ export interface MetricWorldMapProps extends WorldMapProps {
 export const MetricWorldMap = ({
   metric,
   regionDB,
+  width,
   ...otherProps
 }: MetricWorldMapProps) => {
   const theme = useTheme();
-  const { data } = useDataForRegionsAndMetrics(regionDB.all, [metric], false);
+  const { data, error } = useDataForRegionsAndMetrics(
+    regionDB.all,
+    [metric],
+    false
+  );
+
+  if (error) {
+    return (
+      <ErrorBox width={width} height={width && width / 2}>
+        Map could not be loaded.
+      </ErrorBox>
+    );
+  }
 
   return (
     <WorldMap

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -87,6 +87,7 @@ export * from "./components/BarChart";
 export * from "./components/ChartOverlayX";
 export * from "./components/ChartOverlayXY";
 export * from "./components/CompareTable";
+export * from "./components/ErrorBox";
 export * from "./components/Grid";
 export * from "./components/InfoTooltip";
 export * from "./components/LabelIcon";
@@ -124,5 +125,3 @@ export * from "./components/SparkLine";
 export * from "./components/USNationalMap";
 export * from "./components/USStateMap";
 export * from "./components/WorldMap";
-
-export * from "./components/ErrorBox";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -124,3 +124,5 @@ export * from "./components/SparkLine";
 export * from "./components/USNationalMap";
 export * from "./components/USStateMap";
 export * from "./components/WorldMap";
+
+export * from "./components/ErrorBox";


### PR DESCRIPTION
Introduces an `ErrorBox` component and uses it to render a grey error square when a metric fails to load:

![image](https://user-images.githubusercontent.com/206364/205689254-fbcfe44c-6db6-4bd8-b872-8256eb6603d5.png)

See:
* https://act-now-packages--pr474-mikelehen-error-stat-lm5yzgbw.web.app/storybook/index.html?path=/story/components-metriclinechart--loading-error
* https://act-now-packages--pr474-mikelehen-error-stat-lm5yzgbw.web.app/storybook/index.html?path=/story/components-metriclinethresholdchart--loading-error
* https://act-now-packages--pr474-mikelehen-error-stat-lm5yzgbw.web.app/storybook/index.html?path=/story/components-metricserieschart--loading-error
* https://act-now-packages--pr474-mikelehen-error-stat-lm5yzgbw.web.app/storybook/index.html?path=/story/components-metricsparklines--loading-error
* https://act-now-packages--pr474-mikelehen-error-stat-lm5yzgbw.web.app/storybook/index.html?path=/story/components-metricusnationalmap--loading-error
* https://act-now-packages--pr474-mikelehen-error-stat-lm5yzgbw.web.app/storybook/index.html?path=/story/components-metricusstatemap--loading-error
* https://act-now-packages--pr474-mikelehen-error-stat-lm5yzgbw.web.app/storybook/index.html?path=/story/components-metricworldmap--loading-error
* https://act-now-packages--pr474-mikelehen-error-stat-lm5yzgbw.web.app/storybook/index.html?path=/story/components-multimetricusstatemap--loading-error

Notes:
* I'm rendering pretty generic, unhelpful error text with the expectation that we don't want to show error details to users most of the time.  But the error will always be logged in the console.
* For maps, I am using a "default" width/height that won't match the actual map size.  Alternatively I could export the aspect ratio so that we could calculate the error box appropriately, but since errors should not occur during "normal" experience, I don't think it's worth adding complexity.
* I just show a blank box (no error text) for sparklines since they are usually rendered small and so there isn't much room for text. Plus it might be noisy since sparklines are usually rendered right next to each other. 