### PR TITLE
Fix #536: Fix alignment of icon on RegionSearch

### DIFF
--- a/.changeset/olive-eels-wash.md
+++ b/.changeset/olive-eels-wash.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix #536: Fix alignment of icon on RegionSearch

--- a/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
+++ b/packages/ui-components/src/components/RegionSearch/RegionSearch.tsx
@@ -80,6 +80,7 @@ export const RegionSearch = ({
         }
       }}
       clearIcon={<></>}
+      forcePopupIcon={false}
       renderInput={customRenderInput ?? defaultRenderInput}
       renderOption={(props: HTMLAttributes<HTMLLIElement>, option: Region) => (
         <StyledListItem {...props}>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/206364/213286960-1a4cc06d-86fb-4329-b006-8461f84c4667.png)


After:
![image](https://user-images.githubusercontent.com/206364/213286830-8fc92503-863f-4c53-89ae-60cb8e914153.png)

