### PR TITLE
Dark mode follow up improvements

### DIFF
--- a/.changeset/late-houses-learn.md
+++ b/.changeset/late-houses-learn.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Dark theme styling improvements

--- a/packages/ui-components/src/components/Axis/Axis.style.tsx
+++ b/packages/ui-components/src/components/Axis/Axis.style.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
+import { useTheme } from "@mui/material";
 import { AxisBottom as VxAxisBottom, AxisLeft as VxAxisLeft } from "@visx/axis";
 
-import { styled, theme } from "../../styles";
-import palette from "../../styles/theme/palette";
+import { styled } from "../../styles";
 import typography from "../../styles/theme/typography";
 
 export type AxisLeftProps = React.ComponentProps<typeof VxAxisLeft> & {
@@ -25,40 +25,47 @@ export type AxisBottomProps = React.ComponentProps<typeof VxAxisBottom> & {
 };
 
 const baseTickLabelProps = {
-  fill: palette.chart.axisLabel,
   fontFamily: typography.paragraphSmall.fontFamily,
   fontSize: typography.paragraphSmall.fontSize,
   fontWeight: typography.paragraphSmall.fontWeight,
 };
 
-export const AxisLeft = styled((props: AxisLeftProps) => (
-  <VxAxisLeft
-    axisClassName={props.className ?? ""}
-    numTicks={props.numTicks ?? 5}
-    hideTicks={props.hideTicks}
-    tickStroke={theme.palette.chart.axis}
-    tickLabelProps={() => ({
-      textAnchor: "end", // Horizontal anchor
-      verticalAnchor: "middle",
-      dx: "-.25em",
-      ...baseTickLabelProps,
-    })}
-    stroke={theme.palette.chart.axis}
-    {...props}
-  />
-))``;
+export const AxisLeft = styled((props: AxisLeftProps) => {
+  const theme = useTheme();
+  return (
+    <VxAxisLeft
+      axisClassName={props.className ?? ""}
+      numTicks={props.numTicks ?? 5}
+      hideTicks={props.hideTicks}
+      tickStroke={theme.palette.chart.axis}
+      tickLabelProps={() => ({
+        textAnchor: "end", // Horizontal anchor
+        verticalAnchor: "middle",
+        dx: "-.25em",
+        fill: theme.palette.chart.axisLabel,
+        ...baseTickLabelProps,
+      })}
+      stroke={theme.palette.chart.axis}
+      {...props}
+    />
+  );
+})``;
 
-export const AxisBottom = styled((props: AxisBottomProps) => (
-  <VxAxisBottom
-    axisClassName={props.className ?? ""}
-    tickLength={4}
-    tickStroke={theme.palette.chart.axis}
-    tickLabelProps={() => ({
-      textAnchor: "middle", // Horizontal anchor
-      verticalAnchor: "start",
-      ...baseTickLabelProps,
-    })}
-    stroke={theme.palette.chart.axis}
-    {...props}
-  />
-))``;
+export const AxisBottom = styled((props: AxisBottomProps) => {
+  const theme = useTheme();
+  return (
+    <VxAxisBottom
+      axisClassName={props.className ?? ""}
+      tickLength={4}
+      tickStroke={theme.palette.chart.axis}
+      tickLabelProps={() => ({
+        textAnchor: "middle", // Horizontal anchor
+        verticalAnchor: "start",
+        fill: theme.palette.chart.axisLabel,
+        ...baseTickLabelProps,
+      })}
+      stroke={theme.palette.chart.axis}
+      {...props}
+    />
+  );
+})``;

--- a/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.style.ts
+++ b/packages/ui-components/src/components/CompareTable/ColumnHeader/ColumnHeader.style.ts
@@ -9,7 +9,7 @@ export const StyledTableCell = styled(TableCell, {
     isSortable && `padding-bottom: ${theme.spacing(0.5)};`}
   border-bottom: ${({ theme, isSortActive }) =>
     isSortActive
-      ? `solid 2px ${theme.palette.common.black}`
+      ? `solid 2px ${theme.palette.text.primary}`
       : `solid 1px ${theme.palette.border.default}`};
   color: ${({ theme, isSortActive }) =>
     isSortActive ? theme.palette.common.black : theme.palette.secondary.light};

--- a/packages/ui-components/src/components/CompareTable/SortControls/SortControls.style.ts
+++ b/packages/ui-components/src/components/CompareTable/SortControls/SortControls.style.ts
@@ -8,12 +8,12 @@ export const ArrowUpIcon = styled(MuiArrowUpIcon, {
   shouldForwardProp: isValidProp,
 })<{ active: boolean }>`
   color: ${({ active, theme }) =>
-    active ? theme.palette.common.black : theme.palette.border.default};
+    active ? theme.palette.text.primary : theme.palette.border.default};
 `;
 
 export const ArrowDownIcon = styled(MuiArrowDownIcon, {
   shouldForwardProp: isValidProp,
 })<{ active: boolean }>`
   color: ${({ active, theme }) =>
-    active ? theme.palette.common.black : theme.palette.border.default};
+    active ? theme.palette.text.primary : theme.palette.border.default};
 `;

--- a/packages/ui-components/src/components/ErrorBox/ErrorBox.tsx
+++ b/packages/ui-components/src/components/ErrorBox/ErrorBox.tsx
@@ -20,7 +20,9 @@ export const ErrorBox = ({ width, height = 200, children }: ErrorBoxProps) => {
       bgcolor={theme.palette.action.disabledBackground}
       sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
     >
-      <Box>{children ?? "An error occurred."}</Box>
+      <Box color={theme.palette.common.black}>
+        {children ?? "An error occurred."}
+      </Box>
     </Box>
   );
 };

--- a/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
+++ b/packages/ui-components/src/components/MetricCatalogContext/MetricAwareDemo.tsx
@@ -30,7 +30,7 @@ const MetricAwareDemo = ({
   }
 
   return (
-    <Stack sx={{ p: 2, backgroundColor: "#fafafa", borderRadius: 0.5 }}>
+    <Stack sx={{ p: 2, borderRadius: 0.5 }}>
       <Typography variant="labelLarge">{metric.name}</Typography>
       <Typography variant="dataEmphasizedLarge">
         {metric.formatValue(data.currentValue)}

--- a/packages/ui-components/src/styles/theme/dark-theme.tsx
+++ b/packages/ui-components/src/styles/theme/dark-theme.tsx
@@ -108,6 +108,11 @@ const darkThemeConfig = {
           ...theme.typography.labelSmall,
           color: theme.palette.common.white,
         }),
+        deleteIcon: ({ theme }: { theme: Theme }) => ({
+          "&: hover": {
+            color: theme.palette.common.white,
+          },
+        }),
       },
     },
     MuiTabs: {

--- a/packages/ui-components/src/styles/theme/dark-theme.tsx
+++ b/packages/ui-components/src/styles/theme/dark-theme.tsx
@@ -42,6 +42,11 @@ const darkThemeConfig = {
       400: colors.purple[200],
       500: colors.purple[400],
     },
+    chart: {
+      main: colors.common.white,
+      axis: colors.common.white,
+      axisLabel: colors.common.white,
+    },
   },
   typography: {
     h1: {


### PR DESCRIPTION
Style touch-ups for dark mode. Should address all issues listed in [this doc](https://www.dropbox.com/scl/fi/cupjyq2dk82lr2xb5p7gj/Dark-Theme-Improvements.paper?dl=0&rlkey=efnf6e0iqjm218bn56wbgpy5p).

Again, the current goal is not to have all components be perfect, as we will likely tweak things here and there if/when Josh develops a dark mode palette, but to just ensure things are presentable/visible in dark mode.

To review, I recommend going through the above doc ^ and follow along on Storybook.

Closes https://github.com/covid-projections/act-now-packages/issues/452