### PR TITLE
Update d3-scale-chromatic import

### DIFF
--- a/.changeset/twenty-pumpkins-explain.md
+++ b/.changeset/twenty-pumpkins-explain.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix import of d3-scale-chromatic

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -1,10 +1,16 @@
-import { schemeCategory10 } from "d3-scale-chromatic";
+import * as d3ScaleChromatic from "d3-scale-chromatic";
 
 import { DateRange, Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 import { TimeUnit, subtractTime } from "@actnowcoalition/time-utils";
 
 import { Series, SeriesType } from "../SeriesChart";
+
+// TODO (Pablo): Ideally we should be able to import just the scale we need
+// with `import { schemeCategory10 } from "d3-scale-chromatic"`, but Next
+// has a bug that doesn't allow to import modules that only export ES modules
+// (and not CommonJS modules).
+const { schemeCategory10 } = d3ScaleChromatic;
 
 export function getMetricSeries(metric: Metric, regions: Region[]): Series[] {
   return regions.map((region, index) => ({


### PR DESCRIPTION
Importing just the constant we need from `d3-scale-chromatic` breaks the template repository with this error message:

![image](https://user-images.githubusercontent.com/114084/210439773-5fb54ffe-d4af-4fed-84b8-0c0218fc09a7.png)

I think this happens with pure ESM packages (see https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#im-having-problems-with-esm-and-typescript) (we had seen this before, with react-markdown). I updated the import to grab the entire package and use the constant we need instead (not a big deal, the package is really small)

Tested using `yarn link`, it works as expected.