### PR TITLE
Fix lines going outside the chart bounds on MetricSeriesChart

### DIFF
--- a/.changeset/clever-yaks-switch.md
+++ b/.changeset/clever-yaks-switch.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fixes bug that caused series to be visible outside the charting area'

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -20,6 +20,7 @@ import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricTooltip } from "../MetricTooltip";
 import { PointMarker } from "../PointMarker";
+import { RectClipGroup } from "../RectClipGroup";
 import { Series, SeriesChart, SeriesType } from "../SeriesChart";
 import { SeriesLabel } from "./MetricSeriesChart.style";
 
@@ -159,15 +160,17 @@ export const MetricSeriesChart = ({
           height={chartHeight}
           axisLeftProps={{ tickFormat: yAxisFormat }}
         />
-        {seriesList.map((item, itemIndex) => (
-          <SeriesChart
-            key={`series-${itemIndex}`}
-            series={item.series}
-            timeseries={item.timeseries}
-            xScale={xScale}
-            yScale={yScale}
-          />
-        ))}
+        <RectClipGroup width={chartWidth} height={chartHeight}>
+          {seriesList.map((item, itemIndex) => (
+            <SeriesChart
+              key={`series-${itemIndex}`}
+              series={item.series}
+              timeseries={item.timeseries}
+              xScale={xScale}
+              yScale={yScale}
+            />
+          ))}
+        </RectClipGroup>
         {showLabels && (
           <Group>
             {labelPositions.map((item, itemIndex) => (


### PR DESCRIPTION
Discovered this bug yesterday, the series go outside the charting area. This PR fixed that by wrapping the lines in `RectClipGroup`, which hides anything outside the charting area so it doesn't overlap with the axes.

<img width="889" alt="image" src="https://user-images.githubusercontent.com/114084/206605471-ac29c294-3a0b-45b4-a131-26076f742d3a.png">
