### PR TITLE
Add support CSVs in long format

### DIFF
--- a/.changeset/spotty-eggs-move.md
+++ b/.changeset/spotty-eggs-move.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/actnow.js": minor
+---
+
+Add long-form CSV support

--- a/src/metrics/data_providers/CsvDataProvider.test.ts
+++ b/src/metrics/data_providers/CsvDataProvider.test.ts
@@ -122,8 +122,17 @@ describe("CsvDataProvider", () => {
       longFormatCsvProviderOptions
     );
 
-    expect(wideMetricData).toStrictEqual(longMetricData);
-    expect(wideMetricDataTs).toStrictEqual(longMetricDataTs);
+    // Can't use toStrictEqual() because long-format CSVs use 'variable' instead of 'column' in dataReference.
+    expect(wideMetricData.currentValue).toBe(longMetricData.currentValue);
+    expect(wideMetricData.hasTimeseries).toStrictEqual(
+      longMetricData.hasTimeseries
+    );
+    expect(wideMetricDataTs.currentValue).toStrictEqual(
+      longMetricDataTs.currentValue
+    );
+    expect(wideMetricDataTs.timeseries).toStrictEqual(
+      longMetricDataTs.timeseries
+    );
   });
 });
 
@@ -138,13 +147,13 @@ describe("CsvDataProvider with wide-format (default) csv", () => {
       /*includeTimeseries=*/ true,
       /*dateColumn=*/ "date"
     );
-    expect(metricDataNoTs.currentValue).toBe(150);
+    expect(metricDataNoTs.currentValue).toBe(120);
     expect(metricDataNoTs.hasTimeseries()).toBe(false);
 
     expect(metricDataTs.hasTimeseries()).toBe(true);
     expect(metricDataTs.timeseries.length).toBe(1);
-    expect(metricDataTs.timeseries.lastValue).toBe(150);
-    expect(metricDataTs.currentValue).toBe(150);
+    expect(metricDataTs.timeseries.lastValue).toBe(120);
+    expect(metricDataTs.currentValue).toBe(120);
   });
 
   test("fetchData() returns non-timeseries data if timeseries data is not available.", async () => {
@@ -152,7 +161,7 @@ describe("CsvDataProvider with wide-format (default) csv", () => {
       wideCsv,
       /*includeTimeseries=*/ true
     );
-    expect(metricData.currentValue).toBe(150);
+    expect(metricData.currentValue).toBe(120);
     expect(metricData.hasTimeseries()).toBe(false);
   });
 
@@ -175,7 +184,7 @@ describe("CsvDataProvider with wide-format (default) csv", () => {
   });
 });
 
-describe.only("CsvDataProvider with long-format CSV", () => {
+describe("CsvDataProvider with long-format CSV", () => {
   test("fetchData() yields expected data", async () => {
     const metricDataNoTs = await testFetchingCsvData(
       longCsv,
@@ -195,7 +204,7 @@ describe.only("CsvDataProvider with long-format CSV", () => {
     expect(metricDataNoTs.hasTimeseries()).toBe(false);
 
     expect(metricDataTs.hasTimeseries()).toBe(true);
-    expect(metricDataTs.timeseries.length).toBe(2);
+    expect(metricDataTs.timeseries.length).toBe(1);
     expect(metricDataTs.timeseries.lastValue).toBe(120);
     expect(metricDataTs.currentValue).toBe(120);
   });
@@ -223,16 +232,4 @@ describe.only("CsvDataProvider with long-format CSV", () => {
       )
     ).rejects.toThrow();
   });
-
-  // test("fetchData() fails if no data exists for the region", async () => {
-  //   expect(async () =>
-  //     testFetchingCsvData(
-  //       longCsv.replaceAll("36", "25"), // replace NY locations with MA so there's no data for NY.
-  //       /*includeTimeseries=*/ true,
-  //       /*dateColumn=*/ undefined,
-  //       /*metric=*/ testLongMetric,
-  //       longFormatCsvProviderOptions
-  //     )
-  //   ).rejects.toThrow("No data found for region");
-  // });
 });

--- a/src/metrics/data_providers/CsvDataProvider.test.ts
+++ b/src/metrics/data_providers/CsvDataProvider.test.ts
@@ -17,8 +17,8 @@ const csvTimeseries = `region,date,cool_metric
 const longCsv = `region,metric,value,another_column
 12,cool_metric,100,a
 12,another_metric,110,b
-36,cool_metric,120,d
-36,another_metric,130,c`;
+36,another_metric,130,c
+36,cool_metric,120,d`;
 
 const longCsvTimeseries = `region,date,metric,value,another_column
 12,2022-08-02,cool_metric,70,a
@@ -184,6 +184,18 @@ describe("CsvDataProvider with long-format CSV", () => {
     expect(metricData.hasTimeseries()).toBe(false);
   });
 
+  test("fetchData() fails if dateColumn is provided for non-timeseries data.", async () => {
+    expect(async () =>
+      testFetchingCsvData(
+        longCsv,
+        /*includeTimeseries=*/ false,
+        /*dateColumn=*/ "date",
+        /*metric=*/ undefined,
+        longCsvProviderOptions
+      )
+    ).rejects.toThrow("Missing date field");
+  });
+
   test("fetchData() fails if no data exists for the region", async () => {
     expect(async () =>
       testFetchingCsvData(
@@ -196,15 +208,15 @@ describe("CsvDataProvider with long-format CSV", () => {
     ).rejects.toThrow("No data found for region");
   });
 
-  test("fetchData() fails if dateColumn is provided for non-timeseries data.", async () => {
-    expect(async () =>
-      testFetchingCsvData(
-        longCsv,
-        /*includeTimeseries=*/ false,
-        /*dateColumn=*/ "date",
-        /*metric=*/ undefined,
-        longCsvProviderOptions
-      )
-    ).rejects.toThrow("Missing date field");
+  test("fetchData() returns null metric if the metric data for region is not found.", async () => {
+    const metricData = await testFetchingCsvData(
+      longCsv.replace(/\n.*$/, ""), // Remove last line so there's no data for the expected metric for NY.
+      /*includeTimeseries=*/ true,
+      /*dateColumn=*/ "date",
+      /*metric=*/ undefined,
+      longCsvProviderOptions
+    );
+    expect(metricData.currentValue).toBe(null);
+    expect(metricData.hasTimeseries()).toBe(false);
   });
 });

--- a/src/metrics/data_providers/CsvDataProvider.test.ts
+++ b/src/metrics/data_providers/CsvDataProvider.test.ts
@@ -9,10 +9,12 @@ const mockCsv = `region,cool_metric
 36,150
 12,`;
 
-const longCsv = `region,metric,Score
-12,cool_metric,1.2
-36,cool_metric,1.6
-25,cool_metric,1.7`;
+const longCsv = `region,metric,value,another_factor
+12,cool_metric,1.2,a
+12,another,1.3,b
+36,another,1.4,c
+36,cool_metric,1.6,d
+06,cooler_metric,1.7,d`;
 
 const csvTimeseries = `region,date,cool_metric
 36,2022-08-02,150
@@ -126,23 +128,28 @@ describe("CsvDataProvider", () => {
   });
 
   test("fetch long csv", async () => {
-    const provider = new CsvDataProvider(PROVIDER_ID, {
+    const longCsvProvider = new CsvDataProvider("long-csv", {
       regionDb: states,
       regionColumn: "region",
       format: "long",
+      longDataMetricColumn: "metric",
+      longDataValueColumn: "value",
+      // dateColumn: "date",
       csvText: longCsv,
     });
 
     // TODO: need to separate metric lookup from relying on metric id
     const metric = new Metric({
-      id: "cool_metric",
+      id: "metric",
       dataReference: {
-        providerId: PROVIDER_ID,
-        valueColumn: "Score",
-        column: "metric",
+        providerId: "long-csv",
+        column: "cool_metric",
       },
     });
-    const data = await provider.fetchDataForRegionAndMetric(newYork, metric);
+    const data = await longCsvProvider.fetchDataForRegionAndMetric(
+      newYork,
+      metric
+    );
     console.log(data);
     expect(data).toBeDefined();
   });

--- a/src/metrics/data_providers/CsvDataProvider.test.ts
+++ b/src/metrics/data_providers/CsvDataProvider.test.ts
@@ -1,7 +1,7 @@
 import { states } from "../../regions";
 import { Metric } from "../Metric";
 import { MetricCatalog } from "../MetricCatalog";
-import { CsvDataProvider } from "./CsvDataProvider";
+import { CsvDataProvider, CsvDataProviderOptions } from "./CsvDataProvider";
 
 const PROVIDER_ID = "csv-provider";
 
@@ -9,17 +9,24 @@ const mockCsv = `region,cool_metric
 36,150
 12,`;
 
-const longCsv = `region,metric,value,another_factor
-12,cool_metric,1.2,a
-12,another,1.3,b
-36,another,1.4,c
-36,cool_metric,1.6,d
-06,cooler_metric,1.7,d`;
-
 const csvTimeseries = `region,date,cool_metric
 36,2022-08-02,150
 36,2022-08-03,
 12,2022-08-02,`;
+
+const longCsv = `region,metric,value,another_column
+12,cool_metric,100,a
+12,another_metric,110,b
+36,cool_metric,120,d
+36,another_metric,130,c`;
+
+const longCsvTimeseries = `region,date,metric,value,another_column
+12,2022-08-02,cool_metric,70,a
+12,2022-08-02,another_metric,80,b
+36,2022-08-02,cool_metric,90,d
+36,2022-08-02,another_metric,100,c
+36,2022-08-03,cool_metric,120,d
+36,2022-08-03,another_metric,130,c`;
 
 const newYork = states.findByRegionIdStrict("36");
 const testMetric = new Metric({
@@ -33,13 +40,16 @@ const testMetric = new Metric({
  * @param data CSV data to be imported.
  * @param includeTimeseries Whether to include timeseries.
  * @param dateCol Name of date column.
+ * @param metric Metric to fetch data for. Defaults to testMetric.
+ * @param otherProviderArgs Other arguments to pass to CsvDataProvider constructor.
  * @returns MetricData for test region and metric.
  */
 const testFetchingCsvData = async (
   data: string,
   includeTimeseries: boolean,
   dateCol?: string,
-  metric?: Metric
+  metric?: Metric,
+  otherProviderArgs?: Partial<CsvDataProviderOptions>
 ) => {
   metric = metric ?? testMetric;
   const provider = new CsvDataProvider(PROVIDER_ID, {
@@ -47,6 +57,7 @@ const testFetchingCsvData = async (
     regionColumn: "region",
     dateColumn: dateCol,
     csvText: data,
+    ...otherProviderArgs,
   });
   const catalog = new MetricCatalog([metric], [provider]);
   return (
@@ -57,6 +68,32 @@ const testFetchingCsvData = async (
 };
 
 describe("CsvDataProvider", () => {
+  test("Constructor fails if neither url or csv data is provided.", () => {
+    expect(() => {
+      new CsvDataProvider("PROVIDER_ID", {
+        regionDb: states,
+        regionColumn: "region",
+      });
+    }).toThrow("URL or CSV data must be provided");
+  });
+
+  test("fetchData() fails if csv does not have at least one valid region ID.", async () => {
+    expect(async () =>
+      testFetchingCsvData(
+        `region,cool_metric\nNew York,1`,
+        /*includeTimeseries=*/ true
+      )
+    ).rejects.toThrow("Failed to parse data: All region IDs were invalid.");
+  });
+
+  test("fetchData() fails if csv does not have at least one row.", async () => {
+    expect(async () =>
+      testFetchingCsvData(`region,cool_metric`, /*includeTimeseries=*/ true)
+    ).rejects.toThrow("CSV must not be empty.");
+  });
+});
+
+describe("CsvDataProvider with wide-format (default) csv", () => {
   test("fetchData() yields expected data", async () => {
     const metricDataNoTs = await testFetchingCsvData(
       mockCsv,
@@ -85,21 +122,6 @@ describe("CsvDataProvider", () => {
     expect(metricData.hasTimeseries()).toBe(false);
   });
 
-  test("fetchData() fails if csv does not have at least one row.", async () => {
-    expect(async () =>
-      testFetchingCsvData(`region,cool_metric`, /*includeTimeseries=*/ true)
-    ).rejects.toThrow("CSV must not be empty.");
-  });
-
-  test("fetchData() fails if csv does not have at least one valid region ID.", async () => {
-    expect(async () =>
-      testFetchingCsvData(
-        `region,cool_metric\nNew York,1`,
-        /*includeTimeseries=*/ true
-      )
-    ).rejects.toThrow("Failed to parse data: All region IDs were invalid.");
-  });
-
   test("fetchData() fails if metric is missing a 'column' property.", async () => {
     const badMetric = new Metric({
       id: "metric",
@@ -117,40 +139,72 @@ describe("CsvDataProvider", () => {
       )
     ).rejects.toThrow("Missing or invalid metric column name.");
   });
+});
 
-  test("Constructor fails if neither url or csv data is provided.", () => {
-    expect(() => {
-      new CsvDataProvider("PROVIDER_ID", {
-        regionDb: states,
-        regionColumn: "region",
-      });
-    }).toThrow("URL or CSV data must be provided");
+describe("CsvDataProvider with long-format CSV", () => {
+  const longCsvProviderOptions: Partial<CsvDataProviderOptions> = {
+    format: "long",
+    longDataMetricColumn: "metric",
+    longDataValueColumn: "value",
+  };
+
+  test("fetchData() yields expected data", async () => {
+    const metricDataNoTs = await testFetchingCsvData(
+      longCsv,
+      /*includeTimeseries=*/ false,
+      /*dateColumn=*/ undefined,
+      /*metric=*/ undefined,
+      longCsvProviderOptions
+    );
+    const metricDataTs = await testFetchingCsvData(
+      longCsvTimeseries,
+      /*includeTimeseries=*/ true,
+      /*dateColumn=*/ "date",
+      /*metric=*/ undefined,
+      longCsvProviderOptions
+    );
+    expect(metricDataNoTs.currentValue).toBe(120);
+    expect(metricDataNoTs.hasTimeseries()).toBe(false);
+
+    expect(metricDataTs.hasTimeseries()).toBe(true);
+    expect(metricDataTs.timeseries.length).toBe(2);
+    expect(metricDataTs.timeseries.lastValue).toBe(120);
+    expect(metricDataTs.currentValue).toBe(120);
   });
 
-  test("fetch long csv", async () => {
-    const longCsvProvider = new CsvDataProvider("long-csv", {
-      regionDb: states,
-      regionColumn: "region",
-      format: "long",
-      longDataMetricColumn: "metric",
-      longDataValueColumn: "value",
-      // dateColumn: "date",
-      csvText: longCsv,
-    });
-
-    // TODO: need to separate metric lookup from relying on metric id
-    const metric = new Metric({
-      id: "metric",
-      dataReference: {
-        providerId: "long-csv",
-        column: "cool_metric",
-      },
-    });
-    const data = await longCsvProvider.fetchDataForRegionAndMetric(
-      newYork,
-      metric
+  test("fetchData() returns non-timeseries data if timeseries data is not available.", async () => {
+    const metricData = await testFetchingCsvData(
+      longCsv,
+      /*includeTimeseries=*/ true,
+      /*dateColumn=*/ undefined,
+      /*metric=*/ undefined,
+      longCsvProviderOptions
     );
-    console.log(data);
-    expect(data).toBeDefined();
+    expect(metricData.currentValue).toBe(120);
+    expect(metricData.hasTimeseries()).toBe(false);
+  });
+
+  test("fetchData() fails if no data exists for the region", async () => {
+    expect(async () =>
+      testFetchingCsvData(
+        longCsv.replaceAll("36", "25"), // replace NY locations with MA so there's no data for NY.
+        /*includeTimeseries=*/ true,
+        /*dateColumn=*/ undefined,
+        /*metric=*/ undefined,
+        longCsvProviderOptions
+      )
+    ).rejects.toThrow("No data found for region");
+  });
+
+  test("fetchData() fails if dateColumn is provided for non-timeseries data.", async () => {
+    expect(async () =>
+      testFetchingCsvData(
+        longCsv,
+        /*includeTimeseries=*/ false,
+        /*dateColumn=*/ "date",
+        /*metric=*/ undefined,
+        longCsvProviderOptions
+      )
+    ).rejects.toThrow("Missing date field");
   });
 });

--- a/src/metrics/data_providers/CsvDataProvider.test.ts
+++ b/src/metrics/data_providers/CsvDataProvider.test.ts
@@ -9,6 +9,11 @@ const mockCsv = `region,cool_metric
 36,150
 12,`;
 
+const longCsv = `region,metric,Score
+12,cool_metric,1.2
+36,cool_metric,1.6
+25,cool_metric,1.7`;
+
 const csvTimeseries = `region,date,cool_metric
 36,2022-08-02,150
 36,2022-08-03,
@@ -118,5 +123,27 @@ describe("CsvDataProvider", () => {
         regionColumn: "region",
       });
     }).toThrow("URL or CSV data must be provided");
+  });
+
+  test("fetch long csv", async () => {
+    const provider = new CsvDataProvider(PROVIDER_ID, {
+      regionDb: states,
+      regionColumn: "region",
+      format: "long",
+      csvText: longCsv,
+    });
+
+    // TODO: need to separate metric lookup from relying on metric id
+    const metric = new Metric({
+      id: "cool_metric",
+      dataReference: {
+        providerId: PROVIDER_ID,
+        valueColumn: "Score",
+        column: "metric",
+      },
+    });
+    const data = await provider.fetchDataForRegionAndMetric(newYork, metric);
+    console.log(data);
+    expect(data).toBeDefined();
   });
 });

--- a/src/metrics/data_providers/CsvDataProvider.ts
+++ b/src/metrics/data_providers/CsvDataProvider.ts
@@ -52,13 +52,13 @@ export interface CsvDataProviderOptions {
   format?: "wide" | "long";
   /**
    * For long-format CSVs, the name of the column containing the metric names
-   * (meaning, the values for Metric.dataReference.column). This does not need to be
+   * (meaning, the values for Metric.dataReference.column). This should not be
    * set for wide-format CSVs.
    * */
   longDataMetricColumn?: string;
   /**
    * For long-format CSVs, the name of the column containing the observation values.
-   * This does not need to be set for wide-format CSVs.
+   * This should not be set for wide-format CSVs.
    * */
   longDataValueColumn?: string;
 

--- a/src/metrics/data_providers/CsvDataProvider.ts
+++ b/src/metrics/data_providers/CsvDataProvider.ts
@@ -160,7 +160,8 @@ export class CsvDataProvider extends SimpleMetricDataProviderBase {
       region,
       metric,
       variableName,
-      this.dateColumn
+      this.dateColumn,
+      /**strict=*/ false
     );
   }
 

--- a/src/metrics/data_providers/CsvDataProvider.ts
+++ b/src/metrics/data_providers/CsvDataProvider.ts
@@ -53,7 +53,7 @@ export interface CsvDataProviderOptions {
  * of the column containing the metric's data.
  *
  * For long-format CSVs, metrics should specify {@link Metric.dataReference.variable}. This value
- * should match values in the CSV's variableColumn.
+ * should be present in the CSV's variableColumn.
  *
  * Example wide-format CSV:
  * ```

--- a/src/metrics/data_providers/CsvDataProvider.ts
+++ b/src/metrics/data_providers/CsvDataProvider.ts
@@ -14,9 +14,9 @@ import { fetchText } from "./utils";
 
 /** Options for long-format CsvDataProviders. */
 export interface LongFormatCsvOptions {
-  /** The name of the column containing the variable names (meaning, the values for Metric.dataReference.column). */
+  /** The name of the column containing the variable names. */
   variableColumn: string;
-  /** For long-format CSVs, the name of the column containing the observation values. */
+  /** The name of the column containing the observation values. */
   valueColumn: string;
 }
 
@@ -52,8 +52,8 @@ export interface CsvDataProviderOptions {
  * For wide-format CSVs, metrics should specify {@link Metric.dataReference.column} with the name
  * of the column containing the metric's data.
  *
- * For long-format CSVs, metrics should specify {@link Metric.dataReference.variable} with the
- * name of the value of variableColumn that corresponds to the metric's data.
+ * For long-format CSVs, metrics should specify {@link Metric.dataReference.variable}. This value
+ * should match values in the CSV's variableColumn.
  *
  * Example wide-format CSV:
  * ```

--- a/src/metrics/data_providers/CsvDataProvider.ts
+++ b/src/metrics/data_providers/CsvDataProvider.ts
@@ -155,7 +155,7 @@ export class CsvDataProvider extends SimpleMetricDataProviderBase {
         metricName,
         this.dateColumn
       );
-    } else {
+    } else if (this.format === "long") {
       assert(
         this.longDataMetricColumn && this.longDataValueColumn,
         "longDataMetricColumn and longDataValueColumn options must be provided for long-format CSVs."
@@ -169,6 +169,8 @@ export class CsvDataProvider extends SimpleMetricDataProviderBase {
         this.longDataValueColumn,
         this.dateColumn
       );
+    } else {
+      throw new Error(`CsvDataProvider format '${this.format}' not supported.`);
     }
   }
 

--- a/src/metrics/data_providers/CsvDataProvider.ts
+++ b/src/metrics/data_providers/CsvDataProvider.ts
@@ -161,7 +161,7 @@ export class CsvDataProvider extends SimpleMetricDataProviderBase {
       metric,
       variableName,
       this.dateColumn,
-      /**strict=*/ false
+      /*strict=*/ false
     );
   }
 

--- a/src/metrics/data_providers/data_provider_utils.ts
+++ b/src/metrics/data_providers/data_provider_utils.ts
@@ -325,9 +325,14 @@ export async function getMetricDataFromLongDataRows(
   } else {
     const timeseries: Timeseries<unknown> = new Timeseries(
       metricDataRows.map((row) => {
-        const date = row[dateField] as string;
+        const date = row[dateField];
+        assert(
+          date,
+          `Missing date field '${dateField}' in data row. ` +
+            "If this is not timeseries data, do not specify a date field."
+        );
         return {
-          date: new Date(date),
+          date: new Date(date as string),
           value: row[valueField] ?? null,
         };
       })
@@ -335,7 +340,7 @@ export async function getMetricDataFromLongDataRows(
     return new MetricData(
       metric,
       region,
-      timeseries.last ?? null,
+      timeseries.last?.value ?? null,
       timeseries.hasData() ? timeseries : undefined
     );
   }

--- a/src/metrics/data_providers/data_provider_utils.ts
+++ b/src/metrics/data_providers/data_provider_utils.ts
@@ -269,7 +269,8 @@ export async function getMetricDataFromDataRows(
   region: Region,
   metric: Metric,
   metricField: string,
-  dateField?: string
+  dateField?: string,
+  strict = true
 ): Promise<MetricData<unknown>> {
   let metricData: MetricData;
   if (dateField) {
@@ -279,7 +280,7 @@ export async function getMetricDataFromDataRows(
       metric,
       metricField,
       dateField,
-      /* strict= */ true
+      /* strict= */ strict
     );
   } else {
     metricData = dataRowToMetricData(

--- a/src/metrics/data_providers/data_provider_utils.ts
+++ b/src/metrics/data_providers/data_provider_utils.ts
@@ -290,3 +290,22 @@ export async function getMetricDataFromDataRows(
   }
   return metricData;
 }
+
+export async function getMetricDataFromLongDataRow(
+  dataRowsByRegionId: { [regionId: string]: DataRow[] },
+  region: Region,
+  metric: Metric,
+  metricField: string,
+  valueField: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  dateField?: string
+) {
+  const regionData = dataRowsByRegionId[region.regionId];
+  if (regionData.length <= 1) {
+    const metricData = regionData.find((row) => row[metricField] === metric.id);
+    const value = metricData ? metricData[valueField] : null;
+    return new MetricData(metric, region, value);
+  } else {
+    throw new Error("Long-form not implemented for multiple data rows.");
+  }
+}


### PR DESCRIPTION
E.g. to ingest data for [Climate Act Now](https://www.dropbox.com/s/3we8dyoysy6e0hl/CS_Metric_Master_ActNow.xlsx):

```ts
// Untested, but this should be the general workflow/setup
const provider = new CsvDataProvider("climate-long-csv, {
    url: '/path/to/file.csv',
    regionDb: regions,
    regionColumn: "GeoID",
    longFormatCsvOptions: {
        variableColumn: "Metric",
        valueColumn: "Score"
    }
  })


const climateMetric = new Metric({
  id: MetricId.SOME_METRIC,
  dataReference: { 
    providerId: "climate-long-csv", 
    variable: "Affordability ..." } // Where 'variable' is an entry from the 'Metric' column in the xlsx
})

...
```