### PR TITLE
Adds time period filtering to `MultiRegionMultiMetricChart`

### DIFF
--- a/.changeset/forty-tips-shout.md
+++ b/.changeset/forty-tips-shout.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Add abiliity to filter MultiRegionMultiMetricChart by time period

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
@@ -34,15 +34,15 @@ const today = new Date();
 const customTimePeriods: TimePeriod[] = [
   {
     label: "Past week",
-    dateRange: { startAt: subtractTime(today, 7, TimeUnit.DAYS) },
+    dateRange: { startAt: subtractTime(today, 1, TimeUnit.WEEKS) },
   },
   {
     label: "Past 2 weeks",
-    dateRange: { startAt: subtractTime(today, 14, TimeUnit.DAYS) },
+    dateRange: { startAt: subtractTime(today, 2, TimeUnit.WEEKS) },
   },
   {
-    label: "Past 30 days",
-    dateRange: { startAt: subtractTime(today, 30, TimeUnit.DAYS) },
+    label: "Past month",
+    dateRange: { startAt: subtractTime(today, 1, TimeUnit.MONTHS) },
   },
   { label: "All time", dateRange: undefined },
 ];

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import last from "lodash/last";
 import sortBy from "lodash/sortBy";
 
 import { states } from "@actnowcoalition/regions";
+import { TimeUnit, subtractTime } from "@actnowcoalition/time-utils";
 
 import { MultiRegionMultiMetricChart } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
+import { TimePeriod } from "./utils";
 
 const sortedStates = sortBy(states.all, (state) => state.shortName);
 
@@ -25,4 +28,31 @@ Example.args = {
   metrics: metricCatalog.metrics,
   initialMetric: MetricId.MOCK_CASES,
   initialRegions: sortedStates.slice(0, 5),
+};
+
+const today = new Date();
+const customTimePeriods: TimePeriod[] = [
+  {
+    label: "Past week",
+    dateRange: { startAt: subtractTime(today, 7, TimeUnit.DAYS) },
+  },
+  {
+    label: "Past 2 weeks",
+    dateRange: { startAt: subtractTime(today, 14, TimeUnit.DAYS) },
+  },
+  {
+    label: "Past 30 days",
+    dateRange: { startAt: subtractTime(today, 30, TimeUnit.DAYS) },
+  },
+  { label: "All time", dateRange: undefined },
+];
+
+export const WithCustomPeriods = Template.bind({});
+WithCustomPeriods.args = {
+  regions: sortedStates,
+  metrics: metricCatalog.metrics,
+  initialMetric: MetricId.MOCK_CASES,
+  initialRegions: sortedStates.slice(0, 5),
+  timePeriods: customTimePeriods,
+  initialTimePeriod: last(customTimePeriods),
 };

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.tsx
@@ -22,19 +22,11 @@ export interface MultiRegionMultiMetricChartProps extends BaseChartProps {
   initialMetric: Metric | string;
   /* Initially selected regions */
   initialRegions: Region[];
-  /** Time Periods */
+  /** List of time period options that the chart can be filtered by */
   timePeriods?: TimePeriod[];
-  /** default Time period */
+  /** Initially selected time period */
   initialTimePeriod?: TimePeriod;
 }
-
-const getMetricId = (metric: Metric) => metric.id;
-const getMetricLabel = (metric: Metric) => metric.name;
-
-const getRegionLabel = (region: Region) => region.shortName;
-const getRegionValue = (region: Region) => region.regionId;
-
-const getPeriodLabel = (period: TimePeriod) => period.label;
 
 export const MultiRegionMultiMetricChart = ({
   regions,
@@ -121,6 +113,12 @@ export const MultiRegionMultiMetricChart = ({
     </Stack>
   );
 };
+
+const getMetricId = (metric: Metric) => metric.id;
+const getMetricLabel = (metric: Metric) => metric.name;
+const getRegionLabel = (region: Region) => region.shortName;
+const getRegionValue = (region: Region) => region.regionId;
+const getPeriodLabel = (period: TimePeriod) => period.label;
 
 const EmptyState = ({ width, height }: { width: number; height: number }) => (
   <Box

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.tsx
@@ -41,7 +41,7 @@ export const MultiRegionMultiMetricChart = ({
   metrics: metricsOrIds,
   initialMetric: initialMetricOrId,
   initialRegions,
-  timePeriods,
+  timePeriods: customTimePeriods,
   initialTimePeriod,
   height = 500,
   marginRight = 160,
@@ -57,12 +57,15 @@ export const MultiRegionMultiMetricChart = ({
     getMetricId
   );
 
-  const periods = timePeriods ?? getDefaultTimePeriods(new Date());
-  const defaultPeriod = initialTimePeriod ?? periods[periods.length - 1];
+  const timePeriods = customTimePeriods ?? getDefaultTimePeriods(new Date());
+  const initialPeriod =
+    customTimePeriods && initialTimePeriod
+      ? initialTimePeriod
+      : timePeriods[timePeriods.length - 1];
 
   const [selectedPeriod, setSelectedPeriod] = useSelect(
-    periods,
-    defaultPeriod,
+    timePeriods,
+    initialPeriod,
     getPeriodLabel
   );
 
@@ -82,7 +85,7 @@ export const MultiRegionMultiMetricChart = ({
       />
       <Select
         label="Past number of days"
-        options={periods}
+        options={timePeriods}
         selectedOption={selectedPeriod}
         onSelectOption={setSelectedPeriod}
         getLabel={getPeriodLabel}
@@ -120,7 +123,16 @@ export const MultiRegionMultiMetricChart = ({
 };
 
 const EmptyState = ({ width, height }: { width: number; height: number }) => (
-  <Box sx={{ width, height, display: "grid", placeItems: "center" }}>
+  <Box
+    sx={{
+      width,
+      height,
+      display: "grid",
+      placeItems: "center",
+      backgroundColor: "action.disabledBackground",
+      borderRadius: 1,
+    }}
+  >
     <Typography variant="labelSmall" component="div">
       Please select at least one location
     </Typography>

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -19,7 +19,12 @@ export function getMetricSeries(metric: Metric, regions: Region[]): Series[] {
 }
 
 export interface TimePeriod {
+  /** Label to show in the dropdown */
   label: string;
+  /**
+   * Date range to filter the series by. If undefined, it doesn't
+   * filter the timeseries.
+   * */
   dateRange?: DateRange;
 }
 

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -1,7 +1,8 @@
 import { schemeCategory10 } from "d3-scale-chromatic";
 
-import { Metric } from "@actnowcoalition/metrics";
+import { DateRange, Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
+import { TimeUnit, subtractTime } from "@actnowcoalition/time-utils";
 
 import { Series, SeriesType } from "../SeriesChart";
 
@@ -15,4 +16,23 @@ export function getMetricSeries(metric: Metric, regions: Region[]): Series[] {
       stroke: schemeCategory10[index % schemeCategory10.length],
     },
   }));
+}
+
+export interface TimePeriod {
+  label: string;
+  dateRange?: DateRange;
+}
+
+export function getDefaultTimePeriods(date: Date): TimePeriod[] {
+  return [
+    {
+      label: "60",
+      dateRange: { startAt: subtractTime(date, 60, TimeUnit.DAYS) },
+    },
+    {
+      label: "180",
+      dateRange: { startAt: subtractTime(date, 180, TimeUnit.DAYS) },
+    },
+    { label: "All time", dateRange: undefined },
+  ];
 }


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/413

Follow up to implement date filtering for `MultiRegionMultiMetricChart`. I added the same defaults as CAN, but the time periods and labels can be customized as well.

- [Storybook · `MultiRegionMultiMetricChart`](https://act-now-packages--pr488-pablo-trends-filter-zdoarisn.web.app/storybook/index.html?path=/story/components-multiregionmultimetricchart--example)

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/114084/207150810-746f0377-cb95-41bc-bbb3-0e3612cfa267.png">
