### PR TITLE
Enable Storybook composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ dist
 # Generated docs / storybook to be published.
 public/docs/
 public/storybook/
+storybook-static

--- a/packages/ui-components/.storybook/main.ts
+++ b/packages/ui-components/.storybook/main.ts
@@ -6,4 +6,9 @@ export default {
     "@storybook/addon-interactions",
   ],
   framework: "@storybook/react",
+  features: {
+    // This enables generating stories.json to allow Storybook composition
+    // https://storybook.js.org/docs/react/sharing/storybook-composition
+    buildStoriesJson: true,
+  },
 };


### PR DESCRIPTION
Enable Storybook composition. With this flag, we can "include" the ui-components Storybook into the template Storybook, so users can see which components are available as they use them.

https://storybook.js.org/docs/react/sharing/storybook-composition#with-feature-flags

I also added `storybook-static` to `.gitignore`, it was missing. No changeset since it doesn't change our API