### PR TITLE
Fix #538: Add a default tooltip for metric maps.

### DIFF
--- a/.changeset/nervous-coins-judge.md
+++ b/.changeset/nervous-coins-judge.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Fix #538: Add a default tooltip for metric maps.

--- a/packages/ui-components/src/components/MetricMapTooltipContent/MetricMapTooltipContent.stories.tsx
+++ b/packages/ui-components/src/components/MetricMapTooltipContent/MetricMapTooltipContent.stories.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+import { Tooltip, Typography } from "@mui/material";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { states } from "@actnowcoalition/regions";
+
+import { MetricMapTooltipContent } from ".";
+import { MetricId, metricCatalog } from "../../stories/mockMetricCatalog";
+
+export default {
+  title: "Components/MetricMapTooltipContent",
+  component: MetricMapTooltipContent,
+} as ComponentMeta<typeof MetricMapTooltipContent>;
+
+const metric = metricCatalog.getMetric(MetricId.MOCK_CASES);
+const region = states.findByRegionIdStrict("53");
+
+const Template: ComponentStory<typeof MetricMapTooltipContent> = (args) => (
+  <MetricMapTooltipContent {...args} />
+);
+
+export const Example = Template.bind({});
+Example.args = {
+  region,
+  metric,
+};
+
+const ExampleInTooltipTemplate: ComponentStory<
+  typeof MetricMapTooltipContent
+> = (args) => (
+  <Tooltip title={<MetricMapTooltipContent {...args} />}>
+    <Typography variant="labelLarge">Hover me</Typography>
+  </Tooltip>
+);
+
+export const ExampleInTooltip = ExampleInTooltipTemplate.bind({});
+ExampleInTooltip.args = {
+  region,
+  metric,
+};

--- a/packages/ui-components/src/components/MetricMapTooltipContent/MetricMapTooltipContent.tsx
+++ b/packages/ui-components/src/components/MetricMapTooltipContent/MetricMapTooltipContent.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+import { Stack, Typography } from "@mui/material";
+
+import { Metric } from "@actnowcoalition/metrics";
+import { Region } from "@actnowcoalition/regions";
+
+import { useMetricCatalog } from "../MetricCatalogContext";
+import { MetricValue } from "../MetricValue";
+
+export interface MetricMapTooltipContentProps {
+  /**
+   * Metric represented by the content of the tooltip.
+   */
+  metric: Metric | string;
+  /**
+   * Region represented by the content of the tooltip.
+   */
+  region: Region;
+}
+
+export const MetricMapTooltipContent = ({
+  metric: metricOrId,
+  region,
+}: MetricMapTooltipContentProps) => {
+  const metricCatalog = useMetricCatalog();
+  const metric = metricCatalog.getMetric(metricOrId);
+  return (
+    <Stack spacing={0.5}>
+      <Typography variant="labelLarge" color="inherit">
+        {region.fullName}
+      </Typography>
+      <Typography variant="paragraphSmall" color="inherit">
+        {metric.extendedName}
+      </Typography>
+      <MetricValue
+        metric={metric}
+        region={region}
+        color="inherit"
+        variant="dataEmphasizedSmall"
+      />
+    </Stack>
+  );
+};

--- a/packages/ui-components/src/components/MetricMapTooltipContent/index.ts
+++ b/packages/ui-components/src/components/MetricMapTooltipContent/index.ts
@@ -1,0 +1,1 @@
+export * from "./MetricMapTooltipContent";

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.stories.tsx
@@ -20,20 +20,14 @@ const Template: ComponentStory<typeof MetricUSNationalMap> = (args) => (
   <MetricUSNationalMap {...args} />
 );
 
-const getTooltip = (regionId: string) => {
-  return regionDB.findByRegionIdStrict(regionId).fullName;
-};
-
 export const States = Template.bind({});
 States.args = {
-  getTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
 };
 
 export const Counties = Template.bind({});
 Counties.args = {
-  getTooltip,
   metric: MetricId.MOCK_CASES,
   showCounties: true,
   regionDB,

--- a/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
+++ b/packages/ui-components/src/components/MetricUSNationalMap/MetricUSNationalMap.tsx
@@ -3,14 +3,15 @@ import React from "react";
 import { useTheme } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
-import { RegionDB } from "@actnowcoalition/regions";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { ErrorBox } from "../ErrorBox";
+import { MetricMapTooltipContent } from "../MetricMapTooltipContent";
 import { USNationalMap, USNationalMapProps } from "../USNationalMap";
 
 export interface MetricUSNationalMapProps
-  extends Omit<USNationalMapProps, "getRegionUrl"> {
+  extends Omit<USNationalMapProps, "getRegionUrl" | "getTooltip"> {
   /**
    * Metric represented by the map's coloring.
    */
@@ -20,6 +21,13 @@ export interface MetricUSNationalMapProps
    * Used for generating region links, coloring the map, etc.
    */
   regionDB: RegionDB;
+  /**
+   * Function that returns tooltip content for a given region.
+   *
+   * @param region - Region for which to get tooltip content.
+   * @returns Tooltip content for the region.
+   */
+  getTooltip?: (region: Region) => React.ReactNode;
 }
 
 /**
@@ -30,6 +38,7 @@ export interface MetricUSNationalMapProps
 export const MetricUSNationalMap = ({
   metric,
   regionDB,
+  getTooltip,
   showCounties,
   width,
   ...otherProps
@@ -48,6 +57,10 @@ export const MetricUSNationalMap = ({
     );
   }
 
+  const getTooltipInternal =
+    getTooltip ??
+    ((region) => <MetricMapTooltipContent region={region} metric={metric} />);
+
   return (
     <USNationalMap
       getFillColor={(regionId: string) => {
@@ -60,6 +73,10 @@ export const MetricUSNationalMap = ({
         const region = regionDB.findByRegionId(regionId);
         const url = region ? regionDB.getRegionUrl(region) : undefined;
         return url;
+      }}
+      getTooltip={(regionId: string) => {
+        const region = regionDB.findByRegionId(regionId);
+        return region && getTooltipInternal(region);
       }}
       showCounties={showCounties}
       {...otherProps}

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.stories.tsx
@@ -21,14 +21,9 @@ const Template: ComponentStory<typeof MetricUSStateMap> = (args) => (
   <MetricUSStateMap {...args} />
 );
 
-const getTooltip = (regionId: string) => {
-  return regionDB.findByRegionIdStrict(regionId).fullName;
-};
-
 export const NewYork = Template.bind({});
 NewYork.args = {
   stateRegionId: "36",
-  getTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
 };
@@ -36,7 +31,6 @@ NewYork.args = {
 export const Alaska = Template.bind({});
 Alaska.args = {
   stateRegionId: "02",
-  getTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
 };
@@ -45,7 +39,6 @@ export const NewYorkWithHighlightedCounty = Template.bind({});
 NewYorkWithHighlightedCounty.args = {
   stateRegionId: "36",
   highlightedRegion: herkimerCountyNewYorkRegion,
-  getTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
 };

--- a/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MetricUSStateMap/MetricUSStateMap.tsx
@@ -3,15 +3,16 @@ import React from "react";
 import { useTheme } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
-import { RegionDB } from "@actnowcoalition/regions";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { getCountiesOfState } from "../../common/utils/maps";
 import { ErrorBox } from "../ErrorBox";
+import { MetricMapTooltipContent } from "../MetricMapTooltipContent";
 import { USStateMap, USStateMapProps } from "../USStateMap";
 
 export interface MetricUSStateMapProps
-  extends Omit<USStateMapProps, "getRegionUrl"> {
+  extends Omit<USStateMapProps, "getRegionUrl" | "getTooltip"> {
   /**
    * Metric represented by the map's coloring.
    */
@@ -21,6 +22,13 @@ export interface MetricUSStateMapProps
    * Used for generating region links, coloring the map, etc.
    */
   regionDB: RegionDB;
+  /**
+   * Function that returns tooltip content for a given region.
+   *
+   * @param region - Region for which to get tooltip content.
+   * @returns Tooltip content for the region.
+   */
+  getTooltip?: (region: Region) => React.ReactNode;
 }
 
 /**
@@ -32,6 +40,7 @@ export const MetricUSStateMap = ({
   metric,
   stateRegionId,
   regionDB,
+  getTooltip,
   width,
   ...otherProps
 }: MetricUSStateMapProps) => {
@@ -53,6 +62,10 @@ export const MetricUSStateMap = ({
     );
   }
 
+  const getTooltipInternal =
+    getTooltip ??
+    ((region) => <MetricMapTooltipContent region={region} metric={metric} />);
+
   return (
     <USStateMap
       getFillColor={(regionId: string) => {
@@ -65,6 +78,10 @@ export const MetricUSStateMap = ({
         const region = regionDB.findByRegionId(regionId);
         const url = region ? regionDB.getRegionUrl(region) : undefined;
         return url;
+      }}
+      getTooltip={(regionId: string) => {
+        const region = regionDB.findByRegionId(regionId);
+        return region && getTooltipInternal(region);
       }}
       stateRegionId={stateRegionId}
       {...otherProps}

--- a/packages/ui-components/src/components/MetricValue/MetricValue.tsx
+++ b/packages/ui-components/src/components/MetricValue/MetricValue.tsx
@@ -23,12 +23,18 @@ export interface MetricValueProps {
    * @default "dataEmphasizedLarge"
    */
   variant?: TypographyProps["variant"];
+  /**
+   * MUI Typography color applied to the metric value text.
+   * @default "inherit"
+   */
+  color?: TypographyProps["color"];
 }
 
 export const MetricValue = ({
   region,
   metric: metricOrId,
   variant = "dataEmphasizedLarge",
+  color,
 }: MetricValueProps) => {
   const metricCatalog = useMetricCatalog();
   const metric = metricCatalog.getMetric(metricOrId);
@@ -50,7 +56,9 @@ export const MetricValue = ({
   return (
     <Stack direction="row" spacing={1} alignItems="center" width="fit-content">
       {showMetricDot && <MetricDot region={region} metric={metric} />}
-      <Typography variant={variant}>{formattedValue}</Typography>
+      <Typography variant={variant} color={color}>
+        {formattedValue}
+      </Typography>
     </Stack>
   );
 };

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.stories.tsx
@@ -20,14 +20,9 @@ const Template: ComponentStory<typeof MetricWorldMap> = (args) => (
   <MetricWorldMap {...args} />
 );
 
-const getTooltip = (regionId: string) => {
-  return regionDB.findByRegionId(regionId)?.fullName || "n/a";
-};
-
 /** Nations colored by mock metric data */
 export const World = Template.bind({});
 World.args = {
-  getTooltip,
   metric: MetricId.MOCK_CASES,
   regionDB,
 };

--- a/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
+++ b/packages/ui-components/src/components/MetricWorldMap/MetricWorldMap.tsx
@@ -3,14 +3,15 @@ import React from "react";
 import { useTheme } from "@mui/material";
 
 import { Metric } from "@actnowcoalition/metrics";
-import { RegionDB } from "@actnowcoalition/regions";
+import { Region, RegionDB } from "@actnowcoalition/regions";
 
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { ErrorBox } from "../ErrorBox";
+import { MetricMapTooltipContent } from "../MetricMapTooltipContent";
 import WorldMap, { WorldMapProps } from "../WorldMap";
 
 export interface MetricWorldMapProps
-  extends Omit<WorldMapProps, "getRegionUrl"> {
+  extends Omit<WorldMapProps, "getRegionUrl" | "getTooltip"> {
   /**
    * Metric represented by the map's coloring.
    */
@@ -20,6 +21,13 @@ export interface MetricWorldMapProps
    * Used for generating region links, coloring the map, etc.
    */
   regionDB: RegionDB;
+  /**
+   * Function that returns tooltip content for a given region.
+   *
+   * @param region - Region for which to get tooltip content.
+   * @returns Tooltip content for the region.
+   */
+  getTooltip?: (region: Region) => React.ReactNode;
 }
 
 /**
@@ -31,6 +39,7 @@ export const MetricWorldMap = ({
   metric,
   regionDB,
   width,
+  getTooltip,
   ...otherProps
 }: MetricWorldMapProps) => {
   const theme = useTheme();
@@ -48,6 +57,10 @@ export const MetricWorldMap = ({
     );
   }
 
+  const getTooltipInternal =
+    getTooltip ??
+    ((region) => <MetricMapTooltipContent region={region} metric={metric} />);
+
   return (
     <WorldMap
       getFillColor={(regionId: string) => {
@@ -60,6 +73,10 @@ export const MetricWorldMap = ({
         const region = regionDB.findByRegionId(regionId);
         const url = region ? regionDB.getRegionUrl(region) : undefined;
         return url;
+      }}
+      getTooltip={(regionId: string) => {
+        const region = regionDB.findByRegionId(regionId);
+        return region && getTooltipInternal(region);
       }}
       {...otherProps}
     />

--- a/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
+++ b/packages/ui-components/src/components/MultiMetricUSStateMap/MultiMetricUSStateMap.tsx
@@ -33,12 +33,12 @@ export interface MultiMetricUSStateMapProps {
    */
   regionDB: RegionDB;
   /**
-   * Function that returns tooltip content for the region corresponding to a given regionId.
+   * Function that returns tooltip content for a given region.
    *
-   * @param regionId - RegionId of the region for which to get tooltip content.
+   * @param region - Region for which to get tooltip content.
    * @returns Tooltip content for the region.
    */
-  getTooltip?: (regionId: string) => React.ReactNode;
+  getTooltip?: (region: Region) => React.ReactNode;
 }
 
 export const MultiMetricUSStateMap = ({
@@ -59,10 +59,6 @@ export const MultiMetricUSStateMap = ({
   const resolvedMetrics = metrics.map((metric: Metric | string) =>
     metricCatalog.getMetric(metric)
   );
-
-  const defaultGetTooltip = (regionId: string) => {
-    return regionDB.findByRegionIdStrict(regionId).fullName;
-  };
 
   return (
     <>
@@ -97,7 +93,7 @@ export const MultiMetricUSStateMap = ({
           highlightedRegion={highlightedRegion}
           metric={metric}
           regionDB={regionDB}
-          getTooltip={getTooltip ?? defaultGetTooltip}
+          getTooltip={getTooltip}
         />
       </BorderedContainer>
       <BorderedContainerLast>

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -106,6 +106,7 @@ export * from "./components/MetricLegendCategorical";
 export * from "./components/MetricLegendThreshold";
 export * from "./components/MetricLineChart";
 export * from "./components/MetricLineThresholdChart";
+export * from "./components/MetricMapTooltipContent";
 export * from "./components/MetricMultiProgressBar";
 export * from "./components/MetricOverview";
 export * from "./components/MetricScoreOverview";


### PR DESCRIPTION
I don't think there's a good default to add for non-metric-aware maps (displaying the region ID isn't very user-friendly) and so this only applies to metric-aware maps.

<img width="883" alt="image" src="https://user-images.githubusercontent.com/206364/213354782-f2d1c8fa-9af6-4c5d-b7ac-e1c68e5578f6.png">
