### PR TITLE
Fix keyboard navigation on RegionSearch

### DIFF
--- a/.changeset/chilled-beds-taste.md
+++ b/.changeset/chilled-beds-taste.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix RegionSearch keyboard navigation

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.style.ts
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.style.ts
@@ -1,7 +1,5 @@
-import { Link } from "@mui/material";
-
 import { styled } from "../../styles";
 
-export const StyledLink = styled(Link)`
-  text-decoration: none;
+export const StyledListItem = styled("li")`
+  width: 100%;
 `;

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -3,6 +3,7 @@ import React, { HTMLAttributes } from "react";
 import SearchIcon from "@mui/icons-material/Search";
 import {
   Autocomplete,
+  AutocompleteChangeReason,
   AutocompleteProps,
   TextField,
   createFilterOptions,
@@ -59,7 +60,11 @@ export const RegionSearch = ({
   return (
     <Autocomplete
       options={options}
-      onChange={(e, region: Region | null, reason: string) => {
+      onChange={(
+        e,
+        region: Region | null,
+        reason: AutocompleteChangeReason
+      ) => {
         if (region && reason === "selectOption") {
           // Typescript doesn't allow to assign a string to window.location
           // https://github.com/microsoft/TypeScript/issues/48949

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -61,7 +61,9 @@ export const RegionSearch = ({
       options={options}
       onChange={(e, region: Region | null, reason: string) => {
         if (region && reason === "selectOption") {
-          window.location.href = regionDB.getRegionUrl(region);
+          // Typescript doesn't allow to assign a string to window.location
+          // https://github.com/microsoft/TypeScript/issues/48949
+          (window as any).location = regionDB.getRegionUrl(region);
         }
       }}
       clearIcon={<></>}

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -12,17 +12,11 @@ import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { formatPopulation } from "../../common/utils";
 import { SearchItem } from "../SearchItem";
-import { StyledLink } from "./RegionSearch.style";
+import { StyledListItem } from "./RegionSearch.style";
 
 function stringifyOption(region: Region) {
   return region.fullName;
 }
-
-const onChange = (item: Region | null) => {
-  if (item && item.relativeUrl) {
-    window.location.href = item.relativeUrl;
-  }
-};
 
 export type CustomAutocompleteProps = AutocompleteProps<
   Region,
@@ -65,17 +59,20 @@ export const RegionSearch = ({
   return (
     <Autocomplete
       options={options}
-      onChange={(e, item: Region | null) => onChange(item)}
+      onChange={(e, region: Region | null, reason: string) => {
+        if (region && reason === "selectOption") {
+          window.location.href = regionDB.getRegionUrl(region);
+        }
+      }}
       clearIcon={<></>}
       renderInput={customRenderInput ?? defaultRenderInput}
       renderOption={(props: HTMLAttributes<HTMLLIElement>, option: Region) => (
-        <StyledLink href={regionDB.getRegionUrl(option)}>
+        <StyledListItem {...props}>
           <SearchItem
             itemLabel={option.shortName}
             itemSublabel={`${formatPopulation(option.population)} population`}
-            {...props}
           />
-        </StyledLink>
+        </StyledListItem>
       )}
       getOptionLabel={stringifyOption}
       filterOptions={createFilterOptions({

--- a/packages/ui-components/src/components/SearchItem/SearchItem.style.tsx
+++ b/packages/ui-components/src/components/SearchItem/SearchItem.style.tsx
@@ -21,12 +21,9 @@ export const ArrowIcon = styled(ArrowForwardIosIcon)`
 `;
 
 export const Container = styled(Box)`
+  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: ${({ theme }) => theme.spacing(1, 1.5)};
-
-  &:hover {
-    background-color: ${({ theme }) => theme.palette.action.hover};
-  }
+  padding: ${({ theme }) => theme.spacing(0.5, 0)};
 `;


### PR DESCRIPTION
Close https://github.com/covid-projections/act-now-packages/issues/363 - Fix keyboard navigation on `RegionSearch`

The function passed to `renderOption` needs to return a list item, and inject a couple of accessibility props and event handlers that make all work. We were using links which were working when the user clicks on the items, but would interfere with the focus status of each list item, so I updated `onChange` and remove the styled link.

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/114084/207221158-f3a84f38-8a2f-418e-b681-a11e907df916.png">

I updated the styles a bit to match the current style and removed the hover styling on the `SearchItem` since the styles injected on the list item already have some padding and hove styling.