### PR TITLE
Allow to filter MetricSeriesChart by a date range

### DIFF
--- a/.changeset/ninety-crabs-greet.md
+++ b/.changeset/ninety-crabs-greet.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Implement date filter on MetricSeriesChart

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.stories.tsx
@@ -80,6 +80,26 @@ TrendsSingleLocation.args = {
   ],
 };
 
+export const FilteredByDate = Template.bind({});
+FilteredByDate.args = {
+  width,
+  height,
+  dateRange: { startAt: new Date("2022-10-01"), endAt: new Date("2022-11-30") },
+  series: [
+    {
+      region: WA,
+      metric: MetricId.MOCK_CASES,
+      type: SeriesType.BAR,
+    },
+    {
+      region: WA,
+      metric: MetricId.MOCK_CASES,
+      type: SeriesType.LINE,
+      lineProps: { stroke: "black" },
+    },
+  ],
+};
+
 export const TrendsMultipleLocations = Template.bind({});
 TrendsMultipleLocations.args = {
   width,

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -10,7 +10,7 @@ import sortBy from "lodash/sortBy";
 import uniq from "lodash/uniq";
 
 import { assert } from "@actnowcoalition/assert";
-import { Timeseries } from "@actnowcoalition/metrics";
+import { DateRange, Timeseries } from "@actnowcoalition/metrics";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { BaseChartProps } from "../../common/utils/charts";
@@ -34,6 +34,8 @@ export interface MetricSeriesChartProps extends BaseChartProps {
    * of the chart, close to the last value of each series.
    */
   showLabels?: boolean;
+  /** Date range used to filter the series */
+  dateRange?: DateRange;
 }
 
 /**
@@ -56,6 +58,7 @@ export const MetricSeriesChart = ({
   marginRight = 20,
   minValue = 0,
   showLabels = true,
+  dateRange,
 }: MetricSeriesChartProps) => {
   const metricCatalog = useMetricCatalog();
   const theme = useTheme();
@@ -80,9 +83,15 @@ export const MetricSeriesChart = ({
 
   const timeseriesList =
     data &&
-    series.map(({ region, metric }) =>
-      data.metricData(region, metric).timeseries.assertFiniteNumbers()
-    );
+    series.map(({ region, metric }) => {
+      const fullTimeseries = data
+        .metricData(region, metric)
+        .timeseries.assertFiniteNumbers();
+
+      return dateRange
+        ? fullTimeseries.filterToDateRange(dateRange)
+        : fullTimeseries;
+    });
 
   const { pointInfo, onMouseMove, onMouseLeave } =
     useHoveredPoint(timeseriesList);


### PR DESCRIPTION
The `MultiRegionMultiMetricChart` uses the `MetricSeriesChart` component, which currently doesn't allow to filter by date. This PR adds the ability to filter all the time series in `MetricSeriesChart` by a date range.