### PR TITLE
Fix #486: Remove no-longer-needed type annotation.

### DIFF
--- a/.changeset/early-suits-pump.md
+++ b/.changeset/early-suits-pump.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Remove no-longer-needed type annotation on StyledLink.

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.style.ts
@@ -1,5 +1,4 @@
-import { StyledComponent } from "@emotion/styled";
-import { LinkBaseProps, Link as MuiLink } from "@mui/material";
+import { Link as MuiLink } from "@mui/material";
 
 import { styled } from "../../styles";
 import { TableCell } from "../CompareTable";
@@ -10,11 +9,7 @@ export const StyledTableCell = styled(TableCell)`
   padding: 0;
 `;
 
-// TODO: Issue with upgraded MUI/emotion requires an explicit type annotation
-// here. See issue #486
-export const StyledLink: StyledComponent<
-  Omit<LinkBaseProps, "classes">
-> = styled(MuiLink)`
+export const StyledLink = styled(MuiLink)`
   display: flex;
   padding: ${({ theme }) => theme.spacing(2)};
   text-decoration: none;


### PR DESCRIPTION
The type annotation doesn't seem to be required anymore after Pablo's changes in #529.