### PR TITLE
Add missing import for fail() in MultiMetricUSStateMap/utils.ts.

### DIFF
--- a/.changeset/forty-bags-heal.md
+++ b/.changeset/forty-bags-heal.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix missing import for fail() in MultiMetricUSStateMap/utils.ts.

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/utils.ts
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/utils.ts
@@ -1,5 +1,6 @@
 import startCase from "lodash/startCase";
 
+import { fail } from "@actnowcoalition/assert";
 import { Metric } from "@actnowcoalition/metrics";
 
 // TODO(#325) - move these to MetricLegendThreshold (or somewhere more central than here)


### PR DESCRIPTION
It wasn't failing the build because we were picking up the global fail() definition from jest, though it would probably not exist at runtime and cause an error.