### PR TITLE
Allow ShareButton to receive a custom anchor button

### DIFF
--- a/.changeset/long-chairs-smile.md
+++ b/.changeset/long-chairs-smile.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/actnow.js": patch
+---
+
+ShareButton receives an optional anchorButton

--- a/src/ui-components/components/ShareButton/ShareButton.stories.tsx
+++ b/src/ui-components/components/ShareButton/ShareButton.stories.tsx
@@ -64,7 +64,7 @@ export const StyledAnchor = () => (
 export const CustomButton = () => (
   <ShareButton
     {...args}
-    anchor={
+    anchorButton={
       <Button
         variant="contained"
         startIcon={<ShareLocationIcon />}

--- a/src/ui-components/components/ShareButton/ShareButton.stories.tsx
+++ b/src/ui-components/components/ShareButton/ShareButton.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { Box, styled } from "@mui/material";
+import ShareLocationIcon from "@mui/icons-material/ShareLocation";
+import { Box, Button, styled } from "@mui/material";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { ShareButton, ShareButtonProps } from ".";
@@ -58,4 +59,19 @@ export const StyledAnchor = () => (
   <Box sx={{ padding: 4, backgroundColor: "#2c387e" }}>
     <StyledButton {...args} />
   </Box>
+);
+
+export const CustomButton = () => (
+  <ShareButton
+    {...args}
+    anchor={
+      <Button
+        variant="contained"
+        startIcon={<ShareLocationIcon />}
+        onClick={() => console.log("custom onClick")}
+      >
+        Share Location
+      </Button>
+    }
+  />
 );

--- a/src/ui-components/components/ShareButton/ShareButton.tsx
+++ b/src/ui-components/components/ShareButton/ShareButton.tsx
@@ -56,12 +56,13 @@ export interface ShareButtonProps {
   size?: ButtonProps["size"];
   /**
    * MUI Button className applied to the anchor button.
+   * @default ""
    */
   className?: ButtonProps["className"];
   /**
-   *
+   * MUI Button instance to use as anchor button.
    */
-  anchor?: React.ReactElement<ButtonProps, typeof Button>;
+  anchorButton?: React.ReactElement<ButtonProps, typeof Button>;
 }
 
 export const ShareButton = ({
@@ -75,23 +76,27 @@ export const ShareButton = ({
   variant = "outlined",
   size = "large",
   className = "",
-  anchor,
+  anchorButton,
 }: ShareButtonProps) => {
-  const [anchorButton, setAnchorButton] = useState<null | HTMLElement>(null);
+  const [anchorElement, setAnchorElement] = useState<null | HTMLElement>(null);
+
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorButton(event.currentTarget);
+    setAnchorElement(event.currentTarget);
   };
+
   const handleClose = () => {
-    const timer = setTimeout(() => setAnchorButton(null), 1000);
+    const timer = setTimeout(() => setAnchorElement(null), 1000);
     () => clearTimeout(timer);
   };
 
-  const anchorBtn = anchor ? (
-    React.cloneElement(anchor, {
-      ...anchor.props,
+  // We need to clone the anchorButton to modify the onClick handler, so we
+  // can call the original onClick property and the handleClick function.
+  const modifiedAnchorButton = anchorButton ? (
+    React.cloneElement(anchorButton, {
+      ...anchorButton.props,
       onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
         handleClick(event);
-        anchor?.props?.onClick && anchor.props.onClick(event);
+        anchorButton?.props?.onClick && anchorButton.props.onClick(event);
       },
     })
   ) : (
@@ -108,11 +113,11 @@ export const ShareButton = ({
 
   return (
     <>
-      {anchorBtn}
+      {modifiedAnchorButton}
       <Menu
-        anchorEl={anchorButton}
-        open={!isNull(anchorButton)}
-        onClose={() => setAnchorButton(null)}
+        anchorEl={anchorElement}
+        open={!isNull(anchorElement)}
+        onClose={() => setAnchorElement(null)}
         anchorOrigin={{ vertical: "bottom", horizontal: menuOrigin }}
         transformOrigin={{ vertical: "top", horizontal: menuOrigin }}
       >

--- a/src/ui-components/components/ShareButton/ShareButton.tsx
+++ b/src/ui-components/components/ShareButton/ShareButton.tsx
@@ -58,6 +58,10 @@ export interface ShareButtonProps {
    * MUI Button className applied to the anchor button.
    */
   className?: ButtonProps["className"];
+  /**
+   *
+   */
+  anchor?: React.ReactElement<ButtonProps, typeof Button>;
 }
 
 export const ShareButton = ({
@@ -71,6 +75,7 @@ export const ShareButton = ({
   variant = "outlined",
   size = "large",
   className = "",
+  anchor,
 }: ShareButtonProps) => {
   const [anchorButton, setAnchorButton] = useState<null | HTMLElement>(null);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -80,17 +85,30 @@ export const ShareButton = ({
     const timer = setTimeout(() => setAnchorButton(null), 1000);
     () => clearTimeout(timer);
   };
+
+  const anchorBtn = anchor ? (
+    React.cloneElement(anchor, {
+      ...anchor.props,
+      onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+        handleClick(event);
+        anchor?.props?.onClick && anchor.props.onClick(event);
+      },
+    })
+  ) : (
+    <Button
+      className={className}
+      variant={variant}
+      size={size}
+      endIcon={<ShareIcon />}
+      onClick={handleClick}
+    >
+      Share
+    </Button>
+  );
+
   return (
     <>
-      <Button
-        className={className}
-        variant={variant}
-        size={size}
-        endIcon={<ShareIcon />}
-        onClick={handleClick}
-      >
-        Share
-      </Button>
+      {anchorBtn}
       <Menu
         anchorEl={anchorButton}
         open={!isNull(anchorButton)}


### PR DESCRIPTION
Follow up to #585 - This PR allows further customization of the ShareButton by allowing the user to pass a `Button` instance. I considered allowing to pass any clickable element, but that restricts the type of the `onClick` handlers and makes things a bit more complicated

<img width="209" alt="image" src="https://user-images.githubusercontent.com/114084/217363048-24846f2a-d10f-467f-97f8-9af24d6b8f25.png">
