### PR TITLE
Remove stories from the npm bundle

### DIFF
--- a/.changeset/three-dots-judge.md
+++ b/.changeset/three-dots-judge.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Remove stories form the npm bundle

--- a/packages/ui-components/tsconfig.base.json
+++ b/packages/ui-components/tsconfig.base.json
@@ -9,5 +9,10 @@
     "jsx": "react"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
-  "exclude": ["node_modules", "**/*.test.*"]
+  "exclude": [
+    "node_modules",
+    "**/*.test.*",
+    "src/stories",
+    "src/**/*.stories.*"
+  ]
 }


### PR DESCRIPTION
Updating the TS configuration to exclude stories from the npm bundle.

**Testing**

- Pull this branch, delete `packages/ui-components/dist`
- Go to `packages/ui-components`
- Run `yarn build`

The resulting `dist` folder shouldn't have the stories files and folders anymore.