### PR TITLE
Documentation cleanup pt. 2

### DIFF
--- a/.changeset/swift-tools-whisper.md
+++ b/.changeset/swift-tools-whisper.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Clean up prop documentation cont.

--- a/packages/ui-components/src/common/utils/maps.ts
+++ b/packages/ui-components/src/common/utils/maps.ts
@@ -5,12 +5,14 @@ export interface BaseMapProps {
    * Function that returns tooltip content for the region corresponding to a given regionId.
    *
    * @param regionId - RegionId of the region for which to get tooltip content.
+   * @returns Tooltip content for the region.
    */
   getTooltip: (regionId: string) => React.ReactNode;
   /**
    * Function that returns the fill color for a region's shape, given the region's regionId.
    *
    * @param regionId - RegionId of the region for which to get the fill color.
+   * @returns Fill color for the region.
    */
   getFillColor?: (regionId: string) => string;
   /**
@@ -18,6 +20,7 @@ export interface BaseMapProps {
    * @default undefined
    *
    * @param regionId - RegionId of the region for which to get the regionUrl.
+   * @returns Region URL for the region.
    */
   getRegionUrl?: (regionId: string) => string | undefined;
   /**

--- a/packages/ui-components/src/common/utils/maps.ts
+++ b/packages/ui-components/src/common/utils/maps.ts
@@ -4,20 +4,20 @@ export interface BaseMapProps {
   /**
    * Function that returns tooltip content for the region corresponding to a given regionId.
    *
-   * @param {string} regionId RegionId of the region for which to get tooltip content.
+   * @param regionId - RegionId of the region for which to get tooltip content.
    */
   getTooltip: (regionId: string) => React.ReactNode;
   /**
    * Function that returns the fill color for a region's shape, given the region's regionId.
    *
-   * @param {string} regionId RegionId of the region for which to get the fill color.
+   * @param regionId - RegionId of the region for which to get the fill color.
    */
   getFillColor?: (regionId: string) => string;
   /**
    * Function that returns the `regionUrl` for the region corresponding to a given regionId.
    * @default undefined
    *
-   * @param {string} regionId RegionId of the region for which to get the regionUrl.
+   * @param regionId - RegionId of the region for which to get the regionUrl.
    */
   getRegionUrl?: (regionId: string) => string | undefined;
   /**

--- a/packages/ui-components/src/components/Axis/Axis.style.tsx
+++ b/packages/ui-components/src/components/Axis/Axis.style.tsx
@@ -8,14 +8,14 @@ import typography from "../../styles/theme/typography";
 
 export type AxisLeftProps = React.ComponentProps<typeof VxAxisLeft> & {
   /**
-   * The className applied to the outermost axis group element.
+   * ClassName applied to the outermost axis group element.
    */
   className?: string;
 };
 
 export type AxisBottomProps = React.ComponentProps<typeof VxAxisBottom> & {
   /**
-   * The className applied to the outermost axis group element.
+   * ClassName applied to the outermost axis group element.
    */
   className?: string;
   /**

--- a/packages/ui-components/src/components/Axis/Axis.style.tsx
+++ b/packages/ui-components/src/components/Axis/Axis.style.tsx
@@ -8,14 +8,14 @@ import typography from "../../styles/theme/typography";
 
 export type AxisLeftProps = React.ComponentProps<typeof VxAxisLeft> & {
   /**
-   * ClassName applied to the outermost axis group element.
+   * Class name applied to the outermost axis group element.
    */
   className?: string;
 };
 
 export type AxisBottomProps = React.ComponentProps<typeof VxAxisBottom> & {
   /**
-   * ClassName applied to the outermost axis group element.
+   * Class name applied to the outermost axis group element.
    */
   className?: string;
   /**

--- a/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/ChartOverlayX.tsx
@@ -15,7 +15,7 @@ export interface ChartOverlayXProps {
   /**
    * Callback fired when the cursor moves over the overlay.
    *
-   * @param {Date} date The date being hovered.
+   * @param date - The date being hovered.
    */
   onMouseMove: ({ date }: { date: Date }) => void;
   /**

--- a/packages/ui-components/src/components/ChartOverlayX/useHoveredDate.tsx
+++ b/packages/ui-components/src/components/ChartOverlayX/useHoveredDate.tsx
@@ -31,7 +31,7 @@ import { ChartOverlayXProps } from "./ChartOverlayX";
  * );
  * ```
  *
- * @param {Timeseries<T> | undefined} timeseries A timeseries of points that can be hovered, or undefined.
+ * @param timeseries - A timeseries of points that can be hovered, or undefined.
  * @returns The hovered point information and the `onMouseMove` and `onMouseLeave` callbacks.
  */
 

--- a/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
+++ b/packages/ui-components/src/components/ChartOverlayXY/ChartOverlayXY.tsx
@@ -33,7 +33,7 @@ export interface ChartOverlayXYProps {
   /**
    * Callback fired when the cursor moves over the overlay.
    *
-   * @param {HoveredPointInfo} pointInfo Information about the point being hovered.
+   * @param pointInfo - Information about the point being hovered.
    **/
   onMouseMove?: (pointInfo: HoveredPointInfo) => void;
   /**

--- a/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
+++ b/packages/ui-components/src/components/ChartOverlayXY/useHoveredPoint.ts
@@ -40,7 +40,7 @@ import { ChartOverlayXYProps, HoveredPointInfo } from "./ChartOverlayXY";
  * );
  * ```
  *
- * @param {Timeseries<T>[] | undefined} timeseriesList An array of timeseries of points that can be hovered, or undefined.
+ * @param timeseriesList - Array of timeseries of points that can be hovered, or undefined.
  * @returns The hovered point information and the `onMouseMove` and `onMouseLeave` callbacks.
  */
 export function useHoveredPoint<T>(

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -13,14 +13,14 @@ export interface LegendCategoricalProps<T> {
   /**
    * Function that returns the legend item's color.
    *
-   * @param {T} item The legend item.
+   * @typeParam {T} item The legend item.
    * @param {number} itemIndex Index of the legend item.
    */
   getItemColor: (item: T, itemIndex: number) => string;
   /**
    * Function that returns the legend item's label.
    *
-   * @param {T} item The legend item.
+   * @typeParam {T} item The legend item.
    * @param {number} itemIndex Index of the legend item.
    */
   getItemLabel: (item: T, itemIndex: number) => string;

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -13,9 +13,9 @@ export interface LegendCategoricalProps<T> {
   /**
    * Function that returns the legend item's color.
    *
-   * @param T - item The legend item.
+   * @param item - The legend item.
    * @param itemIndex - Index of the legend item.
-   * @returns item color
+   * @returns The item color.
    */
   getItemColor: (item: T, itemIndex: number) => string;
   /**
@@ -23,6 +23,7 @@ export interface LegendCategoricalProps<T> {
    *
    * @param item - The legend item.
    * @param itemIndex - Index of the legend item.
+   * @returns The item label.
    */
   getItemLabel: (item: T, itemIndex: number) => string;
   /**

--- a/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
+++ b/packages/ui-components/src/components/LegendCategorical/LegendCategorical.tsx
@@ -13,15 +13,16 @@ export interface LegendCategoricalProps<T> {
   /**
    * Function that returns the legend item's color.
    *
-   * @typeParam {T} item The legend item.
-   * @param {number} itemIndex Index of the legend item.
+   * @param T - item The legend item.
+   * @param itemIndex - Index of the legend item.
+   * @returns item color
    */
   getItemColor: (item: T, itemIndex: number) => string;
   /**
    * Function that returns the legend item's label.
    *
-   * @typeParam {T} item The legend item.
-   * @param {number} itemIndex Index of the legend item.
+   * @param item - The legend item.
+   * @param itemIndex - Index of the legend item.
    */
   getItemLabel: (item: T, itemIndex: number) => string;
   /**

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -41,29 +41,29 @@ export interface LegendThresholdProps<T> extends BaseLegendThresholdProps {
   /**
    * Function that returns the legend item's color.
    *
-   * @typeParam {T} item The legend item.
-   * @param {number} itemIndex Index of the legend item.
+   * @param item - The legend item.
+   * @param itemIndex - Index of the legend item.
    */
   getItemColor: (item: T, itemIndex: number) => string;
   /**
    * Function that returns the legend item's label.
    *
-   * @typeParam {T} item The legend item.
-   * @param {number} itemIndex Index of the legend item.
+   * @param item - The legend item.
+   * @param itemIndex - Index of the legend item.
    */
   getItemLabel?: (item: T, itemIndex: number) => string;
   /**
    * Function that returns the legend item's sublabel.
    *
-   * @typeParam {T} item The legend item.
-   * @param {number} itemIndex Index of the legend item.
+   * @param item - The legend item.
+   * @param itemIndex - Index of the legend item.
    */
   getItemSublabel?: (item: T, itemIndex: number) => string;
   /**
    * Function that returns whether or not to show an indicator of the current value.
    *
-   * @typeParam {T} item The legend item.
-   * @param {number} itemIndex Index of the legend item.
+   * @param item - The legend item.
+   * @param itemIndex - Index of the legend item.
    */
   getItemShowIndicator?: (item: T, itemIndex: number) => boolean | undefined;
 }

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -41,28 +41,28 @@ export interface LegendThresholdProps<T> extends BaseLegendThresholdProps {
   /**
    * Function that returns the legend item's color.
    *
-   * @param {T} item The legend item.
+   * @typeParam {T} item The legend item.
    * @param {number} itemIndex Index of the legend item.
    */
   getItemColor: (item: T, itemIndex: number) => string;
   /**
    * Function that returns the legend item's label.
    *
-   * @param {T} item The legend item.
+   * @typeParam {T} item The legend item.
    * @param {number} itemIndex Index of the legend item.
    */
   getItemLabel?: (item: T, itemIndex: number) => string;
   /**
    * Function that returns the legend item's sublabel.
    *
-   * @param {T} item The legend item.
+   * @typeParam {T} item The legend item.
    * @param {number} itemIndex Index of the legend item.
    */
   getItemSublabel?: (item: T, itemIndex: number) => string;
   /**
    * Function that returns whether or not to show an indicator of the current value.
    *
-   * @param {T} item The legend item.
+   * @typeParam {T} item The legend item.
    * @param {number} itemIndex Index of the legend item.
    */
   getItemShowIndicator?: (item: T, itemIndex: number) => boolean | undefined;

--- a/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThreshold.tsx
@@ -43,6 +43,7 @@ export interface LegendThresholdProps<T> extends BaseLegendThresholdProps {
    *
    * @param item - The legend item.
    * @param itemIndex - Index of the legend item.
+   * @returns The item color.
    */
   getItemColor: (item: T, itemIndex: number) => string;
   /**
@@ -50,6 +51,7 @@ export interface LegendThresholdProps<T> extends BaseLegendThresholdProps {
    *
    * @param item - The legend item.
    * @param itemIndex - Index of the legend item.
+   * @returns The item label.
    */
   getItemLabel?: (item: T, itemIndex: number) => string;
   /**
@@ -57,6 +59,7 @@ export interface LegendThresholdProps<T> extends BaseLegendThresholdProps {
    *
    * @param item - The legend item.
    * @param itemIndex - Index of the legend item.
+   * @returns The item sublabel.
    */
   getItemSublabel?: (item: T, itemIndex: number) => string;
   /**
@@ -64,6 +67,7 @@ export interface LegendThresholdProps<T> extends BaseLegendThresholdProps {
    *
    * @param item - The legend item.
    * @param itemIndex - Index of the legend item.
+   * @returns Whether or not to show the indicator.
    */
   getItemShowIndicator?: (item: T, itemIndex: number) => boolean | undefined;
 }

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
@@ -45,8 +45,8 @@ const MetricCatalogContext = createContext<MetricCatalog>(defaultMetricCatalog);
  *   // ...render component
  * ```
  *
- * @param metricCatalog The MetricCatalog instance that we want to make available.
- * @param children The component tree that we want to have access to the metric catalog.
+ * @param metricCatalog - The MetricCatalog instance that we want to make available.
+ * @param children - The component tree that we want to have access to the metric catalog.
  * @returns React.ContextProvider with the given metricCatalog
  */
 

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricCatalogContext.tsx
@@ -6,6 +6,17 @@ const defaultMetricCatalog = new MetricCatalog([], []);
 
 const MetricCatalogContext = createContext<MetricCatalog>(defaultMetricCatalog);
 
+export interface MetricCatalogProviderProps {
+  /**
+   * The MetricCatalog passed to the MetricCatalogContext Provider.
+   */
+  metricCatalog: MetricCatalog;
+  /**
+   * The content wrapped by the MetricCatalogContext Provider.
+   */
+  children: React.ReactNode;
+}
+
 /**
  * The `MetricCatalogProvider` component and `useMetricCatalog` hook provide
  * convenient access to the app-level `metricCatalog` instance. It relies on
@@ -49,17 +60,6 @@ const MetricCatalogContext = createContext<MetricCatalog>(defaultMetricCatalog);
  * @param children - The component tree that we want to have access to the metric catalog.
  * @returns React.ContextProvider with the given metricCatalog
  */
-
-export interface MetricCatalogProviderProps {
-  /**
-   * The MetricCatalog passed to the MetricCatalogContext Provider.
-   */
-  metricCatalog: MetricCatalog;
-  /**
-   * The content wrapped by the MetricCatalogContext Provider.
-   */
-  children: React.ReactNode;
-}
 
 export const MetricCatalogProvider = ({
   metricCatalog,

--- a/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/utils.ts
@@ -50,11 +50,11 @@ export interface ChartInterval extends LineInterval {
  * If necessary, we adjust the upper bound of the last interval in the same way as
  * we do for the first interval.
  *
- * @param {Category[]} metricCategories Array of metric categories.
- * @param {number[]} thresholds Array of thresholds.
- * @param {number} minValue Minimum value to show in the chart.
- * @param {number} maxValue Maximum value to show in the chart.
- * @returns {ChartInterval[]} List of chart intervals.
+ * @param metricCategories - Array of metric categories.
+ * @param thresholds - Array of thresholds.
+ * @param minValue - Minimum value to show in the chart.
+ * @param maxValue - Maximum value to show in the chart.
+ * @returns List of chart intervals.
  */
 
 export function calculateChartIntervals(

--- a/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -68,9 +68,9 @@ export interface MetricProgressBarItem {
  * `getProgressBarItems` converts data for two metrics into an array of
  * two items formatted to be passed into MultiProgressBar.
  *
- * @param {MultiMetricDataStore} data A metric data store containing data for multiple metrics for a given region.
- * @param {[MetricProp, MetricProp]} metrics Two metrics to convert into MetricProgressBarItem
- * @returns {[MetricProgressBarItem, MetricProgressBarItem]}
+ * @param data - A metric data store containing data for multiple metrics for a given region.
+ * @param metrics - Array of two metrics to convert into MetricProgressBarItem.
+ * @returns Array of two items of metric information formatted for the progress bar.
  */
 
 function getProgressBarItems(

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -235,8 +235,8 @@ export const MetricSeriesChart = ({
 /**
  * `getDateRange` returns the date range that covers the provided timeseries.
  *
- * @param {Timeseries<unknown>[]} timeseriesList Array of timeseries.
- * @returns {[Date, Date]} [minDate, maxDate]
+ * @param timeseriesList - Array of timeseries.
+ * @returns [minDate, maxDate]
  */
 
 function getDateRange(timeseriesList: Timeseries<unknown>[]): [Date, Date] {
@@ -254,8 +254,8 @@ function getDateRange(timeseriesList: Timeseries<unknown>[]): [Date, Date] {
 /**
  * `getValueRange` returns the range of values that covers the provided timeseries.
  *
- * @param {Timeseries<number>[]} timeseriesList Array of timeseries.
- * @returns {[number, number]} [minValue, maxValue]
+ * @param timeseriesList - Array of timeseries.
+ * @returns [minValue, maxValue]
  */
 
 function getValueRange(timeseriesList: Timeseries<number>[]): [number, number] {

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
@@ -36,6 +36,7 @@ export interface MultiMetricUSStateMapProps {
    * Function that returns tooltip content for the region corresponding to a given regionId.
    *
    * @param regionId - RegionId of the region for which to get tooltip content.
+   * @returns Tooltip content for the region.
    */
   getTooltip?: (regionId: string) => React.ReactNode;
 }

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
@@ -35,7 +35,7 @@ export interface MultiMetricUSStateMapProps {
   /**
    * Function that returns tooltip content for the region corresponding to a given regionId.
    *
-   * @param {string} regionId RegionId of the region for which to get tooltip content.
+   * @param regionId - RegionId of the region for which to get tooltip content.
    */
   getTooltip?: (regionId: string) => React.ReactNode;
 }

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
@@ -52,12 +52,14 @@ export interface MultiProgressBarProps<T> extends BaseMultiProgressBarProps {
    * Function that returns the progress bar item's label.
    *
    * @param item - The progress bar item.
+   * @returns The item label.
    */
   getItemLabel: (item: T) => string;
   /**
    * Function that returns the progress bar item's value.
    *
    * @param item - The progress bar item.
+   * @returns The item value.
    */
   getItemValue: (item: T) => number;
 }

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
@@ -51,13 +51,13 @@ export interface MultiProgressBarProps<T> extends BaseMultiProgressBarProps {
   /**
    * Function that returns the progress bar item's label.
    *
-   * @param {T} item The progress bar item.
+   * @typeParam {T} item The progress bar item.
    */
   getItemLabel: (item: T) => string;
   /**
    * Function that returns the progress bar item's value.
    *
-   * @param {T} item The progress bar item.
+   * @typeParam {T} item The progress bar item.
    */
   getItemValue: (item: T) => number;
 }

--- a/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
+++ b/packages/ui-components/src/components/MultiProgressBar/MultiProgressBar.tsx
@@ -51,13 +51,13 @@ export interface MultiProgressBarProps<T> extends BaseMultiProgressBarProps {
   /**
    * Function that returns the progress bar item's label.
    *
-   * @typeParam {T} item The progress bar item.
+   * @param item - The progress bar item.
    */
   getItemLabel: (item: T) => string;
   /**
    * Function that returns the progress bar item's value.
    *
-   * @typeParam {T} item The progress bar item.
+   * @param item - The progress bar item.
    */
   getItemValue: (item: T) => number;
 }

--- a/packages/ui-components/src/components/USNationalMap/CanvasMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/CanvasMap.tsx
@@ -21,6 +21,7 @@ export interface CanvasMapProps {
    * given the corresponding region's regionId.
    *
    * @param regionId - RegionId corresponding to the shape being colored.
+   * @returns Fill color for the region.
    */
   getFillColor: (regionId: string) => string;
   /**
@@ -35,6 +36,7 @@ export interface CanvasMapProps {
    * Function that returns the geoId of a given feature.
    *
    * @param geo - The feature of which we are getting the geoId.
+   * @returns GeoId of the feature.
    */
   getGeoId: (geo: ExtendedFeature) => string;
 }

--- a/packages/ui-components/src/components/USNationalMap/CanvasMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/CanvasMap.tsx
@@ -20,7 +20,7 @@ export interface CanvasMapProps {
    * Function that returns the fill color for a shape,
    * given the corresponding region's regionId.
    *
-   * @param {string} regionId RegionId corresponding to the shape being colored.
+   * @param regionId - RegionId corresponding to the shape being colored.
    */
   getFillColor: (regionId: string) => string;
   /**
@@ -34,7 +34,7 @@ export interface CanvasMapProps {
   /**
    * Function that returns the geoId of a given feature.
    *
-   * @param {ExtendedFeature} geo The feature of which we are getting the geoId.
+   * @param geo - The feature of which we are getting the geoId.
    */
   getGeoId: (geo: ExtendedFeature) => string;
 }

--- a/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
@@ -24,6 +24,7 @@ export interface StatesMapProps {
    * Function that returns tooltip content for the region corresponding to a given regionId.
    *
    * @param regionId - RegionId of the region for which to get tooltip content.
+   * @returns Tooltip content for the region.
    */
   getTooltip: (regionId: string) => React.ReactNode;
   /**
@@ -34,6 +35,7 @@ export interface StatesMapProps {
    * Function that returns the fill color for a region's shape, given the region's regionId.
    *
    * @param regionId - RegionId of the region for which to get the fill color.
+   * @returns Fill color for the region.
    */
   getFillColor: (regionId: string) => string;
   /**
@@ -41,6 +43,7 @@ export interface StatesMapProps {
    * @default undefined
    *
    * @param regionId - RegionId of the region for which to get the regionUrl.
+   * @returns Region URL for the region.
    */
   getRegionUrl?: (regionId: string) => string | undefined;
 }

--- a/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
@@ -23,7 +23,7 @@ export interface StatesMapProps {
   /**
    * Function that returns tooltip content for the region corresponding to a given regionId.
    *
-   * @param {string} regionId RegionId of the region for which to get tooltip content.
+   * @param regionId - RegionId of the region for which to get tooltip content.
    */
   getTooltip: (regionId: string) => React.ReactNode;
   /**
@@ -33,14 +33,14 @@ export interface StatesMapProps {
   /**
    * Function that returns the fill color for a region's shape, given the region's regionId.
    *
-   * @param {string} regionId RegionId of the region for which to get the fill color.
+   * @param regionId - RegionId of the region for which to get the fill color.
    */
   getFillColor: (regionId: string) => string;
   /**
    * Function that returns the `regionUrl` for the region corresponding to a given regionId.
    * @default undefined
    *
-   * @param {string} regionId RegionId of the region for which to get the regionUrl.
+   * @param regionId - RegionId of the region for which to get the regionUrl.
    */
   getRegionUrl?: (regionId: string) => string | undefined;
 }

--- a/packages/ui-components/src/components/WorldMap/WorldMap.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.tsx
@@ -19,7 +19,7 @@ export interface WorldMapProps extends BaseMapProps {
    * Function that returns the fill opacity for a region's shape, given the region's geoId.
    * @default 1
    *
-   * @param {string} geoId GeoId of the region for which to get the fill opacity.
+   * @param geoId - GeoId of the region for which to get the fill opacity.
    */
   getFillOpacity?: (geoId: string) => number;
 }

--- a/packages/ui-components/src/components/WorldMap/WorldMap.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.tsx
@@ -20,6 +20,7 @@ export interface WorldMapProps extends BaseMapProps {
    * @default 1
    *
    * @param geoId - GeoId of the region for which to get the fill opacity.
+   * @returns Fill opacity for the region.
    */
   getFillOpacity?: (geoId: string) => number;
 }


### PR DESCRIPTION
A continuation of documentation cleanup in #491. Changes made in this PR:
- Remove the redundant type declarations from after `@param` (replaces with ` - ` as used in [the example in TSDoc docs](https://tsdoc.org/pages/tags/returns/)
- Add `@returns` documentation for functional props

For now, I've nixed the plan of replacing `@default` with `@defaultValue` and `@param` with `@typeParam` (in the case of generics) because these changes were making the values appear as regular comments and not as highlighted values (see screenshot below). We can discuss this more after break, when I write up our conventions and put them into a readme of some sort.

<img width="332" alt="Screen Shot 2022-12-15 at 7 55 36 PM" src="https://user-images.githubusercontent.com/44076375/207997746-73a99e4d-c2d0-4f0a-9039-028f706cf51b.png">

<img width="323" alt="Screen Shot 2022-12-15 at 7 55 46 PM" src="https://user-images.githubusercontent.com/44076375/207997747-4842c512-f442-499b-a143-62aefca6fa98.png">