### PR TITLE
Add the no-duplicate-imports rule to the ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "lodash/import-scope": "warn",
     "react/jsx-key": "error",
+    "no-duplicate-imports": "error",
     "no-restricted-imports": [
       "error",
       {

--- a/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
+++ b/packages/metrics/src/data_providers/CovidActNowDataProvider.ts
@@ -9,10 +9,10 @@ import { MultiRegionMultiMetricDataStore } from "../data";
 import { MetricData } from "../data/MetricData";
 import { MetricDataProvider } from "./MetricDataProvider";
 import {
+  DataRow,
   dataRowToMetricData,
   dataRowsToMetricData,
 } from "./data_provider_utils";
-import { DataRow } from "./data_provider_utils";
 import { fetchJson } from "./utils";
 
 // Limit having too many outstanding requests at once, to avoid timeouts, etc.

--- a/packages/ui-components/src/common/hooks/metric-data.test.tsx
+++ b/packages/ui-components/src/common/hooks/metric-data.test.tsx
@@ -1,5 +1,4 @@
-import { ReactNode } from "react";
-import React from "react";
+import React, { ReactNode } from "react";
 
 import { renderHook, waitFor } from "@testing-library/react";
 

--- a/packages/ui-components/src/components/MetricChartBlock/MetricChartBlock.tsx
+++ b/packages/ui-components/src/components/MetricChartBlock/MetricChartBlock.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import React from "react";
+import React, { useState } from "react";
 
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { Stack, Typography } from "@mui/material";

--- a/packages/ui-components/src/components/MetricCompareTable/utils.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/utils.tsx
@@ -4,8 +4,7 @@ import { Stack, Typography } from "@mui/material";
 import isNumber from "lodash/isNumber";
 
 import { Metric, MultiMetricDataStore } from "@actnowcoalition/metrics";
-import { RegionDB } from "@actnowcoalition/regions";
-import { Region } from "@actnowcoalition/regions";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { formatPopulation } from "../../common/utils";
 import {

--- a/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
+++ b/packages/ui-components/src/components/MetricLegendThreshold/MetricLegendThreshold.tsx
@@ -2,13 +2,11 @@ import React from "react";
 
 import { Box, Stack, Typography } from "@mui/material";
 
-import { Metric } from "@actnowcoalition/metrics";
-import { Category } from "@actnowcoalition/metrics";
+import { Category, Metric } from "@actnowcoalition/metrics";
 
 import { BaseLegendThresholdProps, LegendThreshold } from "../LegendThreshold";
 import { useMetricCatalog } from "../MetricCatalogContext";
-import { getMetricCategoryItems } from "./utils";
-import { CategoryItem } from "./utils";
+import { CategoryItem, getMetricCategoryItems } from "./utils";
 
 export interface MetricLegendThresholdProps extends BaseLegendThresholdProps {
   /**

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -8,8 +8,7 @@ import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 
 import { useData } from "../../common/hooks";
-import { BaseChartProps } from "../../common/utils/charts";
-import { getChartRange } from "../../common/utils/charts";
+import { BaseChartProps, getChartRange } from "../../common/utils/charts";
 import { AxesTimeseries } from "../AxesTimeseries";
 import { ChartOverlayX, useHoveredDate } from "../ChartOverlayX";
 import { ErrorBox } from "../ErrorBox";

--- a/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
+++ b/packages/ui-components/src/components/MetricScoreOverview/MetricScoreOverview.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { Stack, Typography } from "@mui/material";
-import { IconButton } from "@mui/material";
+import { IconButton, Stack, Typography } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";

--- a/packages/ui-components/src/components/SeriesChart/SeriesChart.tsx
+++ b/packages/ui-components/src/components/SeriesChart/SeriesChart.tsx
@@ -2,8 +2,7 @@ import React from "react";
 
 import { ScaleLinear, ScaleTime } from "d3-scale";
 
-import { Timeseries } from "@actnowcoalition/metrics";
-import { Metric } from "@actnowcoalition/metrics";
+import { Metric, Timeseries } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
 
 import { BarChart } from "../BarChart";

--- a/packages/ui-components/src/stories/Palette.stories.tsx
+++ b/packages/ui-components/src/stories/Palette.stories.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { Box, Grid, Palette, Stack, Typography } from "@mui/material";
+
+import { Box, Grid, Palette, Stack, Theme, Typography } from "@mui/material";
 import isObject from "lodash/isObject";
-import darkTheme from "../styles/theme/dark-theme";
+
 import lightTheme from "../styles/theme";
-import { Theme } from "@mui/material";
+import darkTheme from "../styles/theme/dark-theme";
 
 export default {
   title: "Design System/Palette",

--- a/packages/ui-components/src/styles/index.ts
+++ b/packages/ui-components/src/styles/index.ts
@@ -1,7 +1,6 @@
 import { createStyled } from "@mui/system";
 
-import theme, { themeConfig } from "./theme";
-import { darkTheme, darkThemeConfig } from "./theme";
+import theme, { darkTheme, darkThemeConfig, themeConfig } from "./theme";
 
 const styled = createStyled({ defaultTheme: theme });
 


### PR DESCRIPTION
Enabling the rule to prevent us from having unmerged imports. This is mostly a stylistic choice (I noticed a few duplicated imports while writing the tutorial), but makes our code look a bit better. (if someone doesn't like this rule we can discuss it during standup too!)

No changeset since we are not altering API/functionality