### PR TITLE
Rename MetricTooltip => MetricChartTooltip.

### DIFF
--- a/.changeset/polite-crews-leave.md
+++ b/.changeset/polite-crews-leave.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Rename MetricTooltip => MetricChartTooltip.

--- a/packages/ui-components/src/components/MetricChartTooltip/MetricChartTooltip.stories.tsx
+++ b/packages/ui-components/src/components/MetricChartTooltip/MetricChartTooltip.stories.tsx
@@ -6,13 +6,13 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { TimeseriesPoint } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";
 
-import { MetricTooltip } from ".";
+import { MetricChartTooltip } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Components/MetricTooltip",
-  component: MetricTooltip,
-} as ComponentMeta<typeof MetricTooltip>;
+  title: "Components/MetricChartTooltip",
+  component: MetricChartTooltip,
+} as ComponentMeta<typeof MetricChartTooltip>;
 
 const metric = metricCatalog.getMetric(MetricId.MOCK_CASES);
 const region = states.findByRegionIdStrict("53");
@@ -23,20 +23,20 @@ const point: TimeseriesPoint<number> = {
 
 const [width, height] = [600, 400];
 
-const Template: ComponentStory<typeof MetricTooltip> = (args) => (
+const Template: ComponentStory<typeof MetricChartTooltip> = (args) => (
   <svg
     width={width}
     height={height}
     style={{ backgroundColor: colors.blue[50] }}
   >
-    <MetricTooltip {...args}>
+    <MetricChartTooltip {...args}>
       <g transform={`translate(${width / 2}, ${height / 2})`}>
         <circle r={60} fill={colors.purple[900]} />
         <text fill="white" textAnchor="middle" dominantBaseline="middle">
           Hover me
         </text>
       </g>
-    </MetricTooltip>
+    </MetricChartTooltip>
   </svg>
 );
 

--- a/packages/ui-components/src/components/MetricChartTooltip/MetricChartTooltip.tsx
+++ b/packages/ui-components/src/components/MetricChartTooltip/MetricChartTooltip.tsx
@@ -8,36 +8,41 @@ import { DateFormat, formatUTCDateTime } from "@actnowcoalition/time-utils";
 
 import { useMetricCatalog } from "../MetricCatalogContext";
 
-export interface MetricTooltipWithChildren extends MetricTooltipContentProps {
+export interface MetricChartTooltipWithChildren
+  extends MetricChartTooltipContentProps {
   /**
    * ReactNode that, when hovered, triggers the tooltip to open.
    */
   children: React.ReactNode;
 }
 
-export type MetricTooltipProps = MetricTooltipWithChildren &
+export type MetricChartTooltipProps = MetricChartTooltipWithChildren &
   Omit<TooltipProps, "title">;
 
-export const MetricTooltip = ({
+export const MetricChartTooltip = ({
   metric,
   region,
   point,
   ...tooltipProps
-}: MetricTooltipProps) => {
+}: MetricChartTooltipProps) => {
   return (
     <Tooltip
       arrow
       placement="top"
       disableInteractive
       title={
-        <MetricTooltipContent metric={metric} region={region} point={point} />
+        <MetricChartTooltipContent
+          metric={metric}
+          region={region}
+          point={point}
+        />
       }
       {...tooltipProps}
     />
   );
 };
 
-export interface MetricTooltipContentProps {
+export interface MetricChartTooltipContentProps {
   /**
    * Metric represented by the content of the tooltip.
    */
@@ -53,11 +58,11 @@ export interface MetricTooltipContentProps {
   point: TimeseriesPoint<number>;
 }
 
-export const MetricTooltipContent = ({
+export const MetricChartTooltipContent = ({
   metric: metricOrId,
   region,
   point,
-}: MetricTooltipContentProps) => {
+}: MetricChartTooltipContentProps) => {
   const metricCatalog = useMetricCatalog();
   const metric = metricCatalog.getMetric(metricOrId);
   return (

--- a/packages/ui-components/src/components/MetricChartTooltip/MetricChartTooltipContent.stories.tsx
+++ b/packages/ui-components/src/components/MetricChartTooltip/MetricChartTooltipContent.stories.tsx
@@ -5,13 +5,13 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { TimeseriesPoint } from "@actnowcoalition/metrics";
 import { states } from "@actnowcoalition/regions";
 
-import { MetricTooltipContent } from ".";
+import { MetricChartTooltipContent } from ".";
 import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
 
 export default {
-  title: "Components/MetricTooltipContent",
-  component: MetricTooltipContent,
-} as ComponentMeta<typeof MetricTooltipContent>;
+  title: "Components/MetricChartTooltipContent",
+  component: MetricChartTooltipContent,
+} as ComponentMeta<typeof MetricChartTooltipContent>;
 
 const metric = metricCatalog.getMetric(MetricId.MOCK_CASES);
 const region = states.findByRegionIdStrict("53");
@@ -20,8 +20,8 @@ const point: TimeseriesPoint<number> = {
   value: 12.54,
 };
 
-const Template: ComponentStory<typeof MetricTooltipContent> = (args) => (
-  <MetricTooltipContent {...args} />
+const Template: ComponentStory<typeof MetricChartTooltipContent> = (args) => (
+  <MetricChartTooltipContent {...args} />
 );
 
 export const Example = Template.bind({});

--- a/packages/ui-components/src/components/MetricChartTooltip/index.ts
+++ b/packages/ui-components/src/components/MetricChartTooltip/index.ts
@@ -1,0 +1,1 @@
+export * from "./MetricChartTooltip";

--- a/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
+++ b/packages/ui-components/src/components/MetricLineChart/MetricLineChart.tsx
@@ -14,7 +14,7 @@ import { ChartOverlayX, useHoveredDate } from "../ChartOverlayX";
 import { ErrorBox } from "../ErrorBox";
 import { LineChart } from "../LineChart";
 import { useMetricCatalog } from "../MetricCatalogContext";
-import { MetricTooltip } from "../MetricTooltip";
+import { MetricChartTooltip } from "../MetricChartTooltip";
 import { PointMarker } from "../PointMarker";
 
 export interface MetricLineChartProps extends BaseChartProps {
@@ -86,7 +86,7 @@ export const MetricLineChart = ({
         />
         <LineChart timeseries={timeseries} xScale={xScale} yScale={yScale} />
         {hoveredPoint && (
-          <MetricTooltip
+          <MetricChartTooltip
             metric={metric}
             region={region}
             point={hoveredPoint}
@@ -96,7 +96,7 @@ export const MetricLineChart = ({
               x={xScale(hoveredPoint.date)}
               y={yScale(hoveredPoint.value)}
             />
-          </MetricTooltip>
+          </MetricChartTooltip>
         )}
         <ChartOverlayX
           width={chartWidth}

--- a/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
+++ b/packages/ui-components/src/components/MetricLineThresholdChart/MetricLineThresholdChart.tsx
@@ -16,7 +16,7 @@ import { ErrorBox } from "../ErrorBox";
 import { GridRows } from "../Grid";
 import { LineIntervalChart } from "../LineIntervalChart";
 import { useMetricCatalog } from "../MetricCatalogContext";
-import { MetricTooltip } from "../MetricTooltip";
+import { MetricChartTooltip } from "../MetricChartTooltip";
 import { PointMarker } from "../PointMarker";
 import { calculateChartIntervals } from "./utils";
 
@@ -130,7 +130,7 @@ export const MetricLineThresholdChart = ({
           topIntervalOffset={5}
         />
         {hoveredPoint && (
-          <MetricTooltip
+          <MetricChartTooltip
             metric={metric}
             region={region}
             point={hoveredPoint}
@@ -141,7 +141,7 @@ export const MetricLineThresholdChart = ({
               y={yScale(hoveredPoint.value)}
               fill={metric.getColor(hoveredPoint.value)}
             />
-          </MetricTooltip>
+          </MetricChartTooltip>
         )}
         <ChartOverlayX
           width={chartWidth}

--- a/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
+++ b/packages/ui-components/src/components/MetricSeriesChart/MetricSeriesChart.tsx
@@ -19,7 +19,7 @@ import { AxesTimeseries } from "../AxesTimeseries";
 import { ChartOverlayXY, useHoveredPoint } from "../ChartOverlayXY";
 import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
-import { MetricTooltip } from "../MetricTooltip";
+import { MetricChartTooltip } from "../MetricChartTooltip";
 import { PointMarker } from "../PointMarker";
 import { RectClipGroup } from "../RectClipGroup";
 import { Series, SeriesChart, SeriesType } from "../SeriesChart";
@@ -210,7 +210,7 @@ export const MetricSeriesChart = ({
           </Group>
         )}
         {pointInfo?.point && isNumber(pointInfo?.timeseriesIndex) && (
-          <MetricTooltip
+          <MetricChartTooltip
             metric={series[pointInfo.timeseriesIndex].metric}
             region={series[pointInfo.timeseriesIndex].region}
             point={pointInfo.point}
@@ -224,7 +224,7 @@ export const MetricSeriesChart = ({
                 defaultTextColor
               )}
             />
-          </MetricTooltip>
+          </MetricChartTooltip>
         )}
         <ChartOverlayXY
           timeseriesList={timeseriesList}

--- a/packages/ui-components/src/components/MetricTooltip/index.ts
+++ b/packages/ui-components/src/components/MetricTooltip/index.ts
@@ -1,1 +1,0 @@
-export * from "./MetricTooltip";

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -111,7 +111,7 @@ export * from "./components/MetricOverview";
 export * from "./components/MetricScoreOverview";
 export * from "./components/MetricSeriesChart";
 export * from "./components/MetricSparklines";
-export * from "./components/MetricTooltip";
+export * from "./components/MetricChartTooltip";
 export * from "./components/MetricUSNationalMap";
 export * from "./components/MetricUSStateMap";
 export * from "./components/MetricValue";


### PR DESCRIPTION
I want to create a `MetricMapTooltip` and so I'm renaming `MetricTooltip` to `MetricChartTooltip` for clarity / symmetry.