### PR TITLE
Dark theme improvements

### DIFF
--- a/.changeset/pretty-dragons-type.md
+++ b/.changeset/pretty-dragons-type.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Create palette story for dark theme and minor dark theme fixes

--- a/packages/ui-components/src/stories/Palette.stories.tsx
+++ b/packages/ui-components/src/stories/Palette.stories.tsx
@@ -51,6 +51,8 @@ const ColorBox = ({ color }: { color: string }) => (
   />
 );
 
+const NON_COLOR_PROPERTIES = ["mode", "getContrastText", "augmentColor"];
+
 // Filter out the palette attributes that don't correspond to colors,
 // such as functions or numeric constants. The `mode` attribute is
 // a string to name themes (dark, light, highContrast), but not a color,
@@ -58,7 +60,7 @@ const ColorBox = ({ color }: { color: string }) => (
 function getPaletteGroups(theme: Theme) {
   const paletteGroups = (Object.keys(theme.palette) as (keyof Palette)[])
     .filter((name) => isObject(theme.palette[name]))
-    .filter((name) => name !== "mode")
+    .filter((name) => !NON_COLOR_PROPERTIES.includes(name))
     .map((name) => {
       const colorGroup = theme.palette[name] as Record<string, string>;
       const colorGroupKeys = Object.keys(colorGroup);

--- a/packages/ui-components/src/stories/Palette.stories.tsx
+++ b/packages/ui-components/src/stories/Palette.stories.tsx
@@ -1,49 +1,18 @@
 import React from "react";
-
 import { Box, Grid, Palette, Stack, Typography } from "@mui/material";
 import isObject from "lodash/isObject";
-
-import theme from "../styles/theme";
+import darkTheme from "../styles/theme/dark-theme";
+import lightTheme from "../styles/theme";
+import { Theme } from "@mui/material";
 
 export default {
   title: "Design System/Palette",
 };
 
-// Filter out the palette attributes that don't correspond to colors,
-// such as functions or numeric constants. The `mode` attribute is
-// a string to name themes (dark, light, highContrast), but not a color,
-// so we filter that out as well.
-const paletteGroups = (Object.keys(theme.palette) as (keyof Palette)[])
-  .filter((name) => isObject(theme.palette[name]))
-  .filter((name) => name !== "mode")
-  .map((name) => {
-    const colorGroup = theme.palette[name] as Record<string, string>;
-    const colorGroupKeys = Object.keys(colorGroup);
-    const colors = colorGroupKeys.map((key) => {
-      return {
-        name: `theme.palette.${name}.${key}`,
-        color: colorGroup[key],
-      };
-    });
-    return { name, colors };
-  });
-
 interface ColorInfo {
   name: string;
   color: string;
 }
-
-export const All = () => (
-  <>
-    {paletteGroups.map((group) => (
-      <ColorGroup
-        key={group.name}
-        colorGroupName={group.name}
-        colorInfoList={group.colors}
-      />
-    ))}
-  </>
-);
 
 const ColorGroup = ({
   colorGroupName,
@@ -75,9 +44,58 @@ const ColorBox = ({ color }: { color: string }) => (
     style={{
       width: 48,
       height: 48,
-      border: `solid 1px ${theme.palette.border.default}`,
-      borderRadius: theme.shape.borderRadius,
+      border: `solid 1px ${lightTheme.palette.border.default}`,
+      borderRadius: lightTheme.shape.borderRadius,
       backgroundColor: color,
     }}
   />
+);
+
+// Filter out the palette attributes that don't correspond to colors,
+// such as functions or numeric constants. The `mode` attribute is
+// a string to name themes (dark, light, highContrast), but not a color,
+// so we filter that out as well.
+function getPaletteGroups(theme: Theme) {
+  const paletteGroups = (Object.keys(theme.palette) as (keyof Palette)[])
+    .filter((name) => isObject(theme.palette[name]))
+    .filter((name) => name !== "mode")
+    .map((name) => {
+      const colorGroup = theme.palette[name] as Record<string, string>;
+      const colorGroupKeys = Object.keys(colorGroup);
+      const colors = colorGroupKeys.map((key) => {
+        return {
+          name: `theme.palette.${name}.${key}`,
+          color: colorGroup[key],
+        };
+      });
+      return { name, colors };
+    });
+  return paletteGroups;
+}
+
+const lightPaletteGroups = getPaletteGroups(lightTheme);
+const darkPaletteGroups = getPaletteGroups(darkTheme);
+
+export const LightMode = () => (
+  <>
+    {lightPaletteGroups.map((group) => (
+      <ColorGroup
+        key={group.name}
+        colorGroupName={group.name}
+        colorInfoList={group.colors}
+      />
+    ))}
+  </>
+);
+
+export const DarkMode = () => (
+  <>
+    {darkPaletteGroups.map((group) => (
+      <ColorGroup
+        key={group.name}
+        colorGroupName={group.name}
+        colorInfoList={group.colors}
+      />
+    ))}
+  </>
 );

--- a/packages/ui-components/src/styles/theme/dark-theme.tsx
+++ b/packages/ui-components/src/styles/theme/dark-theme.tsx
@@ -53,6 +53,15 @@ const darkThemeConfig = {
     h3: {
       color: "#fff",
     },
+    h4: {
+      color: "#fff",
+    },
+    h5: {
+      color: "#fff",
+    },
+    h6: {
+      color: "#fff",
+    },
     dataEmphasizedSmall: {
       color: "#fff",
     },
@@ -68,11 +77,79 @@ const darkThemeConfig = {
     labelSmall: {
       color: "#fff",
     },
+    paragraphLarge: {
+      color: "#fff",
+    },
     paragraphSmall: {
+      color: "#fff",
+    },
+    overline: {
       color: "#fff",
     },
   },
   components: {
+    MuiButton: {
+      styleOverrides: {
+        containedPrimary: ({ theme }: { theme: Theme }) => ({
+          "&: hover": {
+            backgroundColor: theme.palette.grey[500],
+          },
+        }),
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        label: ({ theme }: { theme: Theme }) => ({
+          ...theme.typography.labelSmall,
+          color: theme.palette.common.white,
+        }),
+      },
+    },
+    MuiTabs: {
+      styleOverrides: {
+        indicator: ({ theme }: { theme: Theme }) => ({
+          height: "2px",
+          backgroundColor: theme.palette.common.white,
+        }),
+      },
+    },
+    MuiToggleButtonGroup: {
+      styleOverrides: {
+        groupedHorizontal: ({ theme }: { theme: Theme }) => ({
+          border: "none",
+          color: theme.typography.paragraphSmall.color,
+          textTransform: "none",
+          borderBottom: `solid 2px transparent`,
+          ":not(:first-of-type)": {
+            borderLeft: "none",
+          },
+          "&.Mui-selected": {
+            ...theme.typography.labelSmall,
+            borderBottom: `solid 2px ${theme.palette.common.white}`,
+            backgroundColor: "transparent",
+          },
+        }),
+        groupedVertical: ({ theme }: { theme: Theme }) => ({
+          borderLeft: "none",
+          borderRight: "none",
+          borderTop: "none",
+          borderBottom: "none",
+          color: theme.typography.paragraphSmall.color,
+          textTransform: "none",
+          ":first-of-type": {
+            borderTop: "none",
+          },
+          ":last-of-type": {
+            borderBottom: "none",
+          },
+          "&.Mui-selected": {
+            ...theme.typography.labelSmall,
+            borderRight: `solid 2px ${theme.palette.common.white}`,
+            backgroundColor: "transparent",
+          },
+        }),
+      },
+    },
     MuiTextField: {
       styleOverrides: {
         root: ({ theme }: { theme: Theme }) => ({
@@ -83,7 +160,6 @@ const darkThemeConfig = {
         }),
       },
     },
-
     MuiTable: {
       styleOverrides: {
         root: ({ theme }: { theme: Theme }) => ({


### PR DESCRIPTION
Create a story for dark theme palette.

Minor tweaks to the following components for dark theme. The goal is just to make the component more visible for now, but specific color choices can probably be determined with Josh's guidance.
- Contained button hover state
- Chip
- Indicator color on tab component
- Indicator color on toggle button
- Color for h4, h5, h6, paragraphLarge, and overline typography

Relates to https://github.com/covid-projections/act-now-packages/issues/452