### PR TITLE
Update maps to better handle regions without a URL

### DIFF
--- a/.changeset/cold-candles-reflect.md
+++ b/.changeset/cold-candles-reflect.md
@@ -2,4 +2,4 @@
 "@actnowcoalition/ui-components": patch
 ---
 
-Improve WorldMap to better handle regions without URLs
+Improve maps to better handle missing region URLs

--- a/.changeset/cold-candles-reflect.md
+++ b/.changeset/cold-candles-reflect.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/ui-components": patch
+---
+
+Improve WorldMap to better handle regions without URLs

--- a/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
+++ b/packages/ui-components/src/components/USNationalMap/StatesMap.tsx
@@ -61,19 +61,25 @@ const StatesMap = ({
     <svg width={width} height={height}>
       {statesGeographies.features.map((geo) => {
         const stateFips = `${geo.id}`;
+        const regionUrl = getRegionUrl(stateFips);
+        const innerShape = (
+          <g>
+            {!showCounties && (
+              <RegionShapeBase
+                d={geoPath(geo) ?? ""}
+                fill={getFillColor(stateFips)}
+              />
+            )}
+            <RegionOverlay d={geoPath(geo) ?? ""} />
+          </g>
+        );
         return (
           <Tooltip key={stateFips} title={getTooltip(stateFips) ?? ""}>
-            <Link href={getRegionUrl(stateFips)}>
-              <g>
-                {!showCounties && (
-                  <RegionShapeBase
-                    d={geoPath(geo) ?? ""}
-                    fill={getFillColor(stateFips)}
-                  />
-                )}
-                <RegionOverlay d={geoPath(geo) ?? ""} />
-              </g>
-            </Link>
+            {regionUrl ? (
+              <Link href={regionUrl}>{innerShape}</Link>
+            ) : (
+              innerShape
+            )}
           </Tooltip>
         );
       })}

--- a/packages/ui-components/src/components/USStateMap/USStateMap.tsx
+++ b/packages/ui-components/src/components/USStateMap/USStateMap.tsx
@@ -115,13 +115,19 @@ const USStateMapInner = ({
         {showBorderingStates &&
           otherStates.map((geo) => {
             const stateFips = `${geo.id}`;
+            const regionUrl = getRegionUrl(stateFips);
+            const innerShape = (
+              <g>
+                <BorderingRegion d={geoPath(geo) ?? ""} />
+              </g>
+            );
             return (
               <Tooltip title={getTooltip(stateFips) ?? ""} key={stateFips}>
-                <Link href={getRegionUrl(stateFips)}>
-                  <g>
-                    <BorderingRegion d={geoPath(geo) ?? ""} />
-                  </g>
-                </Link>
+                {regionUrl ? (
+                  <Link href={regionUrl}>{innerShape}</Link>
+                ) : (
+                  innerShape
+                )}
               </Tooltip>
             );
           })}
@@ -129,13 +135,19 @@ const USStateMapInner = ({
         {/* Clickable region overlay */}
         {regionGeoToShow.map((geo) => {
           const geoId = `${geo.id}`;
+          const regionUrl = getRegionUrl(geoId);
+          const innerShape = (
+            <g>
+              <RegionOverlay d={geoPath(geo) ?? ""} />
+            </g>
+          );
           return (
             <Tooltip title={getTooltip(geoId) ?? ""} key={geoId}>
-              <Link href={getRegionUrl(geoId)}>
-                <g>
-                  <RegionOverlay d={geoPath(geo) ?? ""} />
-                </g>
-              </Link>
+              {regionUrl ? (
+                <Link href={regionUrl}>{innerShape}</Link>
+              ) : (
+                innerShape
+              )}
             </Tooltip>
           );
         })}

--- a/packages/ui-components/src/components/WorldMap/WorldMap.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.tsx
@@ -70,13 +70,20 @@ const WorldMapInner = ({
         ))}
 
         {/* Clickable region overlay */}
-        {countries.features.map((geo) => (
-          <Tooltip key={geo.id} title={getTooltip(`${geo.id}`) ?? ""}>
-            <Link href={getRegionUrl(`${geo.id}`)}>
-              <RegionOverlay d={geoPath(geo) ?? ""} />
-            </Link>
-          </Tooltip>
-        ))}
+        {countries.features.map((geo) => {
+          const regionUrl = getRegionUrl(`${geo.id}`);
+          return (
+            <Tooltip key={geo.id} title={getTooltip(`${geo.id}`) ?? ""}>
+              {regionUrl ? (
+                <Link href={regionUrl}>
+                  <RegionOverlay d={geoPath(geo) ?? ""} />
+                </Link>
+              ) : (
+                <RegionOverlay d={geoPath(geo) ?? ""} />
+              )}
+            </Tooltip>
+          );
+        })}
 
         {/* Nation Borders */}
         <path

--- a/packages/ui-components/src/components/WorldMap/WorldMap.tsx
+++ b/packages/ui-components/src/components/WorldMap/WorldMap.tsx
@@ -72,14 +72,13 @@ const WorldMapInner = ({
         {/* Clickable region overlay */}
         {countries.features.map((geo) => {
           const regionUrl = getRegionUrl(`${geo.id}`);
+          const innerShape = <RegionOverlay d={geoPath(geo) ?? ""} />;
           return (
             <Tooltip key={geo.id} title={getTooltip(`${geo.id}`) ?? ""}>
               {regionUrl ? (
-                <Link href={regionUrl}>
-                  <RegionOverlay d={geoPath(geo) ?? ""} />
-                </Link>
+                <Link href={regionUrl}>{innerShape}</Link>
               ) : (
-                <RegionOverlay d={geoPath(geo) ?? ""} />
+                innerShape
               )}
             </Tooltip>
           );


### PR DESCRIPTION
Some regions in the map don't have a corresponding region in the database, which was causing the app to crash since we were trying to create `Link` items to regions without a valid `href` attribute. This PR updates the maps to not create a link when we don't have the url for a given region.