### PR TITLE
Add @mui/material and @emotion/* packages as peerDependencies

### DIFF
--- a/.changeset/neat-windows-tap.md
+++ b/.changeset/neat-windows-tap.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Add @mui/material and dependents as peer dependencies

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -27,7 +27,10 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@mui/material": "^5.11.0",
+    "@emotion/react": "^11.5.0",
+    "@emotion/styled": "^11.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.9",
@@ -53,8 +56,8 @@
     "@actnowcoalition/metrics": "^0.4.0",
     "@actnowcoalition/number-format": "^0.1.2",
     "@actnowcoalition/regions": "^0.1.2",
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
+    "@emotion/react": "^11.5.0",
+    "@emotion/styled": "^11.3.0",
     "@mui/icons-material": "^5.8.4",
     "@mui/lab": "^5.0.0-alpha.111",
     "@mui/material": "^5.10.17",

--- a/packages/ui-components/yarn.lock
+++ b/packages/ui-components/yarn.lock
@@ -1285,7 +1285,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
-"@emotion/react@^11.10.5":
+"@emotion/react@^11.5.0":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.10.5.tgz#95fff612a5de1efa9c0d535384d3cfa115fe175d"
   integrity sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==
@@ -1315,7 +1315,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
   integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
 
-"@emotion/styled@^11.10.5":
+"@emotion/styled@^11.3.0":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
   integrity sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==


### PR DESCRIPTION
The versions of `@mui/material` on `@actnowcoalition/packages` and `act-now-tempate` are not the same. When that happens, we get 2 versions of @mui/material when we install dependencies on the template repo:

```
# act-now-template
node_modules
├── @actnowcoalition
│   └── ui-components
│       └── node_modules
│           ├── @mui
│           │   └── material. # 5.11.3
...
│   └── @mui
│           └── material. # 5.9.0
```

We should have defined `@mui/material` (and its own peer dependencies, `@emotion/styled` and `@emotion/react`) as peer dependencies of `@actnowcoalition/ui-components` to make sure that 

- Both projects have compatible versions 
- Only one version of `@mui/material` is included in the final app

The following packages are now peer dependencies:

- `@mui/material: ^5.11.0`
- `@emotion/react: ^11.5.0`
- `@emotion/styled: ^11.3.0`
- `@mui/icons-material: ^5.11.0`
 
According to the NodeJS article below, the peer dependency versions should be _lenient_ and not too specific, so I think we can tie them to the minor version of each package (`^X.Y.0`)

## Learn more

- https://mui.com/versions/
- https://nodejs.org/es/blog/npm/peer-dependencies/
- https://classic.yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies