### PR TITLE
Update component loaded screenshot logic

### DIFF
--- a/.changeset/serious-monkeys-turn.md
+++ b/.changeset/serious-monkeys-turn.md
@@ -1,0 +1,5 @@
+---
+"@actnowcoalition/actnow.js": patch
+---
+
+Update screenshot detection components

--- a/src/ui-components/components/ComponentLoading/ComponentLoading.tsx
+++ b/src/ui-components/components/ComponentLoading/ComponentLoading.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import { Box } from "@mui/material";
+
+/**
+ * Empty component to be appended to another component to indicate that it is currently loading.
+ *
+ * Used for share image generation to ensure we wait until the component has loaded
+ * before capturing the image.
+ */
+export const ComponentLoading = () => {
+  return (
+    <Box
+      className="act-now-component-loading"
+      style={{ display: "none" }}
+    ></Box>
+  );
+};

--- a/src/ui-components/components/ComponentLoading/index.ts
+++ b/src/ui-components/components/ComponentLoading/index.ts
@@ -1,0 +1,1 @@
+export * from "./ComponentLoading";

--- a/src/ui-components/components/MetricCompareTable/MetricCompareTable.tsx
+++ b/src/ui-components/components/MetricCompareTable/MetricCompareTable.tsx
@@ -14,6 +14,7 @@ import {
   sortTableRows,
 } from "../CompareTable";
 import { ComponentLoaded } from "../ComponentLoaded";
+import { ComponentLoading } from "../ComponentLoading";
 import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { Row, createLocationColumn, createMetricColumn } from "./utils";
@@ -108,7 +109,7 @@ export const MetricCompareTable = ({
         columns={columns}
         {...otherCompareTableProps}
       />
-      {data && <ComponentLoaded />}
+      {data ? <ComponentLoaded /> : <ComponentLoading />}
     </>
   );
 };

--- a/src/ui-components/components/MetricDot/MetricDot.tsx
+++ b/src/ui-components/components/MetricDot/MetricDot.tsx
@@ -4,6 +4,7 @@ import { Metric } from "../../../metrics";
 import { Region } from "../../../regions";
 import { useData } from "../../common/hooks";
 import { ComponentLoaded } from "../ComponentLoaded";
+import { ComponentLoading } from "../ComponentLoading";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { Dot, PlaceholderDot } from "./MetricDot.style";
 
@@ -39,7 +40,7 @@ export const MetricDot = ({ region, metric: metricOrId }: MetricDotProps) => {
   return (
     <>
       <Dot style={{ backgroundColor }} />
-      {data && <ComponentLoaded />}
+      {data ? <ComponentLoaded /> : <ComponentLoading />}
     </>
   );
 };

--- a/src/ui-components/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
+++ b/src/ui-components/components/MetricMultiProgressBar/MetricMultiProgressBar.tsx
@@ -6,6 +6,7 @@ import { Metric, MultiMetricDataStore } from "../../../metrics";
 import { Region } from "../../../regions";
 import { useDataForMetrics } from "../../common/hooks";
 import { ComponentLoaded } from "../ComponentLoaded";
+import { ComponentLoading } from "../ComponentLoading";
 import {
   BaseMultiProgressBarProps,
   DEFAULT_HEIGHT,
@@ -51,7 +52,7 @@ export const MetricMultiProgressBar = ({
         height={height}
         {...otherProgressBarProps}
       />
-      {data && <ComponentLoaded />}
+      {data ? <ComponentLoaded /> : <ComponentLoading />}
     </>
   );
 };

--- a/src/ui-components/components/MetricSparklines/MetricSparklines.tsx
+++ b/src/ui-components/components/MetricSparklines/MetricSparklines.tsx
@@ -8,6 +8,7 @@ import { Region } from "../../../regions";
 import { useDataForMetrics } from "../../common/hooks";
 import { getChartRange } from "../../common/utils/charts";
 import { ComponentLoaded } from "../ComponentLoaded";
+import { ComponentLoading } from "../ComponentLoading";
 import { ErrorBox } from "../ErrorBox";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { BaseSparkLineProps, SparkLine } from "../SparkLine";
@@ -108,7 +109,7 @@ export const MetricSparklines = ({
           maxValue={maxValue}
           {...optionalProps}
         />
-        {data && <ComponentLoaded />}
+        {data ? <ComponentLoaded /> : <ComponentLoading />}
       </>
     );
   }

--- a/src/ui-components/components/MetricUSNationalMap/MetricUSNationalMap.tsx
+++ b/src/ui-components/components/MetricUSNationalMap/MetricUSNationalMap.tsx
@@ -6,6 +6,7 @@ import { Metric } from "../../../metrics";
 import { Region, RegionDB } from "../../../regions";
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { ComponentLoaded } from "../ComponentLoaded";
+import { ComponentLoading } from "../ComponentLoading";
 import { ErrorBox } from "../ErrorBox";
 import { MetricMapTooltipContent } from "../MetricMapTooltipContent";
 import { USNationalMap, USNationalMapProps } from "../USNationalMap";
@@ -82,7 +83,7 @@ export const MetricUSNationalMap = ({
         showCounties={showCounties}
         {...otherProps}
       />
-      {data && <ComponentLoaded />}
+      {data ? <ComponentLoaded /> : <ComponentLoading />}
     </>
   );
 };

--- a/src/ui-components/components/MetricUSStateMap/MetricUSStateMap.tsx
+++ b/src/ui-components/components/MetricUSStateMap/MetricUSStateMap.tsx
@@ -7,6 +7,7 @@ import { Region, RegionDB } from "../../../regions";
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { getCountiesOfState } from "../../common/utils/maps";
 import { ComponentLoaded } from "../ComponentLoaded";
+import { ComponentLoading } from "../ComponentLoading";
 import { ErrorBox } from "../ErrorBox";
 import { MetricMapTooltipContent } from "../MetricMapTooltipContent";
 import { USStateMap, USStateMapProps } from "../USStateMap";
@@ -87,7 +88,7 @@ export const MetricUSStateMap = ({
         stateRegionId={stateRegionId}
         {...otherProps}
       />
-      {data && <ComponentLoaded />}
+      {data ? <ComponentLoaded /> : <ComponentLoading />}
     </>
   );
 };

--- a/src/ui-components/components/MetricValue/MetricValue.tsx
+++ b/src/ui-components/components/MetricValue/MetricValue.tsx
@@ -6,6 +6,7 @@ import { Metric } from "../../../metrics";
 import { Region } from "../../../regions";
 import { useData } from "../../common/hooks";
 import { ComponentLoaded } from "../ComponentLoaded";
+import { ComponentLoading } from "../ComponentLoading";
 import { useMetricCatalog } from "../MetricCatalogContext";
 import { MetricDot } from "../MetricDot";
 
@@ -67,7 +68,7 @@ export const MetricValue = ({
           {formattedValue}
         </Typography>
       </Stack>
-      {data && <ComponentLoaded />}
+      {data ? <ComponentLoaded /> : <ComponentLoading />}
     </>
   );
 };

--- a/src/ui-components/components/MetricWorldMap/MetricWorldMap.tsx
+++ b/src/ui-components/components/MetricWorldMap/MetricWorldMap.tsx
@@ -6,6 +6,7 @@ import { Metric } from "../../../metrics";
 import { Region, RegionDB } from "../../../regions";
 import { useDataForRegionsAndMetrics } from "../../common/hooks";
 import { ComponentLoaded } from "../ComponentLoaded";
+import { ComponentLoading } from "../ComponentLoading";
 import { ErrorBox } from "../ErrorBox";
 import { MetricMapTooltipContent } from "../MetricMapTooltipContent";
 import WorldMap, { WorldMapProps } from "../WorldMap";
@@ -81,7 +82,7 @@ export const MetricWorldMap = ({
         }}
         {...otherProps}
       />
-      {data && <ComponentLoaded />}
+      {data ? <ComponentLoaded /> : <ComponentLoading />}
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,9 +2055,9 @@
     react-is "^18.2.0"
 
 "@mui/core-downloads-tracker@^5.11.4":
-  version "5.11.8"
-  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.8.tgz#e1ba16686276b75f501ebe4fd5b60ce600704e3c"
-  integrity sha512-n/uJRIwZAaJaROaOA4VzycxDo27cusnrRzfycnAkAP5gBndwOJQ1CXjd1Y7hJe5eorj/ukixC7IZD+qCClMCMg==
+  version "5.11.4"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.4.tgz#def5937e21443b197fd1998fd66721bd9c49a1bb"
+  integrity sha512-jWVwGM3vG4O0sXcW0VcIl+njCWbGCBF5vvjRpuKJajrz51AD7D6+fP1SkInZXVk5pRHf6Bnk/Yj9Of9gXxb/hA==
 
 "@mui/icons-material@^5.8.4":
   version "5.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,9 +2055,9 @@
     react-is "^18.2.0"
 
 "@mui/core-downloads-tracker@^5.11.4":
-  version "5.11.4"
-  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.4.tgz#def5937e21443b197fd1998fd66721bd9c49a1bb"
-  integrity sha512-jWVwGM3vG4O0sXcW0VcIl+njCWbGCBF5vvjRpuKJajrz51AD7D6+fP1SkInZXVk5pRHf6Bnk/Yj9Of9gXxb/hA==
+  version "5.11.8"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.11.8.tgz#e1ba16686276b75f501ebe4fd5b60ce600704e3c"
+  integrity sha512-n/uJRIwZAaJaROaOA4VzycxDo27cusnrRzfycnAkAP5gBndwOJQ1CXjd1Y7hJe5eorj/ukixC7IZD+qCClMCMg==
 
 "@mui/icons-material@^5.8.4":
   version "5.11.0"


### PR DESCRIPTION
In conjunction with https://github.com/act-now-coalition/act-now-links-service/pull/44

Appends `act-now-component-loading` class while data is still loading, and `act-now-component-loaded` upon completion. 