### PR TITLE
Handle no data in metric chart

### DIFF
--- a/.changeset/chilled-dryers-pull.md
+++ b/.changeset/chilled-dryers-pull.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Handle no data in metric chart

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -105,6 +105,17 @@ export const MetricSeriesChart = ({
     return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 
+  try {
+    getDateRange(timeseriesList);
+    getValueRange(timeseriesList);
+  } catch (err) {
+    return (
+      <ErrorBox width={width} height={height}>
+        No data in the provided time range.
+      </ErrorBox>
+    );
+  }
+
   const seriesList = series
     .filter(({ metric, region }) => data.hasMetricData(region, metric))
     .map((seriesItem, seriesIndex) => ({

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Skeleton, useTheme } from "@mui/material";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
+import every from "lodash/every";
 import isNumber from "lodash/isNumber";
 import max from "lodash/max";
 import min from "lodash/min";
@@ -101,19 +102,17 @@ export const MetricSeriesChart = ({
         Chart could not be loaded.
       </ErrorBox>
     );
-  } else if (!data || !timeseriesList) {
-    return <Skeleton variant="rectangular" width={width} height={height} />;
-  }
-
-  try {
-    getDateRange(timeseriesList);
-    getValueRange(timeseriesList);
-  } catch (err) {
+  } else if (
+    timeseriesList &&
+    every(timeseriesList, (timeseries) => timeseries.length === 0)
+  ) {
     return (
       <ErrorBox width={width} height={height}>
         No data in the provided time range.
       </ErrorBox>
     );
+  } else if (!data || !timeseriesList) {
+    return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 
   const seriesList = series

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -102,14 +102,16 @@ export const MetricSeriesChart = ({
         Chart could not be loaded.
       </ErrorBox>
     );
+    // Loading state
+  } else if (!data || !timeseriesList) {
+    return <Skeleton variant="rectangular" width={width} height={height} />;
+    // Loaded but no data
   } else if (!hasData(timeseriesList)) {
     return (
       <ErrorBox width={width} height={height}>
         No data in the provided time range.
       </ErrorBox>
     );
-  } else if (!data || !timeseriesList) {
-    return <Skeleton variant="rectangular" width={width} height={height} />;
   }
 
   const seriesList = series

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -3,10 +3,10 @@ import React from "react";
 import { Skeleton, useTheme } from "@mui/material";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
-import every from "lodash/every";
 import isNumber from "lodash/isNumber";
 import max from "lodash/max";
 import min from "lodash/min";
+import some from "lodash/some";
 import sortBy from "lodash/sortBy";
 import uniq from "lodash/uniq";
 
@@ -102,7 +102,7 @@ export const MetricSeriesChart = ({
         Chart could not be loaded.
       </ErrorBox>
     );
-  } else if (every(timeseriesList, (timeseries) => timeseries.length === 0)) {
+  } else if (!hasData(timeseriesList)) {
     return (
       <ErrorBox width={width} height={height}>
         No data in the provided time range.
@@ -237,6 +237,17 @@ export const MetricSeriesChart = ({
     </svg>
   );
 };
+
+/**
+ * `hasData` returns true if at least one timeseries in a timeseriesList has data.
+ *
+ * @param timeseriesList - Array of timeseries.
+ * @returns True if the timeseriesList has data.
+ */
+
+function hasData(timeseriesList: Timeseries<unknown>[] | undefined): boolean {
+  return some(timeseriesList, (timeseries) => timeseries.length > 0);
+}
 
 /**
  * `getDateRange` returns the date range that covers the provided timeseries.

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -102,10 +102,7 @@ export const MetricSeriesChart = ({
         Chart could not be loaded.
       </ErrorBox>
     );
-  } else if (
-    timeseriesList &&
-    every(timeseriesList, (timeseries) => timeseries.length === 0)
-  ) {
+  } else if (every(timeseriesList, (timeseries) => timeseries.length === 0)) {
     return (
       <ErrorBox width={width} height={height}>
         No data in the provided time range.

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import first from "lodash/first";
 import last from "lodash/last";
 import sortBy from "lodash/sortBy";
 
@@ -55,4 +56,12 @@ WithCustomPeriods.args = {
   initialRegions: sortedStates.slice(0, 5),
   timePeriods: customTimePeriods,
   initialTimePeriod: last(customTimePeriods),
+};
+
+export const WithNoData = Template.bind({});
+WithNoData.args = {
+  ...Example.args,
+  initialMetric: MetricId.PI,
+  timePeriods: customTimePeriods,
+  initialTimePeriod: first(customTimePeriods),
 };


### PR DESCRIPTION
Currently when our `MetricSeriesChart` encounters a timeseries with no data in it for the selected time period, it will fail ungracefully. Specifically, it will throw an internal assertion failure that's visible on the console, but not immediately apparent to the user. This PR handles this failure by ensuring the chart informs the user there's no data if it encounters a timeseries with no data for the selected time period.

Closes https://github.com/act-now-coalition/act-now-packages/issues/541

Before
![image](https://user-images.githubusercontent.com/46338131/213014621-f31e369a-4b6f-41a5-ba4f-00aa9b4d81f6.png)

After
![image](https://user-images.githubusercontent.com/46338131/213015045-f45653b9-2ac4-498b-986a-389f9f9ea00a.png)
