### PR TITLE
Better support for long periods for `MultiRegionMultiMetricChart`

### DIFF
--- a/.changeset/chatty-ears-hang.md
+++ b/.changeset/chatty-ears-hang.md
@@ -1,0 +1,6 @@
+---
+"@actnowcoalition/ui-components": patch
+"@actnowcoalition/time-utils": patch
+---
+
+Better support for long time periods for MultiRegionMultiMetricChart

--- a/.changeset/chatty-ears-hang.md
+++ b/.changeset/chatty-ears-hang.md
@@ -1,6 +1,5 @@
 ---
 "@actnowcoalition/ui-components": patch
-"@actnowcoalition/time-utils": patch
 ---
 
-Better support for long time periods for MultiRegionMultiMetricChart
+Update `MultiRegionMultiMetricChart` to better support time intervals not based in a number of days.

--- a/.changeset/shaggy-humans-retire.md
+++ b/.changeset/shaggy-humans-retire.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/time-utils": patch
+---
+
+Add `YEARS` to the `TimeUnit` enum and implement the `getTimeUnitLabel` function to get the name of time units (months, years, minutes) for each time unit.

--- a/packages/time-utils/src/index.test.ts
+++ b/packages/time-utils/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   formatUTCDateTime,
   getStartOf,
   getTimeDiff,
+  getTimeUnitLabel,
   isoDateOnlyString,
   parseDateString,
   parseDateUnix,
@@ -311,5 +312,32 @@ describe("assertDateOnly", () => {
     expect(() => {
       assertDateOnly(new Date(2020, 3, 2, 10, 30));
     }).toThrow();
+  });
+});
+
+describe("getTimeUnitLabel", () => {
+  test("minutes are formatted correctly", () => {
+    expect(getTimeUnitLabel(1, TimeUnit.MINUTES)).toBe("minute");
+    expect(getTimeUnitLabel(5, TimeUnit.MINUTES)).toBe("minutes");
+  });
+  test("hours are formatted correctly", () => {
+    expect(getTimeUnitLabel(1, TimeUnit.HOURS)).toBe("hour");
+    expect(getTimeUnitLabel(5, TimeUnit.HOURS)).toBe("hours");
+  });
+  test("days are formatted correctly", () => {
+    expect(getTimeUnitLabel(1, TimeUnit.DAYS)).toBe("day");
+    expect(getTimeUnitLabel(5, TimeUnit.DAYS)).toBe("days");
+  });
+  test("weeks are formatted correctly", () => {
+    expect(getTimeUnitLabel(1, TimeUnit.WEEKS)).toBe("week");
+    expect(getTimeUnitLabel(5, TimeUnit.WEEKS)).toBe("weeks");
+  });
+  test("months are formatted correctly", () => {
+    expect(getTimeUnitLabel(1, TimeUnit.MONTHS)).toBe("month");
+    expect(getTimeUnitLabel(5, TimeUnit.MONTHS)).toBe("months");
+  });
+  test("years are formatted correctly", () => {
+    expect(getTimeUnitLabel(1, TimeUnit.YEARS)).toBe("year");
+    expect(getTimeUnitLabel(5, TimeUnit.YEARS)).toBe("years");
   });
 });

--- a/packages/time-utils/src/index.ts
+++ b/packages/time-utils/src/index.ts
@@ -1,6 +1,6 @@
 import { DateTime, Duration } from "luxon";
 
-import { assert } from "@actnowcoalition/assert";
+import { assert, fail } from "@actnowcoalition/assert";
 
 export * from "./PureDate";
 
@@ -249,9 +249,8 @@ export function getTimeUnitLabel(amount: number, unit: TimeUnit): string {
     case TimeUnit.YEARS:
       return pluralize(amount, "year", "years");
     default:
-      return `${amount} ${unit}`;
+      fail(`Unsupported unit: ${unit}`);
   }
-  return `${amount} ${unit}`;
 }
 
 /**

--- a/packages/time-utils/src/index.ts
+++ b/packages/time-utils/src/index.ts
@@ -27,6 +27,7 @@ export enum TimeUnit {
   DAYS = "day",
   WEEKS = "week",
   MONTHS = "month",
+  YEARS = "year",
 }
 
 /**
@@ -160,6 +161,8 @@ function getTimeUnitOption(amount: number, unit: TimeUnit): Duration {
       return Duration.fromObject({ weeks: amount });
     case TimeUnit.MONTHS:
       return Duration.fromObject({ months: amount });
+    case TimeUnit.YEARS:
+      return Duration.fromObject({ years: amount });
   }
 }
 
@@ -222,4 +225,50 @@ export function assertDateOnly(date: Date): void {
     onlyDate,
     `Date is expected to have a no time component (hours/minutes/seconds). Date found: ${date.toISOString()}`
   );
+}
+
+/**
+ * Returns a string with the name of the time units, using the plural form
+ * when necessary.
+ *
+ * @param amount - The number of units.
+ * @param unit - The time unit.
+ */
+export function getTimeUnitLabel(amount: number, unit: TimeUnit): string {
+  switch (unit) {
+    case TimeUnit.MINUTES:
+      return pluralize(amount, "minute", "minutes");
+    case TimeUnit.HOURS:
+      return pluralize(amount, "hour", "hours");
+    case TimeUnit.DAYS:
+      return pluralize(amount, "day", "days");
+    case TimeUnit.WEEKS:
+      return pluralize(amount, "week", "weeks");
+    case TimeUnit.MONTHS:
+      return pluralize(amount, "month", "months");
+    case TimeUnit.YEARS:
+      return pluralize(amount, "year", "years");
+    default:
+      return `${amount} ${unit}`;
+  }
+  return `${amount} ${unit}`;
+}
+
+/**
+ * Returns the singular or plural form of a word, depending on the
+ * amount.
+ *
+ * @example
+ *
+ * ```ts
+ * pluralize(1, 'goose', 'geese') → 'goose'
+ * pluralize(5, 'goose', 'geese') → 'geese'
+ *```
+ *
+ * @param amount - Number of things
+ * @param singular - Singular word
+ * @param plural - Plural word
+ */
+function pluralize(amount: number, singular: string, plural: string) {
+  return amount === 1 ? singular : plural;
 }

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
@@ -35,7 +35,6 @@ const customTimePeriods: TimePeriod[] = [
   createTimePeriodOption(1, TimeUnit.WEEKS),
   createTimePeriodOption(2, TimeUnit.WEEKS),
   createTimePeriodOption(1, TimeUnit.MONTHS),
-  { label: "All time", dateRange: undefined },
 ];
 
 export const WithCustomPeriods = Template.bind({});

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
@@ -10,7 +10,7 @@ import { TimeUnit } from "@actnowcoalition/time-utils";
 
 import { MultiRegionMultiMetricChart } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
-import { TimePeriod, createTimePeriodOption } from "./utils";
+import { TimePeriod, timePeriodOption } from "./utils";
 
 const sortedStates = sortBy(states.all, (state) => state.shortName);
 
@@ -32,9 +32,9 @@ Example.args = {
 };
 
 const customTimePeriods: TimePeriod[] = [
-  createTimePeriodOption(1, TimeUnit.WEEKS),
-  createTimePeriodOption(2, TimeUnit.WEEKS),
-  createTimePeriodOption(1, TimeUnit.MONTHS),
+  timePeriodOption(1, TimeUnit.WEEKS),
+  timePeriodOption(2, TimeUnit.WEEKS),
+  timePeriodOption(1, TimeUnit.MONTHS),
 ];
 
 export const WithCustomPeriods = Template.bind({});

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.stories.tsx
@@ -6,11 +6,11 @@ import last from "lodash/last";
 import sortBy from "lodash/sortBy";
 
 import { states } from "@actnowcoalition/regions";
-import { TimeUnit, subtractTime } from "@actnowcoalition/time-utils";
+import { TimeUnit } from "@actnowcoalition/time-utils";
 
 import { MultiRegionMultiMetricChart } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
-import { TimePeriod } from "./utils";
+import { TimePeriod, createTimePeriodOption } from "./utils";
 
 const sortedStates = sortBy(states.all, (state) => state.shortName);
 
@@ -31,20 +31,10 @@ Example.args = {
   initialRegions: sortedStates.slice(0, 5),
 };
 
-const today = new Date();
 const customTimePeriods: TimePeriod[] = [
-  {
-    label: "Past week",
-    dateRange: { startAt: subtractTime(today, 1, TimeUnit.WEEKS) },
-  },
-  {
-    label: "Past 2 weeks",
-    dateRange: { startAt: subtractTime(today, 2, TimeUnit.WEEKS) },
-  },
-  {
-    label: "Past month",
-    dateRange: { startAt: subtractTime(today, 1, TimeUnit.MONTHS) },
-  },
+  createTimePeriodOption(1, TimeUnit.WEEKS),
+  createTimePeriodOption(2, TimeUnit.WEEKS),
+  createTimePeriodOption(1, TimeUnit.MONTHS),
   { label: "All time", dateRange: undefined },
 ];
 

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.tsx
@@ -49,7 +49,12 @@ export const MultiRegionMultiMetricChart = ({
     getMetricId
   );
 
-  const timePeriods = customTimePeriods ?? getDefaultTimePeriods();
+  const fixedTimePeriods = customTimePeriods ?? getDefaultTimePeriods();
+  const timePeriods = [
+    ...fixedTimePeriods,
+    { label: "All time", dateRange: undefined },
+  ];
+
   const initialPeriod =
     customTimePeriods && initialTimePeriod
       ? initialTimePeriod

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.tsx
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/MultiRegionMultiMetricChart.tsx
@@ -49,7 +49,7 @@ export const MultiRegionMultiMetricChart = ({
     getMetricId
   );
 
-  const timePeriods = customTimePeriods ?? getDefaultTimePeriods(new Date());
+  const timePeriods = customTimePeriods ?? getDefaultTimePeriods();
   const initialPeriod =
     customTimePeriods && initialTimePeriod
       ? initialTimePeriod
@@ -76,7 +76,7 @@ export const MultiRegionMultiMetricChart = ({
         getLabel={getMetricLabel}
       />
       <Select
-        label="Past number of days"
+        label="Time period"
         options={timePeriods}
         selectedOption={selectedPeriod}
         onSelectOption={setSelectedPeriod}

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/index.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/index.ts
@@ -1,2 +1,2 @@
 export * from "./MultiRegionMultiMetricChart";
-export { createTimePeriodOption } from "./utils";
+export { timePeriodOption as createTimePeriodOption } from "./utils";

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/index.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/index.ts
@@ -1,1 +1,2 @@
 export * from "./MultiRegionMultiMetricChart";
+export { createTimePeriodOption } from "./utils";

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -1,6 +1,10 @@
 import { DateRange, Metric } from "@actnowcoalition/metrics";
 import { Region } from "@actnowcoalition/regions";
-import { TimeUnit, subtractTime } from "@actnowcoalition/time-utils";
+import {
+  TimeUnit,
+  getTimeUnitLabel,
+  subtractTime,
+} from "@actnowcoalition/time-utils";
 
 import { schemeCategory10 } from "../../common/utils/charts";
 import { Series, SeriesType } from "../SeriesChart";
@@ -39,4 +43,11 @@ export function getDefaultTimePeriods(date: Date): TimePeriod[] {
     },
     { label: "All time", dateRange: undefined },
   ];
+}
+
+export function createTimePeriodOption(amount: number, unit: TimeUnit) {
+  return {
+    label: `${amount} ${getTimeUnitLabel(amount, unit)}`,
+    dateRange: { startAt: subtractTime(new Date(), amount, unit) },
+  };
 }

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -33,8 +33,8 @@ export interface TimePeriod {
 
 export function getDefaultTimePeriods(): TimePeriod[] {
   return [
-    createTimePeriodOption(60, TimeUnit.DAYS),
-    createTimePeriodOption(180, TimeUnit.DAYS),
+    timePeriodOption(60, TimeUnit.DAYS),
+    timePeriodOption(180, TimeUnit.DAYS),
   ];
 }
 
@@ -45,10 +45,7 @@ export function getDefaultTimePeriods(): TimePeriod[] {
  * @param amount - Number of units of time.
  * @param unit - Unit of time.
  */
-export function createTimePeriodOption(
-  amount: number,
-  unit: TimeUnit
-): TimePeriod {
+export function timePeriodOption(amount: number, unit: TimeUnit): TimePeriod {
   return {
     label: `${amount} ${getTimeUnitLabel(amount, unit)}`,
     dateRange: { startAt: subtractTime(new Date(), amount, unit) },

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -35,7 +35,6 @@ export function getDefaultTimePeriods(): TimePeriod[] {
   return [
     createTimePeriodOption(60, TimeUnit.DAYS),
     createTimePeriodOption(180, TimeUnit.DAYS),
-    { label: "All time", dateRange: undefined },
   ];
 }
 

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -31,16 +31,10 @@ export interface TimePeriod {
   dateRange?: DateRange;
 }
 
-export function getDefaultTimePeriods(date: Date): TimePeriod[] {
+export function getDefaultTimePeriods(): TimePeriod[] {
   return [
-    {
-      label: "60",
-      dateRange: { startAt: subtractTime(date, 60, TimeUnit.DAYS) },
-    },
-    {
-      label: "180",
-      dateRange: { startAt: subtractTime(date, 180, TimeUnit.DAYS) },
-    },
+    createTimePeriodOption(60, TimeUnit.DAYS),
+    createTimePeriodOption(180, TimeUnit.DAYS),
     { label: "All time", dateRange: undefined },
   ];
 }

--- a/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
+++ b/packages/ui-components/src/components/MultiRegionMultiMetricChart/utils.ts
@@ -45,7 +45,17 @@ export function getDefaultTimePeriods(date: Date): TimePeriod[] {
   ];
 }
 
-export function createTimePeriodOption(amount: number, unit: TimeUnit) {
+/**
+ * Creates a custom time period option for the MultiRegionMultiMetricChart
+ * component.
+ *
+ * @param amount - Number of units of time.
+ * @param unit - Unit of time.
+ */
+export function createTimePeriodOption(
+  amount: number,
+  unit: TimeUnit
+): TimePeriod {
   return {
     label: `${amount} ${getTimeUnitLabel(amount, unit)}`,
     dateRange: { startAt: subtractTime(new Date(), amount, unit) },


### PR DESCRIPTION
Close https://github.com/act-now-coalition/act-now-packages/issues/540 - Improve support for longer time periods for `MultiRegionMultiMetriChart`

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/114084/213535549-12278ef2-0fda-4f94-ab8d-db6344706aaf.png">

Currently, the time selector on the `MultiRegionMultiMetriChart` component has "Number of days" as selector in the label, which doesn't really work for yearly data. We do allow users to pass a custom `timePeriods` list to populate the menu, but generating a list of time periods involves subtracting time and adding labels, so I added the function `createTimePeriodOption` to make it a bit easier to generate the options for the menu. This way, a user can generate a list more easily:

```tsx
const timePeriods = [
  createTimePeriodOption(1, TimeUnit.MONTH), // 1 month
  createTimePeriodOption(6, TimeUnit.MONTH), // 6 months
  createTimePeriodOption(1, TimeUnit.YEAR),  // 1 year
  createTimePeriodOption(3, TimeUnit.YEAR),  // 3 years
]
```

Also, I updated the component to ensure that the "All time" is always added to this list.


## Changes

**`time-utils`**
- Add `YEARS` to the `TimeUnit` enum so we can select intervals covering multiple years.
- Implement `getTimeUnitLabel` function to get the name of a given `TimeUnit` (For example, `getTimeUnitLabel(3, TimeUnit.MONTHS)` →  `"months"`

**`MultiRegionMultiMetricChart`**
- Implement the `createTimePeriodOption` function to allow users to easily create time periods more easily
- Update the label on the time selector from _Number of days_ → _Time period_
- Always add the "All time" option, so users don't have to 