### PR TITLE
Make ShareButton styled-able

### DIFF
--- a/.changeset/cyan-stingrays-drive.md
+++ b/.changeset/cyan-stingrays-drive.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/actnow.js": patch
+---
+
+Make the ShareButton component styled-able

--- a/src/ui-components/components/ShareButton/ShareButton.stories.tsx
+++ b/src/ui-components/components/ShareButton/ShareButton.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Box } from "@mui/material";
+import { Box, styled } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { ShareButton, ShareButtonProps } from ".";
@@ -45,3 +45,17 @@ WithRightMenuOrigin.args = {
   ...args,
   menuOrigin: "right",
 };
+
+const StyledButton = styled(ShareButton)`
+  color: white;
+  border-color: white;
+  &:hover {
+    border-color: white;
+  }
+`;
+
+export const StyledAnchor = () => (
+  <Box sx={{ padding: 4, backgroundColor: "#2c387e" }}>
+    <StyledButton {...args} />
+  </Box>
+);

--- a/src/ui-components/components/ShareButton/ShareButton.tsx
+++ b/src/ui-components/components/ShareButton/ShareButton.tsx
@@ -57,7 +57,7 @@ export interface ShareButtonProps {
   /**
    * MUI Button className applied to the anchor button.
    */
-  className?: string;
+  className?: ButtonProps["className"];
 }
 
 export const ShareButton = ({

--- a/src/ui-components/components/ShareButton/ShareButton.tsx
+++ b/src/ui-components/components/ShareButton/ShareButton.tsx
@@ -54,6 +54,10 @@ export interface ShareButtonProps {
    * @default "large"
    */
   size?: ButtonProps["size"];
+  /**
+   * MUI Button className applied to the anchor button.
+   */
+  className?: string;
 }
 
 export const ShareButton = ({
@@ -66,6 +70,7 @@ export const ShareButton = ({
   menuOrigin = "left",
   variant = "outlined",
   size = "large",
+  className = "",
 }: ShareButtonProps) => {
   const [anchorButton, setAnchorButton] = useState<null | HTMLElement>(null);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -78,6 +83,7 @@ export const ShareButton = ({
   return (
     <>
       <Button
+        className={className}
         variant={variant}
         size={size}
         endIcon={<ShareIcon />}
@@ -89,14 +95,8 @@ export const ShareButton = ({
         anchorEl={anchorButton}
         open={!isNull(anchorButton)}
         onClose={() => setAnchorButton(null)}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: menuOrigin,
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: menuOrigin,
-        }}
+        anchorOrigin={{ vertical: "bottom", horizontal: menuOrigin }}
+        transformOrigin={{ vertical: "top", horizontal: menuOrigin }}
       >
         <MenuItem>
           <CopyLinkButton


### PR DESCRIPTION
Close #583 - ShareButton is not theme-able enough

The problem is that as it is, the button doesn't allow for one-off customizations. A simple solution is to add `className` to the button props, which allows us to use `styled` to create custom versions of it.

<img width="370" alt="image" src="https://user-images.githubusercontent.com/114084/217335878-6d040865-e122-4eb7-85d5-2ce8116b80b6.png">
