### PR TITLE
Make metric legend threshold more responsive

### DIFF
--- a/.changeset/empty-pumpkins-jump.md
+++ b/.changeset/empty-pumpkins-jump.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Make metric legend threshold thermometer more responsive

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -44,7 +44,7 @@ export const LegendThresholdHorizontalInner = <T,>({
   const totalHeight = height + labelsHeight + indicatorHeight;
 
   return (
-    <svg width="100%" height={totalHeight}>
+    <svg width={width} height={totalHeight}>
       {/* Indicator */}
       {getItemShowIndicator &&
         items.map((item: T, itemIndex) => {

--- a/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
+++ b/packages/ui-components/src/components/LegendThreshold/LegendThresholdHorizontal.tsx
@@ -44,7 +44,7 @@ export const LegendThresholdHorizontalInner = <T,>({
   const totalHeight = height + labelsHeight + indicatorHeight;
 
   return (
-    <svg width={width} height={totalHeight}>
+    <svg width="100%" height={totalHeight}>
       {/* Indicator */}
       {getItemShowIndicator &&
         items.map((item: T, itemIndex) => {

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.stories.tsx
@@ -81,6 +81,19 @@ HorizontalOnlySideLabels.args = {
   endLabel: <Typography variant="paragraphSmall">higher</Typography>,
 };
 
+export const HorizontalWithLongSideLabels = Template.bind({});
+HorizontalWithLongSideLabels.args = {
+  ...HorizontalDefault.args,
+  height: horizontalBarHeight,
+  showLabels: false,
+  startLabel: (
+    <Typography variant="paragraphSmall">I am a long start label</Typography>
+  ),
+  endLabel: (
+    <Typography variant="paragraphSmall">I am a long end label</Typography>
+  ),
+};
+
 export const HorizontalCategories = Template.bind({});
 HorizontalCategories.args = {
   orientation: "horizontal",

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -83,10 +83,10 @@ export const MetricLegendThreshold = ({
           )}
         </Stack>
         <Stack direction="row" spacing={1}>
-          <Box>{startLabel}</Box>
+          <Box textAlign="end">{startLabel}</Box>
           {/* Min width specified to prevent thermometer from extending beyond container.
           More info: https://github.com/airbnb/visx/issues/1014#issuecomment-1180677878 */}
-          <Box flex={1} minWidth={0}>
+          <Box flex={1} minWidth={40}>
             <LegendThreshold<CategoryItem>
               {...commonProps}
               getItemLabel={getItemLabelHorizontal}

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -84,7 +84,9 @@ export const MetricLegendThreshold = ({
         </Stack>
         <Stack direction="row" spacing={1}>
           <Box>{startLabel}</Box>
-          <Box flex={1}>
+          {/* Min width specified to prevent thermometer from extending beyond container.
+          More info: https://github.com/airbnb/visx/issues/1014#issuecomment-1180677878 */}
+          <Box flex={1} minWidth={0}>
             <LegendThreshold<CategoryItem>
               {...commonProps}
               getItemLabel={getItemLabelHorizontal}


### PR DESCRIPTION
Currently the thermometer inside our horizontal metric legend threshold is not fully responsive. It will scale as one expands the window, but not as one shrinks the window. This is due to the automatic minimum size of a flex item (more info [here](https://github.com/airbnb/visx/issues/1014#issuecomment-1180677878)). Setting a minimum value to the parent container resolves the issue.

Closes https://github.com/act-now-coalition/act-now-packages/issues/334

Before:
![image](https://user-images.githubusercontent.com/46338131/211895840-c2801003-ef1d-489b-807f-b4130e627d80.png)

After:
![image](https://user-images.githubusercontent.com/46338131/211895923-01b2d1dc-7951-4771-9c25-c16c0816b85b.png)
![image](https://user-images.githubusercontent.com/46338131/211897422-ef4aa383-5331-470c-bc16-0c71d430fd97.png)
