### PR TITLE
Compare table style fix

### DIFF
--- a/.changeset/hot-pots-try.md
+++ b/.changeset/hot-pots-try.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+fix compare table style bug

--- a/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.style.ts
@@ -36,6 +36,7 @@ export const TableRow = styled(MuiTableRow)(({ theme }) => ({
     backgroundColor: theme.palette.common.white,
   },
   "&:hover": {
+    backgroundColor: theme.palette.grey[200],
     [`.${linkClasses.root} .${typographyClasses.root}`]: {
       color: theme.palette.primary.dark,
     },

--- a/packages/ui-components/src/components/CompareTable/CompareTable.tsx
+++ b/packages/ui-components/src/components/CompareTable/CompareTable.tsx
@@ -26,7 +26,7 @@ export const CompareTable = <R extends CompareTableRowBase>({
       </TableHead>
       <TableBody>
         {rows.map((row, rowIndex) => (
-          <TableRow key={`table-row-${row.rowId}`} hover>
+          <TableRow key={`table-row-${row.rowId}`}>
             {columns.map((column, columnIndex) => (
               <Fragment key={`cell-${row.rowId}-${column.columnId}`}>
                 {column.renderCell({ row, rowIndex, columnIndex })}


### PR DESCRIPTION
Closes #394 

Instead of controlling hover styling via MUI TableRow's `hover` prop (which applies a background color that is a transparent grey and causes the overlap bug seen in the gh issue), we now set the hover background color ourselves in the style file (same grey, just not transparent)