### PR TITLE
Add sideEffects: false to package.json

### DIFF
--- a/.changeset/fair-brooms-exist.md
+++ b/.changeset/fair-brooms-exist.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Mark the package as side-effects free

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -82,5 +82,6 @@
     "react-singleton-hook": "^4.0.0",
     "swr": "^1.3.0",
     "topojson-client": "^3.1.0"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Part of https://github.com/act-now-coalition/act-now-packages/issues/537 - Enabling tree shaking for `@actnowcoalition/ui-components`

The package is free of side effects (as far as I know), not sure why this is the only package where we don't have this flag. I'm going to also add `"type": "module"` on a follow up PR (just want to test the changes one by one).