### PR TITLE
Update the border-radius of the input field on RegionSearch

### DIFF
--- a/.changeset/twenty-numbers-dance.md
+++ b/.changeset/twenty-numbers-dance.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/actnow.js": patch
+---
+
+Small style adjustment on RegionSearch

--- a/src/ui-components/components/RegionSearch/RegionSearch.tsx
+++ b/src/ui-components/components/RegionSearch/RegionSearch.tsx
@@ -55,6 +55,7 @@ export const RegionSearch = ({
     params
   ) => (
     <TextField
+      sx={{ borderRadius: 1 }}
       {...params}
       label={inputLabel}
       variant="outlined"


### PR DESCRIPTION
Small adjustment to the style of `RegionSearch`. Tested by manually changing the background color of the `body` element in Storybook

Before

![image](https://user-images.githubusercontent.com/114084/215893236-9a0e7c9d-89b4-465f-a0eb-1bc6117915f8.png)

After

![image](https://user-images.githubusercontent.com/114084/215893250-09406bf3-892e-4e41-8292-a38f05277e87.png)
