### PR TITLE
Adjust minValue and maxValue logic in charts

### DIFF
--- a/.changeset/fuzzy-teachers-decide.md
+++ b/.changeset/fuzzy-teachers-decide.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Adjust minValue and maxValue calculation logic in charts

--- a/packages/ui-components/src/common/utils/charts.ts
+++ b/packages/ui-components/src/common/utils/charts.ts
@@ -27,6 +27,13 @@ export interface BaseChartProps {
   marginRight?: number;
 }
 
+/**
+ * `getChartRange` determines the minimum and maximum y-axis value of a chart given a metric and corresponding timeseries data.
+ *
+ * @param {Metric} metric A metric instance
+ * @param {NonEmptyTimeseries<number>} timeseries Non-empty timeseries data for the metric.
+ * @returns {[number, number]} [minValue, maxValue]
+ */
 export function getChartRange(
   metric: Metric,
   timeseries: NonEmptyTimeseries<number>
@@ -36,10 +43,10 @@ export function getChartRange(
 
   const { minValue: minValueMetric, maxValue: maxValueMetric } = metric;
 
-  // If available, use minValue and maxValue from the metric definition.
-  // Otherwise, use min and max value of the data.
+  // If available, use `minValue` and `maxValue` from the metric definition.
+  // Otherwise, use `minValue` and `maxValue` value of the timeseries.
   const minValue = minValueMetric ?? minValueTimeseries;
   const maxValue = maxValueMetric ?? maxValueTimeseries;
 
-  return { minValue, maxValue };
+  return [minValue, maxValue];
 }

--- a/packages/ui-components/src/common/utils/charts.ts
+++ b/packages/ui-components/src/common/utils/charts.ts
@@ -1,3 +1,9 @@
+import {
+  Metric,
+  Timeseries,
+  NonEmptyTimeseries,
+} from "@actnowcoalition/metrics";
+
 export interface BaseChartProps {
   width: number;
   height: number;
@@ -5,4 +11,21 @@ export interface BaseChartProps {
   marginBottom?: number;
   marginLeft?: number;
   marginRight?: number;
+}
+
+export function getChartRange(
+  metric: Metric,
+  timeseries: Timeseries<number> | NonEmptyTimeseries<number>
+) {
+  const { minValue: minValueTimeseries, maxValue: maxValueTimeseries } =
+    timeseries;
+
+  const { minValue: minValueMetric, maxValue: maxValueMetric } = metric;
+
+  // If available, use minValue and maxValue from the metric definition.
+  // Otherwise, use min and max value of the data.
+  const minValue = minValueMetric ?? minValueTimeseries;
+  const maxValue = maxValueMetric ?? maxValueTimeseries;
+
+  return { minValue, maxValue };
 }

--- a/packages/ui-components/src/common/utils/charts.ts
+++ b/packages/ui-components/src/common/utils/charts.ts
@@ -1,8 +1,4 @@
-import {
-  Metric,
-  Timeseries,
-  NonEmptyTimeseries,
-} from "@actnowcoalition/metrics";
+import { Metric, NonEmptyTimeseries } from "@actnowcoalition/metrics";
 
 export interface BaseChartProps {
   /**
@@ -33,7 +29,7 @@ export interface BaseChartProps {
 
 export function getChartRange(
   metric: Metric,
-  timeseries: Timeseries<number> | NonEmptyTimeseries<number>
+  timeseries: NonEmptyTimeseries<number>
 ) {
   const { minValue: minValueTimeseries, maxValue: maxValueTimeseries } =
     timeseries;

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -62,7 +62,7 @@ export const MetricLineChart = ({
   });
 
   const yScale = scaleLinear({
-    domain: [metric.minValue ?? minValue, maxValue],
+    domain: [metric.minValue ?? minValue, metric.maxValue ?? maxValue],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -62,7 +62,7 @@ export const MetricLineChart = ({
   const chartWidth = width - marginLeft - marginRight;
 
   const { minDate, maxDate } = timeseries;
-  const { minValue, maxValue } = getChartRange(metric, timeseries);
+  const [minValue, maxValue] = getChartRange(metric, timeseries);
 
   const xScale = scaleUtc({
     domain: [minDate, maxDate],

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -62,6 +62,8 @@ export const MetricLineChart = ({
   });
 
   const yScale = scaleLinear({
+    // If available, use minValue and maxValue from the metric definition.
+    // Otherwise, use min and max value of the data.
     domain: [metric.minValue ?? minValue, metric.maxValue ?? maxValue],
     range: [chartHeight, 0],
   });

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -54,7 +54,7 @@ export const MetricLineChart = ({
   const chartHeight = height - marginTop - marginBottom;
   const chartWidth = width - marginLeft - marginRight;
 
-  const { minDate, maxDate, maxValue } = timeseries;
+  const { minDate, maxDate, minValue, maxValue } = timeseries;
 
   const xScale = scaleUtc({
     domain: [minDate, maxDate],
@@ -62,7 +62,7 @@ export const MetricLineChart = ({
   });
 
   const yScale = scaleLinear({
-    domain: [0, maxValue],
+    domain: [metric.minValue ?? minValue, maxValue],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -70,8 +70,7 @@ export const MetricLineChart = ({
   });
 
   const yScale = scaleLinear({
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    domain: [minValue!, maxValue!],
+    domain: [minValue, maxValue],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -16,6 +16,7 @@ import { LineChart } from "../LineChart";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricTooltip } from "../MetricTooltip";
 import { PointMarker } from "../PointMarker";
+import { getChartRange } from "../../common/utils/charts";
 
 export interface MetricLineChartProps extends BaseChartProps {
   metric: Metric | string;
@@ -54,7 +55,8 @@ export const MetricLineChart = ({
   const chartHeight = height - marginTop - marginBottom;
   const chartWidth = width - marginLeft - marginRight;
 
-  const { minDate, maxDate, minValue, maxValue } = timeseries;
+  const { minDate, maxDate } = timeseries;
+  const { minValue, maxValue } = getChartRange(metric, timeseries);
 
   const xScale = scaleUtc({
     domain: [minDate, maxDate],
@@ -62,9 +64,8 @@ export const MetricLineChart = ({
   });
 
   const yScale = scaleLinear({
-    // If available, use minValue and maxValue from the metric definition.
-    // Otherwise, use min and max value of the data.
-    domain: [metric.minValue ?? minValue, metric.maxValue ?? maxValue],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    domain: [minValue!, maxValue!],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -3,8 +3,6 @@ import React from "react";
 import { Skeleton } from "@mui/material";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import max from "lodash/max";
-import min from "lodash/min";
 
 import { assert } from "@actnowcoalition/assert";
 import { Metric } from "@actnowcoalition/metrics";
@@ -98,18 +96,17 @@ export const MetricLineThresholdChart = ({
   // If available, use minValue from the metric definition.
   // Otherwise, use the lower bound of the lowest threshold.
   const minValueMetric = metric.minValue;
-  const minValueIntervals = min(intervals.map(({ lower }) => lower));
+  const minValueIntervals = Math.min(...intervals.map(({ lower }) => lower));
   const minChartValue = minValueMetric ?? minValueIntervals;
 
   // If available, use maxValue from the metric definition.
   // Otherwise, use the higher bound of the highest threshold.
   const maxValueMetric = metric.maxValue;
-  const maxValueIntervals = max(intervals.map(({ upper }) => upper));
+  const maxValueIntervals = Math.max(...intervals.map(({ upper }) => upper));
   const maxChartValue = maxValueMetric ?? maxValueIntervals;
 
   const yScale = scaleLinear({
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    domain: [minChartValue!, maxChartValue!],
+    domain: [minChartValue, maxChartValue],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -35,11 +35,10 @@ export interface MetricLineThresholdChartProps extends BaseChartProps {
  * MetricLineThresholdChart renders a line chart (specifically, a LineIntervalChart)
  * where line segments are colored according to the metric categories and thresholds.
  *
- * Example: for a metric with two categories, High (red) and Low
- * (green) separated by a threshold at the value 10, the line will be red when
- * above 10 and green below it.
+ * Example: for a metric with two categories,
+ * High (red) and Low (green) separated by a threshold value of 10,
+ * the line is red above 10 and green below 10.
  */
-
 export const MetricLineThresholdChart = ({
   metric: metricOrId,
   region,

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -88,13 +88,17 @@ export const MetricLineThresholdChart = ({
     range: [0, chartWidth],
   });
 
-  const maxChartValue = max(intervals.map(({ upper }) => upper)) ?? maxValue;
-
   // If the metric definition has a defined minimum value, use this value as the minimum value on the y-axis.
   // Otherwise, use the lower bound of the lowest threshold.
   // If neither are available, use the data's minimum value.
   const minChartValue =
     metric.minValue ?? min(intervals.map(({ lower }) => lower)) ?? minValue;
+
+  // If the metric definition has a defined maximum value, use this value as the maximum value on the y-axis.
+  // Otherwise, use the higher bound of the highest threshold.
+  // If neither are available, use the data's maximum value.
+  const maxChartValue =
+    metric.maxValue ?? max(intervals.map(({ upper }) => upper)) ?? maxValue;
 
   const yScale = scaleLinear({
     domain: [minChartValue, maxChartValue],

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -88,8 +88,13 @@ export const MetricLineThresholdChart = ({
     range: [0, chartWidth],
   });
 
-  const minChartValue = min(intervals.map(({ lower }) => lower)) ?? minValue;
   const maxChartValue = max(intervals.map(({ upper }) => upper)) ?? maxValue;
+
+  // If the metric definition has a defined minimum value, use this value as the minimum value on the y-axis.
+  // Otherwise, use the lower bound of the lowest threshold.
+  // If neither are available, use the data's minimum value.
+  const minChartValue =
+    metric.minValue ?? min(intervals.map(({ lower }) => lower)) ?? minValue;
 
   const yScale = scaleLinear({
     domain: [minChartValue, maxChartValue],

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -90,18 +90,19 @@ export const MetricLineThresholdChart = ({
 
   // If available, use minValue from the metric definition.
   // Otherwise, use the lower bound of the lowest threshold.
-  // If neither are available, use min value of the data.
-  const minChartValue =
-    metric.minValue ?? min(intervals.map(({ lower }) => lower)) ?? minValue;
+  const minValueMetric = metric.minValue;
+  const minValueIntervals = min(intervals.map(({ lower }) => lower));
+  const minChartValue = minValueMetric ?? minValueIntervals;
 
   // If available, use maxValue from the metric definition.
   // Otherwise, use the higher bound of the highest threshold.
-  // If neither are available, use max value of the data.
-  const maxChartValue =
-    metric.maxValue ?? max(intervals.map(({ upper }) => upper)) ?? maxValue;
+  const maxValueMetric = metric.maxValue;
+  const maxValueIntervals = max(intervals.map(({ upper }) => upper));
+  const maxChartValue = maxValueMetric ?? maxValueIntervals;
 
   const yScale = scaleLinear({
-    domain: [minChartValue, maxChartValue],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    domain: [minChartValue!, maxChartValue!],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -88,15 +88,15 @@ export const MetricLineThresholdChart = ({
     range: [0, chartWidth],
   });
 
-  // If the metric definition has a defined minimum value, use this value as the minimum value on the y-axis.
+  // If available, use minValue from the metric definition.
   // Otherwise, use the lower bound of the lowest threshold.
-  // If neither are available, use the data's minimum value.
+  // If neither are available, use min value of the data.
   const minChartValue =
     metric.minValue ?? min(intervals.map(({ lower }) => lower)) ?? minValue;
 
-  // If the metric definition has a defined maximum value, use this value as the maximum value on the y-axis.
+  // If available, use maxValue from the metric definition.
   // Otherwise, use the higher bound of the highest threshold.
-  // If neither are available, use the data's maximum value.
+  // If neither are available, use max value of the data.
   const maxChartValue =
     metric.maxValue ?? max(intervals.map(({ upper }) => upper)) ?? maxValue;
 

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -47,20 +47,6 @@ Vaccination.args = {
   ],
 };
 
-export const WithNegativeYValues = Template.bind({});
-WithNegativeYValues.args = {
-  width,
-  height,
-  minValue: -10,
-  series: [
-    {
-      region: WY,
-      metric: MetricId.MOCK_CASES,
-      type: SeriesType.LINE,
-    },
-  ],
-};
-
 export const TrendsSingleLocation = Template.bind({});
 TrendsSingleLocation.args = {
   width,

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -117,7 +117,7 @@ export const MetricSeriesChart = ({
     ? Math.min(metricDefinitionMin, minDataValue)
     : minDataValue;
 
-  // The highest value of one metric may not be the highet of another metric.
+  // The highest value of one metric may not be the highest of another metric.
   // So we use the higher of metricDefinitionMax (which accounts for all metric definitions)
   // and data's maximum value.
   const maxYValue = metricDefinitionMax

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -104,25 +104,11 @@ export const MetricSeriesChart = ({
   const [minDate, maxDate] = getDateRange(timeseriesList);
   const [minDataValue, maxDataValue] = getValueRange(timeseriesList);
 
-  // Get the lowest minimum value (specified in metric definition) out of all metrics.
+  // Get the lowest minValue from the metric definitions of included metrics.
   const metricDefinitionMin = min(metrics.map(({ minValue }) => minValue));
 
-  // Get the highest maximum value (specified in metric definition) out of all metrics.
+  // Get the highest maxValue from the metric definitions of included metrics.
   const metricDefinitionMax = max(metrics.map(({ maxValue }) => maxValue));
-
-  // The lowest value of one metric may not be the lowest of another metric.
-  // So we use the lower of metricDefinitionMin (which accounts for all metric definitions)
-  // and data's minimum value.
-  const minYValue = metricDefinitionMin
-    ? Math.min(metricDefinitionMin, minDataValue)
-    : minDataValue;
-
-  // The highest value of one metric may not be the highest of another metric.
-  // So we use the higher of metricDefinitionMax (which accounts for all metric definitions)
-  // and data's maximum value.
-  const maxYValue = metricDefinitionMax
-    ? Math.max(metricDefinitionMax, maxDataValue)
-    : maxDataValue;
 
   const chartWidth = width - marginLeft - marginRight;
   const chartHeight = height - marginTop - marginBottom;
@@ -133,7 +119,10 @@ export const MetricSeriesChart = ({
   });
 
   const yScale = scaleLinear({
-    domain: [minYValue, maxYValue],
+    domain: [
+      metricDefinitionMin ?? minDataValue,
+      metricDefinitionMax ?? maxDataValue,
+    ],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -104,10 +104,12 @@ export const MetricSeriesChart = ({
   const [minDate, maxDate] = getDateRange(timeseriesList);
   const [minDataValue, maxDataValue] = getValueRange(timeseriesList);
 
-  // Get the lowest minValue from the metric definitions of included metrics.
+  // Given an array of metrics, select the metric with the lowest defined minimum value
+  // and use that minimum value.
   const metricDefinitionMin = min(metrics.map(({ minValue }) => minValue));
 
-  // Get the highest maxValue from the metric definitions of included metrics.
+  // Given an array of metrics, select the metric with the highest defined maximum value
+  // and use that maximum value.
   const metricDefinitionMax = max(metrics.map(({ maxValue }) => maxValue));
 
   const chartWidth = width - marginLeft - marginRight;

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -26,8 +26,6 @@ import { SeriesLabel } from "./MetricSeriesChart.style";
 export interface MetricSeriesChartProps extends BaseChartProps {
   /** List of series to be rendered */
   series: Series[];
-  /** Minimum value for the y-axis. It defaults to 0. */
-  minValue?: number;
   /**
    * Show labels for each series. The labels will be shown on the right side
    * of the chart, close to the last value of each series.
@@ -53,7 +51,6 @@ export const MetricSeriesChart = ({
   marginBottom = 40,
   marginLeft = 70,
   marginRight = 20,
-  minValue = 0,
   showLabels = true,
 }: MetricSeriesChartProps) => {
   const metricCatalog = useMetricCatalog();
@@ -107,10 +104,15 @@ export const MetricSeriesChart = ({
   const [minDate, maxDate] = getDateRange(timeseriesList);
   const [minDataValue, maxValue] = getValueRange(timeseriesList);
 
-  // Note: We use minValue if provided. If not, we default to start from zero,
-  // which is best in most cases, unless minDataValue is negative, in which
-  // case we use that value instead.
-  const minYValue = isNumber(minValue) ? minValue : Math.min(0, minDataValue);
+  // Out of all metrics to be included in the chart,
+  // get the lowest minimum value defined in the metric definition.
+  const metricDefinitionMin = min(metrics.map(({ minValue }) => minValue));
+
+  // If at least one of the metric definitions has a defined minimum value,
+  // use the the minimum value of that or the minimum data value.
+  const minYValue = metricDefinitionMin
+    ? Math.min(metricDefinitionMin, minDataValue)
+    : minDataValue;
 
   const chartWidth = width - marginLeft - marginRight;
   const chartHeight = height - marginTop - marginBottom;

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -30,11 +30,6 @@ export interface MetricSeriesChartProps extends BaseChartProps {
    */
   series: Series[];
   /**
-   * Minimum value for the y-axis.
-   * @default 0
-   */
-  minValue?: number;
-  /**
    * Show labels for each series.
    * @default true
    */
@@ -53,7 +48,6 @@ export interface MetricSeriesChartProps extends BaseChartProps {
  * The axis will be calculated from the data. The appearance of each series
  * depends on its type and other properties passed when creating the series.
  */
-
 export const MetricSeriesChart = ({
   series,
   width,
@@ -130,6 +124,9 @@ export const MetricSeriesChart = ({
   // and use that maximum value.
   const metricDefinitionMax = max(metrics.map(({ maxValue }) => maxValue));
 
+  const minValue = metricDefinitionMin ?? minDataValue;
+  const maxValue = metricDefinitionMax ?? maxDataValue;
+
   const chartWidth = width - marginLeft - marginRight;
   const chartHeight = height - marginTop - marginBottom;
 
@@ -139,10 +136,7 @@ export const MetricSeriesChart = ({
   });
 
   const yScale = scaleLinear({
-    domain: [
-      metricDefinitionMin ?? minDataValue,
-      metricDefinitionMax ?? maxDataValue,
-    ],
+    domain: [minValue, maxValue],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -102,17 +102,25 @@ export const MetricSeriesChart = ({
     .filter(({ timeseries }) => timeseries.hasData());
 
   const [minDate, maxDate] = getDateRange(timeseriesList);
-  const [minDataValue, maxValue] = getValueRange(timeseriesList);
+  const [minDataValue, maxDataValue] = getValueRange(timeseriesList);
 
   // Out of all metrics to be included in the chart,
-  // get the lowest minimum value defined in the metric definition.
+  // get the lowest minimum value and highest maximum value
+  // defined in the metric definition.
   const metricDefinitionMin = min(metrics.map(({ minValue }) => minValue));
+  const metricDefinitionMax = max(metrics.map(({ maxValue }) => maxValue));
 
   // If at least one of the metric definitions has a defined minimum value,
-  // use the the minimum value of that or the minimum data value.
+  // use the lower of that minimum value or the minimum data value.
   const minYValue = metricDefinitionMin
     ? Math.min(metricDefinitionMin, minDataValue)
     : minDataValue;
+
+  // If at least one of the metric definitions has a defined maximum value,
+  // use the higher of that maximum value or the maximum data value.
+  const maxYValue = metricDefinitionMax
+    ? Math.max(metricDefinitionMax, maxDataValue)
+    : maxDataValue;
 
   const chartWidth = width - marginLeft - marginRight;
   const chartHeight = height - marginTop - marginBottom;
@@ -123,7 +131,7 @@ export const MetricSeriesChart = ({
   });
 
   const yScale = scaleLinear({
-    domain: [minYValue, maxValue],
+    domain: [minYValue, maxYValue],
     range: [chartHeight, 0],
   });
 

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -104,20 +104,22 @@ export const MetricSeriesChart = ({
   const [minDate, maxDate] = getDateRange(timeseriesList);
   const [minDataValue, maxDataValue] = getValueRange(timeseriesList);
 
-  // Out of all metrics to be included in the chart,
-  // get the lowest minimum value and highest maximum value
-  // defined in the metric definition.
+  // Get the lowest minimum value (specified in metric definition) out of all metrics.
   const metricDefinitionMin = min(metrics.map(({ minValue }) => minValue));
+
+  // Get the highest maximum value (specified in metric definition) out of all metrics.
   const metricDefinitionMax = max(metrics.map(({ maxValue }) => maxValue));
 
-  // If at least one of the metric definitions has a defined minimum value,
-  // use the lower of that minimum value or the minimum data value.
+  // The lowest value of one metric may not be the lowest of another metric.
+  // So we use the lower of metricDefinitionMin (which accounts for all metric definitions)
+  // and data's minimum value.
   const minYValue = metricDefinitionMin
     ? Math.min(metricDefinitionMin, minDataValue)
     : minDataValue;
 
-  // If at least one of the metric definitions has a defined maximum value,
-  // use the higher of that maximum value or the maximum data value.
+  // The highest value of one metric may not be the highet of another metric.
+  // So we use the higher of metricDefinitionMax (which accounts for all metric definitions)
+  // and data's maximum value.
   const maxYValue = metricDefinitionMax
     ? Math.max(metricDefinitionMax, maxDataValue)
     : maxDataValue;

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -64,17 +64,21 @@ export const MetricSparklines = ({
       ?.timeseries.assertFiniteNumbers()
       .filterToDateRange({ startAt: dateFrom, endAt: dateTo });
 
+    // Use minValue from metric definitions.
+    // If unspecified, use minimum data value.
     const minValue =
       metricLineChart.minValue && metricBarChart.minValue
         ? Math.min(metricLineChart.minValue, metricBarChart.minValue)
-        : timeseriesLineChart.minValue && timeseriesBarChart.minValue
+        : timeseriesLineChart.hasData() && timeseriesBarChart.hasData()
         ? Math.min(timeseriesLineChart.minValue, timeseriesBarChart.minValue)
         : undefined;
 
+    // Use maxValue from metric definitions.
+    // If unspecified, use maximum data value.
     const maxValue =
       metricLineChart.maxValue && metricBarChart.maxValue
         ? Math.min(metricLineChart.maxValue, metricBarChart.maxValue)
-        : timeseriesLineChart.maxValue && timeseriesBarChart.maxValue
+        : timeseriesLineChart.hasData() && timeseriesBarChart.hasData()
         ? Math.min(timeseriesLineChart.maxValue, timeseriesBarChart.maxValue)
         : undefined;
 

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -71,11 +71,19 @@ export const MetricSparklines = ({
         ? Math.min(timeseriesLineChart.minValue, timeseriesBarChart.minValue)
         : undefined;
 
+    const maxValue =
+      metricLineChart.maxValue && metricBarChart.maxValue
+        ? Math.min(metricLineChart.maxValue, metricBarChart.maxValue)
+        : timeseriesLineChart.maxValue && timeseriesBarChart.maxValue
+        ? Math.min(timeseriesLineChart.maxValue, timeseriesBarChart.maxValue)
+        : undefined;
+
     return (
       <SparkLine
         timeseriesLineChart={timeseriesLineChart}
         timeseriesBarChart={timeseriesBarChart}
         minValue={minValue}
+        maxValue={maxValue}
         {...optionalProps}
       />
     );

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -10,6 +10,7 @@ import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { BaseSparkLineProps, SparkLine } from "../SparkLine";
 import { getChartRange } from "../../common/utils/charts";
+import { assert } from "@actnowcoalition/assert";
 
 export interface MetricSparklinesProps extends BaseSparkLineProps {
   /**
@@ -77,20 +78,22 @@ export const MetricSparklines = ({
       ?.timeseries.assertFiniteNumbers()
       .filterToDateRange({ startAt: dateFrom, endAt: dateTo });
 
+    assert(
+      timeseriesLineChart.hasData(),
+      `Timeseries line chart cannot be empty`
+    );
     const { minValue: minValueLineChart, maxValue: maxValueLineChart } =
       getChartRange(metricLineChart, timeseriesLineChart);
 
+    assert(
+      timeseriesBarChart.hasData(),
+      `Timeseries bar chart cannot be empty`
+    );
     const { minValue: minValueBarChart, maxValue: maxValueBarChart } =
       getChartRange(metricBarChart, timeseriesBarChart);
 
-    const minValue =
-      minValueLineChart && minValueBarChart
-        ? Math.min(minValueLineChart, minValueBarChart)
-        : undefined;
-    const maxValue =
-      maxValueLineChart && maxValueBarChart
-        ? Math.max(maxValueLineChart, maxValueBarChart)
-        : undefined;
+    const minValue = Math.min(minValueLineChart, minValueBarChart);
+    const maxValue = Math.max(maxValueLineChart, maxValueBarChart);
 
     return (
       <SparkLine

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -9,6 +9,7 @@ import { useDataForMetrics } from "../../common/hooks";
 import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { BaseSparkLineProps, SparkLine } from "../SparkLine";
+import { getChartRange } from "../../common/utils/charts";
 
 export interface MetricSparklinesProps extends BaseSparkLineProps {
   /** Region to generate sparkline for. */
@@ -64,22 +65,19 @@ export const MetricSparklines = ({
       ?.timeseries.assertFiniteNumbers()
       .filterToDateRange({ startAt: dateFrom, endAt: dateTo });
 
-    // Use minValue from metric definitions.
-    // If unspecified, use minimum data value.
-    const minValue =
-      metricLineChart.minValue && metricBarChart.minValue
-        ? Math.min(metricLineChart.minValue, metricBarChart.minValue)
-        : timeseriesLineChart.hasData() && timeseriesBarChart.hasData()
-        ? Math.min(timeseriesLineChart.minValue, timeseriesBarChart.minValue)
-        : undefined;
+    const { minValue: minValueLineChart, maxValue: maxValueLineChart } =
+      getChartRange(metricLineChart, timeseriesLineChart);
 
-    // Use maxValue from metric definitions.
-    // If unspecified, use maximum data value.
+    const { minValue: minValueBarChart, maxValue: maxValueBarChart } =
+      getChartRange(metricBarChart, timeseriesBarChart);
+
+    const minValue =
+      minValueLineChart && minValueBarChart
+        ? Math.min(minValueLineChart, minValueBarChart)
+        : undefined;
     const maxValue =
-      metricLineChart.maxValue && metricBarChart.maxValue
-        ? Math.min(metricLineChart.maxValue, metricBarChart.maxValue)
-        : timeseriesLineChart.hasData() && timeseriesBarChart.hasData()
-        ? Math.min(timeseriesLineChart.maxValue, timeseriesBarChart.maxValue)
+      maxValueLineChart && maxValueBarChart
+        ? Math.max(maxValueLineChart, maxValueBarChart)
         : undefined;
 
     return (

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -64,10 +64,18 @@ export const MetricSparklines = ({
       ?.timeseries.assertFiniteNumbers()
       .filterToDateRange({ startAt: dateFrom, endAt: dateTo });
 
+    const minValue =
+      metricLineChart.minValue && metricBarChart.minValue
+        ? Math.min(metricLineChart.minValue, metricBarChart.minValue)
+        : timeseriesLineChart.minValue && timeseriesBarChart.minValue
+        ? Math.min(timeseriesLineChart.minValue, timeseriesBarChart.minValue)
+        : undefined;
+
     return (
       <SparkLine
         timeseriesLineChart={timeseriesLineChart}
         timeseriesBarChart={timeseriesBarChart}
+        minValue={minValue}
         {...optionalProps}
       />
     );

--- a/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
+++ b/packages/ui-components/src/components/MetricSparklines/MetricSparklines.tsx
@@ -82,15 +82,19 @@ export const MetricSparklines = ({
       timeseriesLineChart.hasData(),
       `Timeseries line chart cannot be empty`
     );
-    const { minValue: minValueLineChart, maxValue: maxValueLineChart } =
-      getChartRange(metricLineChart, timeseriesLineChart);
+    const [minValueLineChart, maxValueLineChart] = getChartRange(
+      metricLineChart,
+      timeseriesLineChart
+    );
 
     assert(
       timeseriesBarChart.hasData(),
       `Timeseries bar chart cannot be empty`
     );
-    const { minValue: minValueBarChart, maxValue: maxValueBarChart } =
-      getChartRange(metricBarChart, timeseriesBarChart);
+    const [minValueBarChart, maxValueBarChart] = getChartRange(
+      metricBarChart,
+      timeseriesBarChart
+    );
 
     const minValue = Math.min(minValueLineChart, minValueBarChart);
     const maxValue = Math.max(maxValueLineChart, maxValueBarChart);

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -29,6 +29,9 @@ export interface SparkLineProps extends BaseSparkLineProps {
 
   /** Minimum value on the y-axis */
   minValue?: number;
+
+  /** Maximum value on the y-axis */
+  maxValue?: number;
 }
 
 export const SparkLine = ({
@@ -38,6 +41,7 @@ export const SparkLine = ({
   height = 50,
   barWidth = 2,
   minValue,
+  maxValue,
 }: SparkLineProps) => {
   const theme = useTheme();
   const padding = 2;
@@ -52,7 +56,7 @@ export const SparkLine = ({
   });
 
   const yScaleBar = scaleLinear({
-    domain: [minValue ?? 0, timeseriesBarChart.maxValue],
+    domain: [minValue ?? 0, maxValue ?? timeseriesBarChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 
@@ -62,7 +66,7 @@ export const SparkLine = ({
   });
 
   const yScaleLine = scaleLinear({
-    domain: [minValue ?? 0, timeseriesLineChart.maxValue],
+    domain: [minValue ?? 0, maxValue ?? timeseriesLineChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -26,6 +26,9 @@ export interface SparkLineProps extends BaseSparkLineProps {
 
   /** Timeseries used to draw the line chart */
   timeseriesLineChart: Timeseries<number>;
+
+  /** Minimum value on the y-axis */
+  minValue?: number;
 }
 
 export const SparkLine = ({
@@ -34,6 +37,7 @@ export const SparkLine = ({
   width = 150,
   height = 50,
   barWidth = 2,
+  minValue,
 }: SparkLineProps) => {
   const theme = useTheme();
   const padding = 2;
@@ -48,7 +52,7 @@ export const SparkLine = ({
   });
 
   const yScaleBar = scaleLinear({
-    domain: [0, timeseriesBarChart.maxValue],
+    domain: [minValue ?? 0, timeseriesBarChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 
@@ -58,7 +62,7 @@ export const SparkLine = ({
   });
 
   const yScaleLine = scaleLinear({
-    domain: [0, timeseriesLineChart.maxValue],
+    domain: [minValue ?? 0, timeseriesLineChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -37,11 +37,14 @@ export interface SparkLineProps extends BaseSparkLineProps {
    * Timeseries used to draw the line chart.
    */
   timeseriesLineChart: Timeseries<number>;
-
-  /** Minimum value on the y-axis */
+  /**
+   * Minimum value on the y-axis.
+   * @default 0
+   */
   minValue?: number;
-
-  /** Maximum value on the y-axis */
+  /**
+   * Maximum value on the y-axis.
+   */
   maxValue?: number;
 }
 
@@ -51,7 +54,7 @@ export const SparkLine = ({
   width = 150,
   height = 50,
   barWidth = 2,
-  minValue: propMinValue,
+  minValue = 0,
   maxValue: propMaxValue,
 }: SparkLineProps) => {
   const padding = 2;
@@ -59,8 +62,6 @@ export const SparkLine = ({
   if (!timeseriesBarChart.hasData() || !timeseriesLineChart.hasData()) {
     return null;
   }
-
-  const minValue = propMinValue ?? 0;
 
   const xScaleBar = scaleUtc({
     domain: [timeseriesBarChart.minDate, timeseriesBarChart.maxDate],

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -60,13 +60,15 @@ export const SparkLine = ({
     return null;
   }
 
+  const minValue = propMinValue ?? 0;
+
   const xScaleBar = scaleUtc({
     domain: [timeseriesBarChart.minDate, timeseriesBarChart.maxDate],
     range: [0, width - 2 * padding],
   });
 
   const yScaleBar = scaleLinear({
-    domain: [propMinValue ?? 0, propMaxValue ?? timeseriesBarChart.maxValue],
+    domain: [minValue, propMaxValue ?? timeseriesBarChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 
@@ -76,7 +78,7 @@ export const SparkLine = ({
   });
 
   const yScaleLine = scaleLinear({
-    domain: [propMinValue ?? 0, propMaxValue ?? timeseriesLineChart.maxValue],
+    domain: [minValue, propMaxValue ?? timeseriesLineChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 

--- a/packages/ui-components/src/components/SparkLine/SparkLine.tsx
+++ b/packages/ui-components/src/components/SparkLine/SparkLine.tsx
@@ -40,8 +40,8 @@ export const SparkLine = ({
   width = 150,
   height = 50,
   barWidth = 2,
-  minValue,
-  maxValue,
+  minValue: propMinValue,
+  maxValue: propMaxValue,
 }: SparkLineProps) => {
   const theme = useTheme();
   const padding = 2;
@@ -56,7 +56,7 @@ export const SparkLine = ({
   });
 
   const yScaleBar = scaleLinear({
-    domain: [minValue ?? 0, maxValue ?? timeseriesBarChart.maxValue],
+    domain: [propMinValue ?? 0, propMaxValue ?? timeseriesBarChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 
@@ -66,7 +66,7 @@ export const SparkLine = ({
   });
 
   const yScaleLine = scaleLinear({
-    domain: [minValue ?? 0, maxValue ?? timeseriesLineChart.maxValue],
+    domain: [propMinValue ?? 0, propMaxValue ?? timeseriesLineChart.maxValue],
     range: [height - 2 * padding, 0],
   });
 

--- a/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.tsx
+++ b/packages/ui-components/src/components/TimeseriesLineChart/TimeseriesLineChart.tsx
@@ -25,7 +25,7 @@ export const TimeseriesLineChart = ({
   const chartHeight = height - marginTop - marginBottom;
   const chartWidth = width - marginLeft - marginRight;
 
-  const { minDate, maxDate, maxValue } = timeseries;
+  const { minDate, maxDate, minValue, maxValue } = timeseries;
 
   const xScale = scaleUtc({
     domain: [minDate, maxDate],
@@ -33,7 +33,7 @@ export const TimeseriesLineChart = ({
   });
 
   const yScale = scaleLinear({
-    domain: [0, maxValue],
+    domain: [minValue, maxValue],
     range: [chartHeight, 0],
   });
 


### PR DESCRIPTION
This PR adjusts `minValue` and `maxValue` calculation logic for our charts to be more consistent with each other. Based on discussion with the team ([doc](https://www.dropbox.com/scl/fi/zmykem7z5r1plryn79r6a/minValue-and-maxValue-in-Charts.paper?dl=0&rlkey=wzsfi96zd9y5ffctkhjuc1zcj) for context), in general `minValue` and `maxValue` are now calculated as follow:

_If the metric definition has a specified `minValue` or `maxValue`, use that value.
If not, and the chart is not a threshold chart, then use the data’s minimum and maximum value. (Threshold chart will use the lower and upper bounds first before resorting to the data’s minimum and maximum value)._

Closes #386 