### PR TITLE
Ensure metric line threshold chart isn't stuck loading

### DIFF
--- a/.changeset/warm-fans-poke.md
+++ b/.changeset/warm-fans-poke.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Ensure metric line threshold chart doesn't hang

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -64,8 +64,16 @@ export const MetricLineThresholdChart = ({
         Chart could not be loaded.
       </ErrorBox>
     );
-  } else if (!timeseries?.hasData?.()) {
+    // Loading state
+  } else if (!timeseries) {
     return <Skeleton variant="rectangular" width={width} height={height} />;
+    // Loaded but no data
+  } else if (!timeseries?.hasData()) {
+    return (
+      <ErrorBox width={width} height={height}>
+        No data for {region.shortName}
+      </ErrorBox>
+    );
   }
 
   const chartHeight = height - marginTop - marginBottom;


### PR DESCRIPTION
Currently when there's no data, the `MetricLineThresholdChart` would hang in loading state. This PR fixes this by adjusting the conditional to first check that the timeseries isn't undefined (i.e. loading state), and if it's defined but there's no data, then return an appropriate error box with a no-data message.

Closes https://github.com/act-now-coalition/act-now-packages/issues/535

**To test:**
1. Pull this branch and run storybook on this branch.
2. On the line declaring `timeseries` variable (line 56) in `MetricLineThresholdChart.tsx`, add a date filter to a period when there's no data (e.g. `.filterToDateRange({startAt: new Date("2023-01-01")})`).
3. Check that the affected `MetricLineThresholdChart` stories are now displaying a no-data message.

**Nice-to-have:**
It would be easier to test in the future if there's a way to either...
- Create an empty metric instance or a new metric instance (based on an existing metric instance) that filters data by date. This way we can more easily create stories displaying scenarios with no data.
- Move the ability to filter by date out of `MetricLineThresholdChart.tsx`.