### PR TITLE
Add a loading state to the `MetricCompareTable`

### DIFF
--- a/.changeset/little-walls-travel.md
+++ b/.changeset/little-walls-travel.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Add a loading state to MetricCompareTable

--- a/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/packages/ui-components/src/components/MetricCompareTable/MetricCompareTable.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+import { Skeleton } from "@mui/material";
+
 import { Metric } from "@actnowcoalition/metrics";
 import { Region, RegionDB } from "@actnowcoalition/regions";
 
@@ -75,8 +77,7 @@ export const MetricCompareTable = ({
   if (error) {
     return <ErrorBox>Table could not be loaded.</ErrorBox>;
   } else if (!data) {
-    // TODO(#473): Better loading state.
-    return null;
+    return <Skeleton variant="rectangular" width="100%" height="100%" />;
   }
 
   const rows: Row[] = data.all.map((multiMetricDataStore) => ({


### PR DESCRIPTION
Close https://github.com/act-now-coalition/act-now-packages/issues/473 - Add loading state to the `MetricCompareTable` component.

See in [Storybook](https://act-now-packages--pr547-pablo-473-compare-lo-wkgipb7z.web.app/storybook/index.html?path=/story/components-metriccomparetable--loading-delay) 
