### PR TITLE
Restore d3-scale-chromatic

### DIFF
--- a/.changeset/rare-lions-scream.md
+++ b/.changeset/rare-lions-scream.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Restore d3-scale-chromatic

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -72,6 +72,7 @@
     "@visx/shape": "^2.12.2",
     "@visx/voronoi": "^2.10.0",
     "d3-geo": "^2.0.2",
+    "d3-scale-chromatic": "^3.0.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-markdown": "^8.0.3",
     "react-share": "^4.4.0",

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -1,24 +1,10 @@
+import { schemeCategory10 } from "d3-scale-chromatic";
+
 import { DateRange, Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 import { TimeUnit, subtractTime } from "@actnowcoalition/time-utils";
 
 import { Series, SeriesType } from "../SeriesChart";
-
-// These colors come are from d3-scale-chromatic, but importing them directly
-// causes Next to crash because d3-scale-chromatic is a pure ES module.
-// See https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#im-having-problems-with-esm-and-typescript
-const schemeCategory10 = [
-  "#1f77b4",
-  "#ff7f0e",
-  "#2ca02c",
-  "#d62728",
-  "#9467bd",
-  "#8c564b",
-  "#e377c2",
-  "#7f7f7f",
-  "#bcbd22",
-  "#17becf",
-];
 
 export function getMetricSeries(metric: Metric, regions: Region[]): Series[] {
   return regions.map((region, index) => ({

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -4965,6 +4965,11 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
   integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
 
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
 "d3-dispatch@1 - 2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
@@ -5002,6 +5007,13 @@ d3-geo@^2.0.2:
   dependencies:
     d3-color "1 - 2"
 
+"d3-interpolate@1 - 3":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
 d3-interpolate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
@@ -5018,6 +5030,14 @@ d3-random@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-2.2.2.tgz#5eebd209ef4e45a2b362b019c1fb21c2c98cbb6e"
   integrity sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==
+
+d3-scale-chromatic@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
+  dependencies:
+    d3-color "1 - 3"
+    d3-interpolate "1 - 3"
 
 d3-scale@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
So I wanted to remove `d3-scale-chromatic` because I thought it was causing the template repo to break, but it wasn't it (we have been using `d3-scale-chromatic` for a while), so I'm restoring it and will investigate what was breaking the template repo (it might have been the `fail` function that @mikelehen fixed)