### PR TITLE
Remove getRegionUrl prop from metric-aware maps

### DIFF
--- a/.changeset/cool-balloons-pretend.md
+++ b/.changeset/cool-balloons-pretend.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": minor
+---
+
+Remove getRegionUrl prop from metric-aware maps

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
@@ -9,7 +9,8 @@ import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { ErrorBox } from "../ErrorBox";
 import { USNationalMap, USNationalMapProps } from "../USNationalMap";
 
-export interface MetricUSNationalMapProps extends USNationalMapProps {
+export interface MetricUSNationalMapProps
+  extends Omit<USNationalMapProps, "getRegionUrl"> {
   /**
    * Metric represented by the map's coloring.
    */

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
@@ -10,7 +10,8 @@ import { getCountiesOfState } from "../../common/utils/maps";
 import { ErrorBox } from "../ErrorBox";
 import { USStateMap, USStateMapProps } from "../USStateMap";
 
-export interface MetricUSStateMapProps extends USStateMapProps {
+export interface MetricUSStateMapProps
+  extends Omit<USStateMapProps, "getRegionUrl"> {
   /**
    * Metric represented by the map's coloring.
    */

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
@@ -9,7 +9,8 @@ import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { ErrorBox } from "../ErrorBox";
 import WorldMap, { WorldMapProps } from "../WorldMap";
 
-export interface MetricWorldMapProps extends WorldMapProps {
+export interface MetricWorldMapProps
+  extends Omit<WorldMapProps, "getRegionUrl"> {
   /**
    * Metric represented by the map's coloring.
    */


### PR DESCRIPTION
Close https://github.com/act-now-coalition/act-now-packages/issues/539 - Remove `getRegionUrl` prop from metric-aware maps.

Metric-aware maps receive the `RegionDB` instance of the app, so they have access to the `getRegionUrl` function from it.